### PR TITLE
Require shared UDPConnectionFixed for circuits and guard movement sender lifecycle

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/network/core/AgentCircuit.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/core/AgentCircuit.kt
@@ -1,16 +1,14 @@
 package com.linkpoint.network.core
 
-import android.util.Log
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.network.events.EventBus
 import com.linkpoint.network.events.ConnectionState
 import com.linkpoint.network.events.ConnectionStateChangedEvent
 import com.linkpoint.protocol.auth.AuthReply
-import com.linkpoint.protocol.messages.MessageIds
 import com.linkpoint.protocol.messages.CircuitDispatcher
+import com.linkpoint.protocol.messages.MessageIds
 import com.linkpoint.protocol.messages.UDPConnectionFixed
 import com.linkpoint.protocol.messages.MessageRouter
-import com.linkpoint.protocol.messages.MessageEventListener
 import com.linkpoint.protocol.scenery.SceneDataHandler
 import com.linkpoint.render.RenderQueue
 import com.linkpoint.render.SceneGraph
@@ -18,9 +16,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
-import java.util.UUID
 
 /**
  * Agent Circuit with Circuit Establishment State Machine
@@ -39,7 +34,7 @@ import java.util.UUID
  */
 class AgentCircuit(
     private val authReply: AuthReply,
-    private val sharedConnection: UDPConnectionFixed? = null,
+    private val sharedConnection: UDPConnectionFixed,
     private val sceneGraph: SceneGraph? = null,
     private val renderQueue: RenderQueue? = null,
     private val scope: CoroutineScope = CoroutineScope(CircuitDispatcher.dispatcher + SupervisorJob())
@@ -57,20 +52,8 @@ class AgentCircuit(
     private var agentUpdateJob: Job? = null
     private var stateListener: CircuitStateListener? = null
 
-    /**
-     * Use the shared connection if provided (correct Lumiya-style architecture).
-     * Only fall back to creating own connection if no shared connection given
-     * (backwards compatibility during migration).
-     */
-    private val udpConnection: UDPConnectionFixed = sharedConnection ?: UDPConnectionFixed(
-        simIP = authReply.simIP,
-        simPort = authReply.simPort,
-        circuitCode = authReply.circuitCode
-    ).apply {
-        setSessionInfo(authReply.sessionId, authReply.agentId)
-    }
-
-    private val usesSharedConnection = sharedConnection != null
+    private val udpConnection: UDPConnectionFixed = sharedConnection
+    private val lifecycleOwnerId = "AgentCircuit:${authReply.agentId}:${authReply.circuitCode}"
 
     private val messageRouter = udpConnection.getMessageRouter()
     private val sceneDataHandler = SceneDataHandler(sceneGraph, renderQueue)
@@ -118,83 +101,16 @@ class AgentCircuit(
     private suspend fun establishCircuit() {
         NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP, "=== Starting Circuit Establishment ===")
         transitionState(CircuitState.CONNECTING, "Starting connection")
-
-        if (usesSharedConnection) {
-            // Shared connection is already connected - skip socket creation
-            // The main app's SecondLifeProtocol already sent UseCircuitCode and CompleteAgentMovement
-            NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP,
-                "Using shared connection (Lumiya-style) - skipping redundant UseCircuitCode")
-            isConnected = true
-            transitionState(CircuitState.USE_CIRCUIT_CODE_ACKED, "Shared connection")
-            transitionState(CircuitState.COMPLETE_AGENT_MOVEMENT_ACKED, "Shared connection")
-            transitionState(CircuitState.CIRCUIT_READY, "Ready (shared connection)")
-            startAgentUpdates()
-        } else {
-            // Legacy path: own connection (will be removed in future)
-            NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
-                "WARNING: AgentCircuit creating own socket - this creates competing connections!")
-            val connected = udpConnection.connect()
-            if (!connected) {
-                transitionState(CircuitState.ERROR, "UDP connection failed")
-                stateListener?.onCircuitError("UDP connection failed")
-                return
-            }
-            isConnected = true
-            sendUseCircuitCode()
-        }
-    }
-
-    private suspend fun sendUseCircuitCode() {
-        NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP, "Sending UseCircuitCode")
-
-        val listener = object : MessageEventListener {
-            override fun onMessageAcknowledged(seqNum: Int, msgId: Int) {
-                NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP, "UseCircuitCode ACKed")
-                transitionState(CircuitState.USE_CIRCUIT_CODE_ACKED, "ACKed")
-                scope.launch { sendCompleteAgentMovement() }
-            }
-
-            override fun onMessageTimeout(seqNum: Int, msgId: Int) {
-                NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP, "UseCircuitCode timeout")
-                transitionState(CircuitState.ERROR, "Timeout")
-                stateListener?.onCircuitError("UseCircuitCode timeout")
-            }
-        }
-
-        val payload = ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN)
-        payload.putInt(authReply.circuitCode)
-        payload.put(authReply.sessionId.asBytes())
-        payload.put(authReply.agentId.asBytes())
-
-        udpConnection.sendPacket(MessageIds.USE_CIRCUIT_CODE, payload.array(), reliable = true, listener = listener)
-        transitionState(CircuitState.USE_CIRCUIT_CODE_SENT, "Sent")
-    }
-
-    private suspend fun sendCompleteAgentMovement() {
-        NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP, "Sending CompleteAgentMovement")
-
-        val listener = object : MessageEventListener {
-            override fun onMessageAcknowledged(seqNum: Int, msgId: Int) {
-                NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP, "CompleteAgentMovement ACKed - CIRCUIT READY")
-                transitionState(CircuitState.COMPLETE_AGENT_MOVEMENT_ACKED, "ACKed")
-                transitionState(CircuitState.CIRCUIT_READY, "Ready")
-                scope.launch { startAgentUpdates() }
-            }
-
-            override fun onMessageTimeout(seqNum: Int, msgId: Int) {
-                NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP, "CompleteAgentMovement timeout")
-                transitionState(CircuitState.ERROR, "Timeout")
-                stateListener?.onCircuitError("CompleteAgentMovement timeout")
-            }
-        }
-
-        val payload = ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN)
-        payload.put(authReply.agentId.asBytes())
-        payload.put(authReply.sessionId.asBytes())
-        payload.putInt(authReply.circuitCode)
-
-        udpConnection.sendPacket(MessageIds.COMPLETE_AGENT_MOVEMENT, payload.array(), reliable = true, listener = listener)
-        transitionState(CircuitState.COMPLETE_AGENT_MOVEMENT_SENT, "Sent")
+        NetworkLogger.log(
+            NetworkLogger.Level.INFO,
+            NetworkLogger.Category.UDP,
+            "Using shared connection (Lumiya-style) - skipping redundant UseCircuitCode"
+        )
+        isConnected = true
+        transitionState(CircuitState.USE_CIRCUIT_CODE_ACKED, "Shared connection")
+        transitionState(CircuitState.COMPLETE_AGENT_MOVEMENT_ACKED, "Shared connection")
+        transitionState(CircuitState.CIRCUIT_READY, "Ready (shared connection)")
+        startAgentUpdates()
     }
 
     private suspend fun registerSceneDataHandlers() {
@@ -213,10 +129,21 @@ class AgentCircuit(
             override fun getPriority() = 0
         })
 
