### PR TITLE
Implement GrantUserRights message in PWA demo

### DIFF
--- a/PWA-demo/js/friends-extended.js
+++ b/PWA-demo/js/friends-extended.js
@@ -306,7 +306,38 @@ class FriendsExtended {
       friend.rightsGiven = rights;
     }
     
-    // TODO: Send GrantUserRights message
+    // Send GrantUserRights message
+    if (window.app && window.app.protocolManager) {
+      const pm = window.app.protocolManager;
+      if (window.SLMessageTypes && window.SLMessageTypes.GrantUserRightsMessage) {
+        const msg = new window.SLMessageTypes.GrantUserRightsMessage(
+          pm.agentId,
+          pm.sessionId,
+          friendUUID,
+          rights
+        );
+
+        // Allocate buffer (AgentData=32 + Count=1 + Rights=20 = 53 bytes)
+        const buffer = new ArrayBuffer(64);
+        const length = msg.packPayload(buffer);
+        const payload = new Uint8Array(buffer, 0, length);
+
+        // Since ProtocolManager might use WebSockets and JSON wrapping in the PWA demo,
+        // we'll try to send it in a way it expects or just simulate if it's not a full implementation
+        if (pm.sendMessage) {
+          pm.sendMessage('GrantUserRights', {
+            friend_id: friendUUID,
+            rights: rights,
+            // Provide payload for low-level protocol adapters
+            payload: Array.from(payload)
+          });
+        }
+      } else {
+        console.warn('SLMessageTypes.GrantUserRightsMessage not available');
+      }
+    } else {
+      console.warn('window.app.protocolManager not available to send GrantUserRights');
+    }
   }
   
   /**

--- a/PWA-demo/js/sl-messages.js
+++ b/PWA-demo/js/sl-messages.js
@@ -36,6 +36,9 @@ const MessageIDs = {
   TELEPORT_PROGRESS: 0x56,
   TELEPORT_FINISH: 0x57,
   TELEPORT_FAILED: 0x58,
+
+  // Friend Messages
+  GRANT_USER_RIGHTS: 0xFFFF0140,
 };
 
 /**
@@ -368,6 +371,78 @@ class ObjectUpdateMessage extends SLMessage {
   }
 }
 
+
+/**
+ * GrantUserRights message
+ */
+class GrantUserRightsMessage extends SLMessage {
+  constructor(agentId, sessionId, friendId, rights) {
+    super();
+    this.agentId = agentId;
+    this.sessionId = sessionId;
+    this.friendId = friendId;
+    this.rights = rights;
+    this.isReliable = true;
+  }
+
+  getMessageID() {
+    return MessageIDs.GRANT_USER_RIGHTS;
+  }
+
+  getMessageName() {
+    return 'GrantUserRights';
+  }
+
+  packPayload(buffer) {
+    const view = new DataView(buffer);
+    let offset = 0;
+
+    // AgentData Block
+    // AgentID (LLUUID - big-endian per SL protocol)
+    offset = this.uuidToBytes(this.agentId, view, offset);
+
+    // SessionID (LLUUID - big-endian per SL protocol)
+    offset = this.uuidToBytes(this.sessionId, view, offset);
+
+    // Rights block count (1 block)
+    view.setUint8(offset++, 1);
+
+    // Rights Block
+    // AgentRelated (LLUUID - big-endian per SL protocol)
+    offset = this.uuidToBytes(this.friendId, view, offset);
+
+    // RelatedRights (S32)
+    view.setInt32(offset, this.rights, true); // Little Endian
+    offset += 4;
+
+    return offset;
+  }
+
+  uuidToBytes(uuid, view, offset) {
+    if (!uuid) {
+      for (let i = 0; i < 16; i++) {
+        view.setUint8(offset++, 0);
+      }
+      return offset;
+    }
+
+    const hex = uuid.replace(/-/g, '');
+    if (hex.length !== 32 || !/^[0-9a-fA-F]+$/.test(hex)) {
+      throw new Error(`Invalid UUID format: ${uuid}`);
+    }
+
+    const msb = BigInt('0x' + hex.substring(0, 16));
+    const lsb = BigInt('0x' + hex.substring(16, 32));
+
+    view.setBigUint64(offset, msb, false); // big-endian
+    offset += 8;
+    view.setBigUint64(offset, lsb, false); // big-endian
+    offset += 8;
+
+    return offset;
+  }
+}
+
 /**
  * AgentUpdate message
  */
