### PR TITLE
feat: send UpdateGroupInfo messages in GroupsManager

### DIFF
--- a/PWA-demo/js/groups.js
+++ b/PWA-demo/js/groups.js
@@ -549,9 +549,20 @@ class GroupsManager {
     if (group) {
       group.charter = charter;
       this.notifyChange('group-updated', groupUUID);
+
+      if (window.app && window.app.protocol) {
+        window.app.protocol.sendMessage('UpdateGroupInfo', {
+          uuid: group.uuid,
+          charter: group.charter,
+          showInList: group.showInList,
+          insigniaID: group.insigniaID,
+          membershipFee: group.membershipFee,
+          openEnrollment: group.openEnrollment,
+          allowPublish: group.allowPublish,
+          maturePublish: group.maturePublish
+        });
+      }
     }
-    
-    // TODO: Send UpdateGroupInfo message
   }
   
   /**
@@ -564,9 +575,20 @@ class GroupsManager {
     if (group) {
       group.insigniaID = insigniaID;
       this.notifyChange('group-updated', groupUUID);
+
+      if (window.app && window.app.protocol) {
+        window.app.protocol.sendMessage('UpdateGroupInfo', {
+          uuid: group.uuid,
+          charter: group.charter,
+          showInList: group.showInList,
+          insigniaID: group.insigniaID,
+          membershipFee: group.membershipFee,
+          openEnrollment: group.openEnrollment,
+          allowPublish: group.allowPublish,
+          maturePublish: group.maturePublish
+        });
+      }
     }
-    
-    // TODO: Send UpdateGroupInfo message
   }
   
   /**

--- a/PWA-demo/tests/phase2/groups.test.js
+++ b/PWA-demo/tests/phase2/groups.test.js
@@ -1,14 +1,85 @@
-/**
- * Test stub for groups.js
- * 
- * TODO: Implement tests for GroupsManager
- * - Test group info management
- * - Test group member tracking
- * - Test group roles
- * - Test group chat sessions
- * - Test group notices
- * - Test group permissions
- */
+const fs = require('fs');
 
-// Placeholder for future test implementation
-console.log('groups.js tests - TODO');
+// Stub window object before loading groups.js
+global.window = {
+  app: {
+    protocol: {
+      sendMessage: jest.fn()
+    }
+  }
+};
+
+const code = fs.readFileSync('js/groups.js', 'utf8');
+
+// Replace export default with something jest can handle simply via evaluation
+const evalCode = code.replace(/export default groupsManager;/, '')
+                     .replace(/export \{ GroupsManager \};/, '')
+                     .replace(/export const GroupPowers/, 'const GroupPowers');
+
+let GroupsManager;
+const mockExports = {};
+const evaluateCode = new Function('exports', 'window', evalCode + '\nreturn GroupsManager;');
+GroupsManager = evaluateCode(mockExports, global.window);
+
+describe('GroupsManager', () => {
+  let groupsManager;
+
+  beforeEach(() => {
+    groupsManager = new GroupsManager();
+    global.window.app.protocol.sendMessage.mockClear();
+  });
+
+  test('updateCharter sends UpdateGroupInfo message', () => {
+    const uuid = 'test-uuid';
+    groupsManager.setGroupInfo({
+      uuid,
+      name: 'Test Group',
+      charter: 'Old Charter',
+      showInList: true,
+      membershipFee: 10,
+      openEnrollment: false,
+      allowPublish: true,
+      maturePublish: false
+    });
+
+    groupsManager.updateCharter(uuid, 'New Charter');
+
+    expect(global.window.app.protocol.sendMessage).toHaveBeenCalledWith('UpdateGroupInfo', {
+      uuid,
+      charter: 'New Charter',
+      showInList: true,
+      insigniaID: null,
+      membershipFee: 10,
+      openEnrollment: false,
+      allowPublish: true,
+      maturePublish: false
+    });
+  });
+
+  test('setInsignia sends UpdateGroupInfo message', () => {
+    const uuid = 'test-uuid';
+    groupsManager.setGroupInfo({
+      uuid,
+      name: 'Test Group',
+      charter: 'Test Charter',
+      showInList: false,
+      membershipFee: 0,
+      openEnrollment: true,
+      allowPublish: false,
+      maturePublish: true
+    });
+
+    groupsManager.setInsignia(uuid, 'new-insignia-uuid');
+
+    expect(global.window.app.protocol.sendMessage).toHaveBeenCalledWith('UpdateGroupInfo', {
+      uuid,
+      charter: 'Test Charter',
+      showInList: false,
+      insigniaID: 'new-insignia-uuid',
+      membershipFee: 0,
+      openEnrollment: true,
+      allowPublish: false,
+      maturePublish: true
+    });
+  });
+});

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,45 @@
+--- PWA-demo/js/groups.js
++++ PWA-demo/js/groups.js
+@@ -550,8 +550,18 @@
+       group.charter = charter;
+       this.notifyChange('group-updated', groupUUID);
+-    }
+-
+-    // TODO: Send UpdateGroupInfo message
++
++      if (window.app && window.app.protocol) {
++        window.app.protocol.sendMessage('UpdateGroupInfo', {
++          uuid: group.uuid,
++          charter: group.charter,
++          showInList: group.showInList,
++          insigniaID: group.insigniaID,
++          membershipFee: group.membershipFee,
++          openEnrollment: group.openEnrollment,
++          allowPublish: group.allowPublish,
++          maturePublish: group.maturePublish
++        });
++      }
++    }
+   }
+
+@@ -565,8 +575,18 @@
+       group.insigniaID = insigniaID;
+       this.notifyChange('group-updated', groupUUID);
+-    }
+-
+-    // TODO: Send UpdateGroupInfo message
++
++      if (window.app && window.app.protocol) {
++        window.app.protocol.sendMessage('UpdateGroupInfo', {
++          uuid: group.uuid,
++          charter: group.charter,
++          showInList: group.showInList,
++          insigniaID: group.insigniaID,
++          membershipFee: group.membershipFee,
++          openEnrollment: group.openEnrollment,
++          allowPublish: group.allowPublish,
++          maturePublish: group.maturePublish
++        });
++      }
++    }
+   }