-        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Scene handlers registered on ${if (usesSharedConnection) "shared" else "own"} connection")
+        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Scene handlers registered on shared connection")
     }
 
     private fun startAgentUpdates() {
+        val lifecycleAcquired = udpConnection.tryAcquireMovementLifecycle(lifecycleOwnerId)
+        if (!lifecycleAcquired) {
+            val currentOwner = udpConnection.getMovementLifecycleOwner()
+            NetworkLogger.log(
+                NetworkLogger.Level.WARN,
+                NetworkLogger.Category.UDP,
+                "Skipping AgentCircuit update loop; movement lifecycle already owned by $currentOwner"
+            )
+            return
+        }
+
         agentUpdateJob = scope.launch {
             while (isActive && isConnected) {
                 try {
@@ -245,7 +172,7 @@ class AgentCircuit(
     fun getStatistics() = mapOf(
         "state" to _circuitState.value.name,
         "connected" to isConnected,
-        "usesSharedConnection" to usesSharedConnection,
+        "usesSharedConnection" to true,
         "sceneStats" to sceneDataHandler.getStatistics()
     )
 
@@ -254,11 +181,8 @@ class AgentCircuit(
     fun close() {
         isConnected = false
         agentUpdateJob?.cancel()
+        udpConnection.releaseMovementLifecycle(lifecycleOwnerId)
         try {
-            // Only disconnect if we own the connection
-            if (!usesSharedConnection) {
-                udpConnection.disconnect()
-            }
             scope.launch {
                 EventBus.publish(ConnectionStateChangedEvent(ConnectionState.CONNECTED, ConnectionState.DISCONNECTED))
             }
@@ -269,12 +193,4 @@ class AgentCircuit(
         scope.cancel()
     }
 
-    private fun UUID.asBytes(): ByteArray {
-        val bytes = ByteArray(16)
-        val msb = this.mostSignificantBits
-        val lsb = this.leastSignificantBits
-        for (i in 7 downTo 0) bytes[7 - i] = (msb shr (i * 8)).toByte()
-        for (i in 7 downTo 0) bytes[15 - i] = (lsb shr (i * 8)).toByte()
-        return bytes
-    }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/network/core/GridConnection.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/core/GridConnection.kt
@@ -38,7 +38,7 @@ import java.util.UUID
  */
 class GridConnection(
     private val context: Context,
-    private val sharedUdpConnection: UDPConnectionFixed? = null,
+    private val sharedUdpConnection: UDPConnectionFixed,
     private val connectionId: UUID = UUID.randomUUID(),
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 ) {
@@ -276,7 +276,7 @@ class GridConnection(
             // Step 4: Set up UDP reconnection callback
             // When the UDP connection detects it's dead (e.g. 5 unanswered pings,
             // socket errors), this callback triggers reconnection of the full session.
-            sharedUdpConnection?.setReconnectionCallback {
+            sharedUdpConnection.setReconnectionCallback {
                 NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
                     "UDP reconnection callback triggered - attempting to reconnect")
                 scope.launch {
@@ -391,7 +391,7 @@ class GridConnection(
      * @return The created temp circuit
      */
     fun createTempCircuit(authReply: AuthReply): TempCircuit {
-        val tempCircuit = TempCircuit(authReply)
+        val tempCircuit = TempCircuit(authReply, sharedConnection = sharedUdpConnection)
         tempCircuits[authReply] = tempCircuit
         return tempCircuit
     }

--- a/Linkpoint/src/main/java/com/linkpoint/network/core/TempCircuit.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/core/TempCircuit.kt
@@ -1,10 +1,6 @@
 package com.linkpoint.network.core
 
-import android.util.Log
 import com.linkpoint.network.NetworkLogger
-import com.linkpoint.network.events.EventBus
-import com.linkpoint.network.events.ConnectionStateChangedEvent
-import com.linkpoint.network.events.ConnectionState
 import com.linkpoint.protocol.auth.AuthReply
 import com.linkpoint.protocol.messages.UDPConnectionFixed
 import com.linkpoint.protocol.messages.MessageRouter
@@ -44,6 +40,7 @@ import java.util.UUID
  */
 class TempCircuit(
     private val authReply: AuthReply,
+    private val sharedConnection: UDPConnectionFixed,
     private val scope: CoroutineScope = CoroutineScope(CircuitDispatcher.dispatcher + SupervisorJob())
 ) {
     
@@ -71,17 +68,8 @@ class TempCircuit(
     private val _circuitState = MutableStateFlow(CircuitState.INITIALIZING)
     val circuitState: StateFlow<CircuitState> = _circuitState.asStateFlow()
     
-    /**
-     * Fixed UDP connection for this circuit
-     * Using UDPConnectionFixed which includes MessageRouter integration
-     */
-    private val udpConnection = UDPConnectionFixed(
-        simIP = authReply.simIP,
-        simPort = authReply.simPort,
-        circuitCode = authReply.circuitCode
-    ).apply {
-        setSessionInfo(authReply.sessionId, authReply.agentId)
-    }
+    /** Shared UDP connection for this circuit. */
+    private val udpConnection: UDPConnectionFixed = sharedConnection
     
     /**
      * Message router for routing incoming messages to handlers
@@ -128,48 +116,19 @@ class TempCircuit(
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Initializing temp circuit")
         
         try {
-            // Start UDP connection with fixed implementation
-            startUDPConnectionFixed()
-            
             // Start timeout timer (mobile-optimized: 30s max)
             startTimeoutTimer()
             
             _circuitState.value = CircuitState.ACTIVE
             isActive = true
             
-            NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Temp circuit initialized successfully")
+            NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Temp circuit initialized successfully (shared UDP)")
             
         } catch (e: Exception) {
             NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP, "Failed to initialize temp circuit: ${e.message}")
             _circuitState.value = CircuitState.ERROR
             close()
             throw e
-        }
-    }
-    
-    /**
-     * Start UDP connection
-     * Uses UDPConnectionFixed which properly handles receive operations
-     */
-    private suspend fun startUDPConnectionFixed() {
-        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Starting temp circuit UDP connection (Fixed implementation)")
-        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Sim IP: ${authReply.simIP}, Port: ${authReply.simPort}")
-        
-        val connected = udpConnection.connect()
-        
-        if (connected) {
-            NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "✓ Temp circuit UDP connection established")
-            isActive = true
-            
-            // Publish connection state event via EventBus
-            EventBus.publish(ConnectionStateChangedEvent(
-                ConnectionState.DISCONNECTED,
-                ConnectionState.CONNECTED
-            ))
-        } else {
-            NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP, "✗ Failed to establish temp circuit UDP connection")
-            isActive = false
-            throw IllegalStateException("Failed to connect temp circuit UDP")
         }
     }
     
@@ -285,26 +244,11 @@ class TempCircuit(
         // Cancel timeout job
         timeoutJob?.cancel()
         
-        // Disconnect UDP connection
-        try {
-            udpConnection.disconnect()
-            
-            // Publish connection state event via EventBus
-            scope.launch {
-                EventBus.publish(ConnectionStateChangedEvent(
-                    ConnectionState.CONNECTED,
-                    ConnectionState.DISCONNECTED
-                ))
-            }
-        } catch (e: Exception) {
-            NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP, "Error closing UDP connection: ${e.message}")
-        }
-        
         _circuitState.value = CircuitState.CLOSED
         
         // Cancel scope
         scope.cancel()
         
-        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Temp circuit closed")
+        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "Temp circuit closed (shared UDP retained)")
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -22,6 +22,7 @@ import java.nio.channels.DatagramChannel
 import java.nio.channels.SelectionKey
 import java.nio.channels.Selector
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
@@ -246,6 +247,7 @@ class UDPConnectionFixed {
 
     // Agent update job
     private var agentUpdateJob: Job? = null
+    private val movementLifecycleOwner = AtomicReference<String?>(null)
     
     // Mobile optimized: 10 updates/sec = 100ms interval
     private val AGENT_UPDATE_INTERVAL_MS = 100L
@@ -283,6 +285,7 @@ class UDPConnectionFixed {
     
     /** Timestamp when connection was attempted (for connection duration) */
     private var connectionAttemptTime = 0L
+    private val connectAttemptCount = AtomicInteger(0)
     
     /** Last connection error message (for troubleshooting) */
     private var lastConnectionError: String? = null
@@ -565,12 +568,56 @@ class UDPConnectionFixed {
      * Get the circuit code for this connection
      */
     fun getCircuitCode(): Int = circuitCode
+
+    /**
+     * Guards ownership of movement/reliable-send lifecycle for shared circuits.
+     * Only one owner should drive send loops at a time.
+     */
+    fun tryAcquireMovementLifecycle(ownerId: String): Boolean {
+        require(ownerId.isNotBlank()) { "ownerId must not be blank" }
+        val acquired = movementLifecycleOwner.compareAndSet(null, ownerId) || movementLifecycleOwner.get() == ownerId
+        if (!acquired) {
+            NetworkLogger.log(
+                NetworkLogger.Level.WARN,
+                NetworkLogger.Category.UDP,
+                "Movement lifecycle acquire denied for $ownerId; owner=${movementLifecycleOwner.get()}"
+            )
+        } else {
+            NetworkLogger.log(
+                NetworkLogger.Level.DEBUG,
+                NetworkLogger.Category.UDP,
+                "Movement lifecycle owned by ${movementLifecycleOwner.get()}"
+            )
+        }
+        return acquired
+    }
+
+    fun getMovementLifecycleOwner(): String? = movementLifecycleOwner.get()
+
+    fun releaseMovementLifecycle(ownerId: String) {
+        if (!movementLifecycleOwner.compareAndSet(ownerId, null)) {
+            NetworkLogger.log(
+                NetworkLogger.Level.WARN,
+                NetworkLogger.Category.UDP,
+                "Movement lifecycle release ignored for $ownerId; owner=${movementLifecycleOwner.get()}"
+            )
+        } else {
+            NetworkLogger.log(
+                NetworkLogger.Level.DEBUG,
+                NetworkLogger.Category.UDP,
+                "Movement lifecycle released by $ownerId"
+            )
+        }
+    }
+
+    fun getConnectAttemptCount(): Int = connectAttemptCount.get()
     
     /**
      * Connect to the simulator
      */
     suspend fun connect(): Boolean = withContext(CircuitDispatcher.dispatcher) {
         try {
+            connectAttemptCount.incrementAndGet()
             // Record connection attempt time and reset ALL statistics for new session
             connectionAttemptTime = System.currentTimeMillis()
             lastConnectionError = null

--- a/Linkpoint/src/test/kotlin/com/linkpoint/connection/SharedUdpCircuitIntegrationTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/connection/SharedUdpCircuitIntegrationTest.kt
@@ -1,0 +1,60 @@
+package com.linkpoint.connection
+
+import com.linkpoint.network.core.AgentCircuit
+import com.linkpoint.network.core.CircuitState
+import com.linkpoint.network.core.TempCircuit
+import com.linkpoint.protocol.auth.AuthReply
+import com.linkpoint.protocol.messages.UDPConnectionFixed
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+class SharedUdpCircuitIntegrationTest {
+
+    @Test
+    fun `agent and temp circuit establishment do not open second socket`() = runBlocking {
+        val sharedConnection = UDPConnectionFixed()
+        sharedConnection.setSessionInfo(UUID.randomUUID(), UUID.randomUUID())
+
+        val authReply = AuthReply(
+            sessionId = UUID.randomUUID(),
+            agentId = UUID.randomUUID(),
+            circuitCode = 123456,
+            simIP = "127.0.0.1",
+            simPort = 13000,
+            seedCapability = "https://example.com/seed"
+        )
+
+        val agentCircuit = AgentCircuit(authReply, sharedConnection = sharedConnection)
+        val tempCircuit = TempCircuit(authReply, sharedConnection = sharedConnection)
+
+        repeat(20) {
+            if (agentCircuit.circuitState.value == CircuitState.CIRCUIT_READY &&
+                tempCircuit.circuitState.value == TempCircuit.CircuitState.ACTIVE
+            ) {
+                return@repeat
+            }
+            delay(25)
+        }
+
+        assertTrue(
+            "Agent circuit should become ready on shared connection",
+            agentCircuit.circuitState.value == CircuitState.CIRCUIT_READY
+        )
+        assertTrue(
+            "Temp circuit should become active on shared connection",
+            tempCircuit.circuitState.value == TempCircuit.CircuitState.ACTIVE
+        )
+        assertEquals(
+            "No private UDP socket should be opened during circuit establishment",
+            0,
+            sharedConnection.getConnectAttemptCount()
+        )
+
+        tempCircuit.close()
+        agentCircuit.close()
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize UDP socket ownership onto a single shared `UDPConnectionFixed` instance to avoid competing sockets and duplicate I/O loops during circuit establishment.
- Remove legacy per-circuit socket creation paths which could open a second socket and interfere with the app-wide I/O thread and reliable-send lifecycle.

### Description
- Changed `AgentCircuit` to require a non-null `sharedConnection: UDPConnectionFixed` in its constructor and removed the fallback that created a private `UDPConnectionFixed` instance.
- Updated `TempCircuit` to take the shared `UDPConnectionFixed` and stop creating/connecting/disconnecting its own socket, retaining the shared connection for message routing.
- Updated `GridConnection` to require and pass the shared UDP instance to both `AgentCircuit` and `TempCircuit`, and to set the reconnection callback on the provided shared connection.
- Added lifecycle ownership APIs to `UDPConnectionFixed` (`tryAcquireMovementLifecycle`, `getMovementLifecycleOwner`, `releaseMovementLifecycle`) and logging so only one sender/movement lifecycle owner can run at a time, plus a `connect` attempt counter (`getConnectAttemptCount`) used by tests.
- Added `SharedUdpCircuitIntegrationTest` that instantiates an `AgentCircuit` and `TempCircuit` with the same shared `UDPConnectionFixed` and asserts that no additional `connect()` attempts occurred on the shared connection.

### Testing
- Added an integration test `SharedUdpCircuitIntegrationTest` which verifies circuits created with the same shared `UDPConnectionFixed` do not trigger a second socket connect; the test was added to `Linkpoint/src/test/kotlin/com/linkpoint/connection/SharedUdpCircuitIntegrationTest.kt` and asserts `sharedConnection.getConnectAttemptCount() == 0`.
- Attempted to run the test via `./gradlew test --tests "com.linkpoint.connection.SharedUdpCircuitIntegrationTest"`, but the build could not be executed in this environment because the Android SDK location is not configured (`ANDROID_HOME`/`local.properties`), so tests did not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b63d56d88323b3a47c2b18492f88)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the UDP socket ownership architecture to centralize it onto a single shared `UDPConnectionFixed` instance across all circuits. It removes the legacy per-circuit socket creation paths that caused competing sockets and duplicate I/O loops during circuit establishment. The changes make `sharedConnection` a required parameter for `AgentCircuit` and `TempCircuit`, eliminate redundant socket connect/disconnect calls in circuit lifecycle, and add lifecycle ownership APIs to `UDPConnectionFixed` to ensure only one movement sender runs at a time. An integration test validates that circuits created with the shared connection do not trigger additional socket connects.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/network/core/TempCircuit.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/network/core/AgentCircuit.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/network/core/GridConnection.kt` |
| 5 | `Linkpoint/src/test/kotlin/com/linkpoint/connection/SharedUdpCircuitIntegrationTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->