### PR TITLE
Implement AgentProfile capability fetch and tests in UserProfileManager

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/users/UserProfileManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/users/UserProfileManager.kt
@@ -28,7 +28,12 @@ import java.util.concurrent.ConcurrentHashMap
 class UserProfileManager(
     private val capabilityManager: CapabilityManager,
     private val udpConnection: UDPConnectionFixed,
-    private val agentId: UUID
+    private val agentId: UUID,
+    private val capabilityRequest: suspend (String, LLSDValue?) -> LLSDValue? =
+        { capabilityName, body -> capabilityManager.request(capabilityName, body) },
+    private val udpFallbackRequest: suspend (UUID) -> Unit = { fallbackAvatarId ->
+        sendPropertiesRequestInternal(fallbackAvatarId)
+    }
 ) {
     companion object {
         private const val TAG = "UserProfileManager"
@@ -76,7 +81,7 @@ class UserProfileManager(
         try {
             val cap = capabilityManager.getCapability("AgentProfile")
             if (cap != null) {
-                fetchProfileViaCap(avatarId, cap)
+                fetchProfileViaCap(avatarId)
                 return
             }
         } catch (e: Exception) {
@@ -90,11 +95,20 @@ class UserProfileManager(
     /**
      * Fetch profile via AgentProfile capability.
      */
-    private suspend fun fetchProfileViaCap(avatarId: UUID, capUrl: String) {
+    private suspend fun fetchProfileViaCap(avatarId: UUID) {
         try {
-            // The capability URL includes the agent ID
-            // For now, just use UDP fallback since we don't have direct HTTP method
-            sendPropertiesRequest(avatarId)
+            val request = LLSDMap().apply {
+                this["avatar_id"] = LLSDUUID(avatarId)
+            }
+            val response = capabilityRequest("AgentProfile", request)
+            if (response is LLSDMap) {
+                val profile = parseProfileFromLLSD(avatarId, response)
+                cacheProfile(avatarId, profile)
+                notifyCallbacks(avatarId, profile)
+            } else {
+                Log.w(TAG, "AgentProfile capability returned non-map response, using UDP")
+                sendPropertiesRequest(avatarId)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to fetch profile via capability", e)
             // Fallback to UDP
@@ -106,6 +120,10 @@ class UserProfileManager(
      * Send AvatarPropertiesRequest via UDP.
      */
     private suspend fun sendPropertiesRequest(avatarId: UUID) {
+        udpFallbackRequest(avatarId)
+    }
+
+    private suspend fun sendPropertiesRequestInternal(avatarId: UUID) {
         try {
             val payload = ByteBuffer.allocate(48).order(ByteOrder.LITTLE_ENDIAN)
             

--- a/Linkpoint/src/test/kotlin/com/linkpoint/users/UserProfileManagerTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/users/UserProfileManagerTest.kt
@@ -1,0 +1,132 @@
+package com.linkpoint.users
+
+import com.linkpoint.protocol.capabilities.CapabilityManager
+import com.linkpoint.protocol.llsd.LLSDInteger
+import com.linkpoint.protocol.llsd.LLSDMap
+import com.linkpoint.protocol.llsd.LLSDString
+import com.linkpoint.protocol.llsd.LLSDUUID
+import com.linkpoint.protocol.llsd.LLSDValue
+import com.linkpoint.protocol.messages.UDPConnectionFixed
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+class UserProfileManagerTest {
+
+    @Test
+    fun `requestProfile uses AgentProfile capability response and caches callback result`() = runBlocking {
+        val capabilityManager = CapabilityManager().apply {
+            setCapabilityForTest("AgentProfile", "http://example.invalid/agent-profile")
+        }
+        val avatarId = UUID.randomUUID()
+
+        var capturedRequest: LLSDValue? = null
+        val fallbackCount = AtomicInteger(0)
+        var callbackProfile: UserProfile? = null
+
+        val manager = UserProfileManager(
+            capabilityManager = capabilityManager,
+            udpConnection = UDPConnectionFixed(),
+            agentId = UUID.randomUUID(),
+            capabilityRequest = { capName, body ->
+                assertEquals("AgentProfile", capName)
+                capturedRequest = body
+                LLSDMap().apply {
+                    this["sl_image_id"] = LLSDUUID(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+                    this["fl_image_id"] = LLSDUUID(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+                    this["partner_id"] = LLSDUUID(UUID.fromString("33333333-3333-3333-3333-333333333333"))
+                    this["sl_about_text"] = LLSDString("about")
+                    this["fl_about_text"] = LLSDString("first life")
+                    this["born_on"] = LLSDString("January 1, 2000")
+                    this["profile_url"] = LLSDString("https://example.com/profile")
+                    this["flags"] = LLSDInteger(0x10)
+                    this["display_name"] = LLSDString("Display Name")
+                    this["username"] = LLSDString("display.name")
+                    this["account_type"] = LLSDString("Resident")
+                }
+            },
+            udpFallbackRequest = {
+                fallbackCount.incrementAndGet()
+            }
+        )
+
+        manager.requestProfile(avatarId) { profile ->
+            callbackProfile = profile
+        }
+
+        val requestMap = capturedRequest as? LLSDMap
+        assertNotNull(requestMap)
+        assertEquals(avatarId, requestMap?.getUUID("avatar_id"))
+
+        assertEquals(0, fallbackCount.get())
+        assertNotNull(callbackProfile)
+        assertEquals("Display Name", callbackProfile?.displayName)
+        assertEquals("about", callbackProfile?.aboutText)
+        assertTrue(callbackProfile?.isOnline == true)
+
+        val cached = manager.getCachedProfile(avatarId)
+        assertNotNull(cached)
+        assertEquals("display.name", cached?.username)
+    }
+
+    @Test
+    fun `requestProfile falls back to UDP when AgentProfile returns malformed LLSD`() = runBlocking {
+        val capabilityManager = CapabilityManager().apply {
+            setCapabilityForTest("AgentProfile", "http://example.invalid/agent-profile")
+        }
+        val fallbackCount = AtomicInteger(0)
+        val manager = UserProfileManager(
+            capabilityManager = capabilityManager,
+            udpConnection = UDPConnectionFixed(),
+            agentId = UUID.randomUUID(),
+            capabilityRequest = { _, _ -> LLSDString("not a map") },
+            udpFallbackRequest = { fallbackCount.incrementAndGet() }
+        )
+
+        var callbackInvoked = false
+        val avatarId = UUID.randomUUID()
+        manager.requestProfile(avatarId) {
+            callbackInvoked = true
+        }
+
+        assertEquals(1, fallbackCount.get())
+        assertFalse(callbackInvoked)
+        assertNull(manager.getCachedProfile(avatarId))
+    }
+
+    @Test
+    fun `requestProfile falls back to UDP when capability is unavailable`() = runBlocking {
+        val capabilityManager = CapabilityManager()
+        var capabilityCalled = false
+        val fallbackCount = AtomicInteger(0)
+        val manager = UserProfileManager(
+            capabilityManager = capabilityManager,
+            udpConnection = UDPConnectionFixed(),
+            agentId = UUID.randomUUID(),
+            capabilityRequest = { _, _ ->
+                capabilityCalled = true
+                null
+            },
+            udpFallbackRequest = { fallbackCount.incrementAndGet() }
+        )
+
+        manager.requestProfile(UUID.randomUUID())
+
+        assertFalse(capabilityCalled)
+        assertEquals(1, fallbackCount.get())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun CapabilityManager.setCapabilityForTest(name: String, url: String) {
+        val field = CapabilityManager::class.java.getDeclaredField("capabilities")
+        field.isAccessible = true
+        val capabilities = field.get(this) as MutableMap<String, String>
+        capabilities[name] = url
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the previous unconditional UDP-first behavior with a real HTTP-based `AgentProfile` capability path to use server capabilities when available.  
- Parse LLSD capability responses into `UserProfile` and route results through the existing cache and callback machinery.  
- Preserve UDP as a deterministic fallback only on explicit capability failure or unavailable/malformed responses and enable deterministic unit testing via injection points.  

### Description
- Implemented `fetchProfileViaCap()` to build an LLSD request with `"avatar_id"` and call the capability request path via an injectable `capabilityRequest` lambda that defaults to `capabilityManager.request`.  
- Parse `LLSDMap` responses using `parseProfileFromLLSD()`, then call existing `cacheProfile()` and `notifyCallbacks()` on success.  
- Keep UDP fallback behavior only when the capability is missing, returns `null`, throws, or returns a non-`LLSDMap`/malformed response, by invoking the UDP path via an injectable `udpFallbackRequest` lambda.  
- Added small refactor: extracted the internal UDP send to `sendPropertiesRequestInternal()` and routed `sendPropertiesRequest()` through the injectable fallback to enable test interception.  
- Added unit tests in `Linkpoint/src/test/kotlin/com/linkpoint/users/UserProfileManagerTest.kt` that cover a successful capability response, malformed LLSD response fallback, and no-capability fallback.  

### Testing
- Added three unit tests (`UserProfileManagerTest`) exercising capability-success, malformed-capability->UDP, and capability-unavailable->UDP scenarios; these tests are committed.  
- Attempted to run the unit tests via Gradle (`./gradlew testDebugUnitTest --tests com.linkpoint.users.UserProfileManagerTest`), but the run failed due to missing Android SDK configuration (`sdk.dir` / `ANDROID_HOME`) in the current environment, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b62e17fc832389f2e13b0a8a97f4)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements an HTTP-based `AgentProfile` capability path in `UserProfileManager` to fetch user profiles from server capabilities when available, replacing the previous UDP-first approach. The implementation parses LLSD capability responses into `UserProfile` objects, routes them through the existing cache and callback machinery, and preserves UDP as a deterministic fallback only when the capability is missing, returns malformed data, or throws an exception. The changes include dependency injection points (`capabilityRequest` and `udpFallbackRequest` lambdas) to enable testability, a small refactor extracting UDP send logic into `sendPropertiesRequestInternal()`, and comprehensive unit tests covering successful capability responses, malformed LLSD fallback, and capability-unavailable fallback scenarios.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/users/UserProfileManagerTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/users/UserProfileManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->