### PR TITLE
feat: Send UpdateGroupInfo message

### DIFF
--- a/PWA-demo/js/groups.js
+++ b/PWA-demo/js/groups.js
@@ -546,12 +546,30 @@ class GroupsManager {
    */
   updateCharter(groupUUID, charter) {
     const group = this.groups.get(groupUUID);
-    if (group) {
-      group.charter = charter;
-      this.notifyChange('group-updated', groupUUID);
-    }
+    if (!group) return;
+
+    group.charter = charter;
+    this.notifyChange('group-updated', groupUUID);
     
-    // TODO: Send UpdateGroupInfo message
+    // Send UpdateGroupInfo message
+    if (window.app && window.app.agentId && window.app.sessionId) {
+      const MsgClass = window.SLMessageTypes ? window.SLMessageTypes.UpdateGroupInfoMessage : (typeof UpdateGroupInfoMessage !== 'undefined' ? UpdateGroupInfoMessage : null);
+      if (MsgClass && window.app.protocolManager) {
+        const msg = new MsgClass(
+          window.app.agentId,
+          window.app.sessionId,
+          groupUUID,
+          charter,
+          group.showInList !== undefined ? group.showInList : true,
+          group.insigniaID || '00000000-0000-0000-0000-000000000000',
+          group.membershipFee || 0,
+          group.openEnrollment !== undefined ? group.openEnrollment : true,
+          group.allowPublish !== undefined ? group.allowPublish : true,
+          group.maturePublish !== undefined ? group.maturePublish : false
+        );
+        window.app.protocolManager.sendMessage(msg);
+      }
+    }
   }
   
   /**
@@ -561,12 +579,30 @@ class GroupsManager {
    */
   setInsignia(groupUUID, insigniaID) {
     const group = this.groups.get(groupUUID);
-    if (group) {
-      group.insigniaID = insigniaID;
-      this.notifyChange('group-updated', groupUUID);
-    }
+    if (!group) return;
+
+    group.insigniaID = insigniaID;
+    this.notifyChange('group-updated', groupUUID);
     
-    // TODO: Send UpdateGroupInfo message
+    // Send UpdateGroupInfo message
+    if (window.app && window.app.agentId && window.app.sessionId) {
+      const MsgClass = window.SLMessageTypes ? window.SLMessageTypes.UpdateGroupInfoMessage : (typeof UpdateGroupInfoMessage !== 'undefined' ? UpdateGroupInfoMessage : null);
+      if (MsgClass && window.app.protocolManager) {
+        const msg = new MsgClass(
+          window.app.agentId,
+          window.app.sessionId,
+          groupUUID,
+          group.charter || '',
+          group.showInList !== undefined ? group.showInList : true,
+          insigniaID,
+          group.membershipFee || 0,
+          group.openEnrollment !== undefined ? group.openEnrollment : true,
+          group.allowPublish !== undefined ? group.allowPublish : true,
+          group.maturePublish !== undefined ? group.maturePublish : false
+        );
+        window.app.protocolManager.sendMessage(msg);
+      }
+    }
   }
   
   /**

--- a/PWA-demo/js/sl-messages.js
+++ b/PWA-demo/js/sl-messages.js
@@ -16,6 +16,9 @@ const MessageIDs = {
   CHAT_FROM_VIEWER: 0x50,
   IMPROVED_IM: 0x12,
   
+  // Group Messages
+  UPDATE_GROUP_INFO: 0xFFFF0155,
+
   // Object Messages
   OBJECT_UPDATE: 0x0C,
   OBJECT_UPDATE_COMPRESSED: 0x0D,
@@ -402,6 +405,101 @@ class AgentUpdateMessage extends SLMessage {
   }
 }
 
+
+/**
+ * UpdateGroupInfo message
+ */
+class UpdateGroupInfoMessage extends SLMessage {
+  constructor(agentId, sessionId, groupId, charter = '', showInList = true, insigniaId = '00000000-0000-0000-0000-000000000000', membershipFee = 0, openEnrollment = true, allowPublish = true, maturePublish = false) {
+    super();
+    this.agentId = agentId;
+    this.sessionId = sessionId;
+    this.groupId = groupId;
+    this.charter = charter;
+    this.showInList = showInList;
+    this.insigniaId = insigniaId;
+    this.membershipFee = membershipFee;
+    this.openEnrollment = openEnrollment;
+    this.allowPublish = allowPublish;
+    this.maturePublish = maturePublish;
+    this.isReliable = true;
+    this.zeroCoded = true;
+  }
+
+  getMessageID() {
+    return MessageIDs.UPDATE_GROUP_INFO;
+  }
+
+  getMessageName() {
+    return 'UpdateGroupInfo';
+  }
+
+  packPayload(buffer) {
+    const view = new DataView(buffer);
+    let offset = 0;
+
+    // AgentData block
+    offset = this.uuidToBytes(this.agentId, view, offset);
+    offset = this.uuidToBytes(this.sessionId, view, offset);
+
+    // GroupData block
+    offset = this.uuidToBytes(this.groupId, view, offset);
+
+    // Charter (Variable 2)
+    const charterBytes = new TextEncoder().encode(this.charter);
+    view.setUint16(offset, charterBytes.length, true); // Little Endian
+    offset += 2;
+    for (let i = 0; i < charterBytes.length; i++) {
+      view.setUint8(offset++, charterBytes[i]);
+    }
+
+    // ShowInList (BOOL)
+    view.setUint8(offset++, this.showInList ? 1 : 0);
+
+    // InsigniaID (UUID)
+    offset = this.uuidToBytes(this.insigniaId, view, offset);
+
+    // MembershipFee (S32)
+    view.setInt32(offset, this.membershipFee, true); // Little Endian
+    offset += 4;
+
+    // OpenEnrollment (BOOL)
+    view.setUint8(offset++, this.openEnrollment ? 1 : 0);
+
+    // AllowPublish (BOOL)
+    view.setUint8(offset++, this.allowPublish ? 1 : 0);
+
+    // MaturePublish (BOOL)
+    view.setUint8(offset++, this.maturePublish ? 1 : 0);
+
+    return offset;
+  }
+
+  uuidToBytes(uuid, view, offset) {
+    if (!uuid) {
+      for (let i = 0; i < 16; i++) {
+        view.setUint8(offset++, 0);
+      }
+      return offset;
+    }
+
+    const hex = uuid.replace(/-/g, '');
+    if (hex.length !== 32 || !/^[0-9a-fA-F]+$/.test(hex)) {
+      throw new Error('Invalid UUID format: ' + uuid);
+    }
+
+    const msb = BigInt('0x' + hex.substring(0, 16));
+    const lsb = BigInt('0x' + hex.substring(16, 32));
+
+    view.setBigUint64(offset, msb, false); // big-endian
+    offset += 8;
+    view.setBigUint64(offset, lsb, false); // big-endian
+    offset += 8;
+
+    return offset;
+  }
+}
+
 // Export all message types
 window.SLMessageTypes = {
   MessageIDs,
@@ -411,5 +509,6 @@ window.SLMessageTypes = {
   ChatFromSimulatorMessage,
   ChatFromViewerMessage,
   ObjectUpdateMessage,
-  AgentUpdateMessage
+  AgentUpdateMessage,
+  UpdateGroupInfoMessage
 };


### PR DESCRIPTION
Implemented `UpdateGroupInfoMessage` sending when group charter or insignia
is updated in the PWA demo (`PWA-demo/js/groups.js`). Added the message ID
`UPDATE_GROUP_INFO` (0xFFFF0155) and the message class logic in
`PWA-demo/js/sl-messages.js`.

---
*PR created automatically by Jules for task [11842748852267845328](https://jules.google.com/task/11842748852267845328) started by @Kaleaon*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements the ability to send `UpdateGroupInfoMessage` when group charter or insignia is updated in the PWA demo. The changes add a new message class with ID `0xFFFF0155` that serializes group metadata (charter, insignia, membership settings, etc.) and integrates it into the existing group management methods `updateCharter()` and `setInsignia()` to automatically send updates to the protocol manager.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `PWA-demo/js/sl-messages.js` |
| 2 | `PWA-demo/js/groups.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->