--- a/patch.js
+++ b/patch.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const file = 'PWA-demo/js/groups.js';
+let data = fs.readFileSync(file, 'utf8');
+
+data = data.replace(
+`  updateCharter(groupUUID, charter) {
+    const group = this.groups.get(groupUUID);
+    if (group) {
+      group.charter = charter;
+      this.notifyChange('group-updated', groupUUID);
+    }
+
+    // TODO: Send UpdateGroupInfo message
+  }`,
+`  updateCharter(groupUUID, charter) {
+    const group = this.groups.get(groupUUID);
+    if (group) {
+      group.charter = charter;
+      this.notifyChange('group-updated', groupUUID);
+
+      if (window.app && window.app.protocol) {
+        window.app.protocol.sendMessage('UpdateGroupInfo', {
+          uuid: group.uuid,
+          charter: group.charter,
+          showInList: group.showInList,
+          insigniaID: group.insigniaID,
+          membershipFee: group.membershipFee,
+          openEnrollment: group.openEnrollment,
+          allowPublish: group.allowPublish,
+          maturePublish: group.maturePublish
+        });
+      }
+    }
+  }`
+);
+
+data = data.replace(
+`  setInsignia(groupUUID, insigniaID) {
+    const group = this.groups.get(groupUUID);
+    if (group) {
+      group.insigniaID = insigniaID;
+      this.notifyChange('group-updated', groupUUID);
+    }
+
+    // TODO: Send UpdateGroupInfo message
+  }`,
+`  setInsignia(groupUUID, insigniaID) {
+    const group = this.groups.get(groupUUID);
+    if (group) {
+      group.insigniaID = insigniaID;
+      this.notifyChange('group-updated', groupUUID);
+
+      if (window.app && window.app.protocol) {
+        window.app.protocol.sendMessage('UpdateGroupInfo', {
+          uuid: group.uuid,
+          charter: group.charter,
+          showInList: group.showInList,
+          insigniaID: group.insigniaID,
+          membershipFee: group.membershipFee,
+          openEnrollment: group.openEnrollment,
+          allowPublish: group.allowPublish,
+          maturePublish: group.maturePublish
+        });
+      }
+    }
+  }`
+);
+
+fs.writeFileSync(file, data, 'utf8');


### PR DESCRIPTION
Implemented sending of `UpdateGroupInfo` messages from `GroupsManager.updateCharter` and `GroupsManager.setInsignia` in the PWA demo.
These messages are dispatched using the globally available `window.app.protocol.sendMessage` since `GroupsManager` does not receive a direct protocol dependency.
The payload constructed incorporates existing group details (`uuid`, `charter`, `showInList`, `insigniaID`, `membershipFee`, `openEnrollment`, `allowPublish`, `maturePublish`).

---
*PR created automatically by Jules for task [3232662136617547419](https://jules.google.com/task/3232662136617547419) started by @Kaleaon*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements sending `UpdateGroupInfo` messages when group charters or insignias are updated in the GroupsManager. The implementation adds protocol message dispatching via `window.app.protocol.sendMessage` in the `updateCharter` and `setInsignia` methods, removing TODO comments that previously marked this as planned work. Corresponding unit tests have been added to verify that both methods correctly send the UpdateGroupInfo messages with all required group properties.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `PWA-demo/js/groups.js` |
| 2 | `PWA-demo/tests/phase2/groups.test.js` |
| 3 | `patch.diff` |
| 4 | `patch.js` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `patch.diff` | This appears to be a generated diff file that duplicates the changes already shown in groups.js - it's unusual to commit diff files as part of a PR |
| `patch.js` | This is a code generation/patching script that was likely used to create the changes but shouldn't typically be committed to the repository |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->