### PR TITLE
Validate Group Notice Permissions

### DIFF
--- a/PWA-demo/js/groups.js
+++ b/PWA-demo/js/groups.js
@@ -325,15 +325,21 @@ class GroupsManager {
   /**
    * Send group notice
    * @param {string} groupUUID - UUID of the group
+   * @param {string} senderUUID - UUID of the sender
    * @param {string} subject - Notice subject
    * @param {string} message - Notice message
    * @param {Object} attachment - Optional inventory attachment
    */
-  sendGroupNotice(groupUUID, subject, message, attachment = null) {
+  sendGroupNotice(groupUUID, senderUUID, subject, message, attachment = null) {
     console.log(`Sending group notice to ${groupUUID}: ${subject}`);
     
+    // Validate permissions (ALLOW_SEND_NOTICE)
+    if (!this.hasPower(groupUUID, senderUUID, GroupPowers.ALLOW_SEND_NOTICE)) {
+      console.warn(`User ${senderUUID} missing ALLOW_SEND_NOTICE permission for group ${groupUUID}`);
+      throw new Error("You do not have permission to send notices to this group.");
+    }
+
     // TODO: Send GroupNoticeRequest capability request
-    // TODO: Validate permissions (ALLOW_SEND_NOTICE)
   }
   
   /**
@@ -701,4 +707,4 @@ class GroupsManager {
 // Export singleton instance
 const groupsManager = new GroupsManager();
 export default groupsManager;
-export { GroupsManager, GroupPowers };
+export { GroupsManager };


### PR DESCRIPTION
Implemented permission checking for sending group notices in `PWA-demo/js/groups.js`.
Updated `sendGroupNotice` signature to accept `senderUUID` and check for `ALLOW_SEND_NOTICE` capability (GroupPowers) before sending.
Also fixed a duplicate export syntax error in `PWA-demo/js/groups.js`.

---
*PR created automatically by Jules for task [2341406834865144494](https://jules.google.com/task/2341406834865144494) started by @Kaleaon*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds permission validation for sending group notices by updating the `sendGroupNotice` method to accept a `senderUUID` parameter and checking for `ALLOW_SEND_NOTICE` capability before allowing the operation. It also fixes a duplicate export syntax error by removing `GroupPowers` from the exports.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `PWA-demo/js/groups.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added permission validation for group notice submissions to ensure only authorized members can send notices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->