@@ -411,5 +486,6 @@ window.SLMessageTypes = {
   ChatFromSimulatorMessage,
   ChatFromViewerMessage,
   ObjectUpdateMessage,
-  AgentUpdateMessage
+  AgentUpdateMessage,
+  GrantUserRightsMessage
 };

--- a/PWA-demo/tests/phase2/friends-extended.test.js
+++ b/PWA-demo/tests/phase2/friends-extended.test.js
@@ -1,13 +1,50 @@
-/**
- * Test stub for friends-extended.js
- * 
- * TODO: Implement tests for FriendsExtended
- * - Test friend request handling
- * - Test online status notifications
- * - Test friend permissions/rights
- * - Test calling card management
- * - Test friend groups
- */
+const assert = require('assert');
 
-// Placeholder for future test implementation
-console.log('friends-extended.js tests - TODO');
+// Mock browser environment
+global.window = {};
+
+// Load dependencies
+const fs = require('fs');
+const path = require('path');
+
+const slMessagesCode = fs.readFileSync(path.join(__dirname, '../../js/sl-messages.js'), 'utf8');
+eval(slMessagesCode);
+
+const friendsExtendedCode = fs.readFileSync(path.join(__dirname, '../../js/friends-extended.js'), 'utf8');
+
+// Simple mock for testing
+let sentMessages = [];
+window.app = {
+  protocolManager: {
+    agentId: '11111111-2222-3333-4444-555555555555',
+    sessionId: '66666666-7777-8888-9999-000000000000',
+    sendMessage: (type, data) => {
+      sentMessages.push({ type, data });
+    }
+  }
+};
+
+// We need to slightly patch the module export for CJS testing since it uses ES6 export
+const codeToRun = friendsExtendedCode.replace(/export /g, '')
+                                     .replace('default friendsExtended;', 'global.friendsExtended = friendsExtended;')
+                                     .replace('{ FriendsExtended, FriendRights, FriendStatus };', '');
+eval(codeToRun);
+
+function runTests() {
+  console.log('Running FriendsExtended tests...');
+
+  // Test grantRights
+  sentMessages = [];
+  friendsExtended.grantRights('12345678-1234-1234-1234-123456789012', 3);
+
+  assert.strictEqual(sentMessages.length, 1, 'Should have sent one message');
+  assert.strictEqual(sentMessages[0].type, 'GrantUserRights', 'Message type should be GrantUserRights');
+  assert.strictEqual(sentMessages[0].data.friend_id, '12345678-1234-1234-1234-123456789012', 'Friend ID should match');
+  assert.strictEqual(sentMessages[0].data.rights, 3, 'Rights should match');
+  assert.ok(sentMessages[0].data.payload, 'Payload should be present');
+  assert.strictEqual(sentMessages[0].data.payload.length, 53, 'Payload length should be 53 bytes');
+
+  console.log('✅ All tests passed!');
+}
+
+runTests();


### PR DESCRIPTION
Implement GrantUserRights message in PWA demo

- Added `GRANT_USER_RIGHTS` MessageID to `sl-messages.js`
- Implemented `GrantUserRightsMessage` structure and payload packing
- Implemented `GrantUserRights` message sending in `FriendsExtended.grantRights` method
- Added a basic unit test verifying the payload size and behavior in `friends-extended.test.js`

---
*PR created automatically by Jules for task [6060735935899919397](https://jules.google.com/task/6060735935899919397) started by @Kaleaon*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the `GrantUserRights` message functionality in the PWA demo, allowing users to grant rights to friends. It adds the message type definition and ID to `sl-messages.js`, implements the message structure with proper payload packing following the SecondLife protocol (UUID handling in big-endian format, rights as S32 in little-endian), integrates the message sending logic into the `FriendsExtended.grantRights` method with appropriate fallbacks and warnings, and includes a unit test that verifies the payload size (53 bytes) and message behavior.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `PWA-demo/js/sl-messages.js` |
| 2 | `PWA-demo/js/friends-extended.js` |
| 3 | `PWA-demo/tests/phase2/friends-extended.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->