### PR TITLE
feat: Implement sending DeclineFriendship message

### DIFF
--- a/PWA-demo/js/friends-extended.js
+++ b/PWA-demo/js/friends-extended.js
@@ -127,9 +127,20 @@ class FriendsExtended {
   declineFriendRequest(fromUUID) {
     console.log(`Declining friend request from ${fromUUID}`);
     
+    // Get session ID before deleting the request
+    const request = this.pendingRequests.get(fromUUID);
+    const sessionID = request ? request.sessionID : null;
+
     this.pendingRequests.delete(fromUUID);
     
-    // TODO: Send DeclineFriendship message
+    // Send DeclineFriendship message via protocol manager
+    if (window.app && window.app.protocol) {
+      window.app.protocol.sendMessage('DeclineFriendship', {
+        agent_id: window.app.auth.user.id,
+        session_id: window.app.protocol.sessionId,
+        transaction_id: sessionID || '00000000-0000-0000-0000-000000000000'
+      });
+    }
   }
   
   /**


### PR DESCRIPTION
This implements the missing `TODO: Send DeclineFriendship message` in `PWA-demo/js/friends-extended.js`.

Changes:
- Added `window.app.protocol.sendMessage('DeclineFriendship', ...)` in `declineFriendRequest`.
- Sends `agent_id` from the auth user object.
- Sends `session_id` from the protocol object.
- Sends `transaction_id` using the original request's `sessionID`, falling back to a zero-UUID.

---
*PR created automatically by Jules for task [6795025634472086687](https://jules.google.com/task/6795025634472086687) started by @Kaleaon*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the previously missing functionality to send a `DeclineFriendship` message when a user declines a friend request. The implementation captures the session ID from the pending request before deletion, then sends a protocol message with the agent ID, session ID, and transaction ID (falling back to a zero-UUID if unavailable).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `PWA-demo/js/friends-extended.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->