### PR TITLE
Align ParcelManager parcel messages with Lumiya protocol (ParcelBuy/ParcelPropertiesUpdate/AccessList)

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt
@@ -86,6 +86,13 @@ class ParcelManager(
         buffer.putLong(uuid.leastSignificantBits)
         buffer.order(order)
     }
+
+    private fun putVariable1String(buffer: ByteBuffer, value: String?) {
+        val bytes = (value ?: "").toByteArray(Charsets.UTF_8)
+        val safeBytes = if (bytes.size > 255) bytes.copyOf(255) else bytes
+        buffer.put(safeBytes.size.toByte())
+        buffer.put(safeBytes)
+    }
     
     /**
      * Handle ParcelProperties message
@@ -235,19 +242,27 @@ class ParcelManager(
     fun buyLand(localId: Int, forGroup: Boolean = false) {
         scope.launch {
             try {
-                // ParcelBuy message
-                val payload = ByteBuffer.allocate(80).order(ByteOrder.LITTLE_ENDIAN)
+                // ParcelBuy message (Lumiya parity):
+                // AgentData(32) + Data(16+1+1+4+1) + ParcelData(4+4) = 67 bytes
+                val payload = ByteBuffer.allocate(67).order(ByteOrder.LITTLE_ENDIAN)
+                val groupId = if (forGroup) {
+                    parcels[localId]?.groupId ?: UUID(0L, 0L)
+                } else {
+                    UUID(0L, 0L)
+                }
                 
                 // AgentData with proper IDs
                 writeAgentData(payload)
                 
                 // Data block
-                payload.putInt(localId)  // ParcelLocalID
-                payload.put(if (forGroup) 1 else 0)  // ForGroup
-                repeat(16) { payload.put(0) }  // GroupID placeholder
-                payload.put(0)  // IsGroupOwned
+                writeUUID(payload, groupId)
+                payload.put(if (forGroup) 1 else 0)  // IsGroupOwned
                 payload.put(0)  // RemoveContribution
-                payload.putInt(0)  // Final price (0 = use parcel price)
+                payload.putInt(localId)
+                payload.put(1)  // Final=true
+
+                // ParcelData block
+                payload.putInt(0)  // Price (0 = simulator authoritative price)
                 payload.putInt(0)  // Area
                 
                 udpConnection.sendPacket(MessageIds.PARCEL_BUY, payload.array(), reliable = true)
@@ -311,20 +326,23 @@ class ParcelManager(
     fun setForSale(localId: Int, price: Int, forAll: Boolean = true) {
         scope.launch {
             try {
-                // ParcelPropertiesUpdate message with sale info
-                val payload = ByteBuffer.allocate(100).order(ByteOrder.LITTLE_ENDIAN)
-                
-                // AgentData with proper IDs
-                writeAgentData(payload)
-                
-                // ParcelData block
-                payload.putInt(localId)
-                payload.putInt(if (forAll) FLAG_FOR_SALE.toInt() else 0)  // Flags with FOR_SALE
-                payload.putInt(price)  // SalePrice
-                repeat(16) { payload.put(0) }  // Name placeholder (empty string)
-                repeat(16) { payload.put(0) }  // Description placeholder
-                
-                udpConnection.sendPacket(MessageIds.PARCEL_PROPERTIES_UPDATE, payload.array(), reliable = true)
+                val parcel = parcels[localId]
+                val existingFlags = parcel?.flags ?: 0L
+                val updatedFlags = if (forAll) {
+                    existingFlags or FLAG_FOR_SALE
+                } else {
+                    existingFlags and FLAG_FOR_SALE.inv()
+                }
+
+                if (parcel != null) {
+                    parcels[localId] = parcel.copy(flags = updatedFlags)
+                }
+
+                sendParcelPropertiesUpdate(
+                    localId = localId,
+                    salePriceOverride = price,
+                    parcelFlagsOverride = updatedFlags
+                )
                 Log.i(TAG, "Set parcel $localId for sale at price $price")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to set parcel for sale", e)
@@ -452,7 +470,8 @@ class ParcelManager(
         scope.launch {
             try {
                 // ParcelAccessListUpdate message
-                val payload = ByteBuffer.allocate(80).order(ByteOrder.LITTLE_ENDIAN)
+                val payload = ByteBuffer.allocate(93).order(ByteOrder.LITTLE_ENDIAN)
+                val transactionId = UUID.randomUUID()
                 
                 // AgentData with proper IDs
                 writeAgentData(payload)
@@ -460,8 +479,7 @@ class ParcelManager(
                 // Data block
                 payload.putInt(0)  // Flags - add to access
                 payload.putInt(localId)
-                payload.putInt(0)  // TransactionID (upper 32 bits)
-                payload.putInt(0)  // TransactionID (lower 32 bits)
+                writeUUID(payload, transactionId)
                 payload.putInt(1)  // SequenceID
                 payload.putInt(1)  // Sections
                 
@@ -485,7 +503,8 @@ class ParcelManager(
     fun removeFromAccessList(localId: Int, agentId: UUID) {
         scope.launch {
             try {
-                val payload = ByteBuffer.allocate(80).order(ByteOrder.LITTLE_ENDIAN)
+                val payload = ByteBuffer.allocate(93).order(ByteOrder.LITTLE_ENDIAN)
+                val transactionId = UUID.randomUUID()
                 
                 // AgentData with proper IDs
                 writeAgentData(payload)
@@ -493,8 +512,7 @@ class ParcelManager(
                 // Data block
                 payload.putInt(1)  // Flags - remove from access
                 payload.putInt(localId)
-                payload.putInt(0)
-                payload.putInt(0)
+                writeUUID(payload, transactionId)
                 payload.putInt(1)
                 payload.putInt(1)
                 
@@ -518,7 +536,8 @@ class ParcelManager(
     fun addToBanList(localId: Int, agentId: UUID) {
         scope.launch {
             try {
-                val payload = ByteBuffer.allocate(80).order(ByteOrder.LITTLE_ENDIAN)
+                val payload = ByteBuffer.allocate(93).order(ByteOrder.LITTLE_ENDIAN)
+                val transactionId = UUID.randomUUID()
                 
                 // AgentData with proper IDs
                 writeAgentData(payload)
@@ -526,8 +545,7 @@ class ParcelManager(
                 // Data block  
                 payload.putInt(2)  // Flags - ban list
                 payload.putInt(localId)
-                payload.putInt(0)
-                payload.putInt(0)
+                writeUUID(payload, transactionId)
                 payload.putInt(1)
                 payload.putInt(1)
                 
@@ -551,7 +569,8 @@ class ParcelManager(
     fun removeFromBanList(localId: Int, agentId: UUID) {
         scope.launch {
             try {
-                val payload = ByteBuffer.allocate(80).order(ByteOrder.LITTLE_ENDIAN)
+                val payload = ByteBuffer.allocate(93).order(ByteOrder.LITTLE_ENDIAN)
+                val transactionId = UUID.randomUUID()
                 
                 // AgentData with proper IDs
                 writeAgentData(payload)
@@ -559,8 +578,7 @@ class ParcelManager(
                 // Data block
                 payload.putInt(3)  // Flags - remove from ban
                 payload.putInt(localId)
-                payload.putInt(0)
-                payload.putInt(0)
+                writeUUID(payload, transactionId)
                 payload.putInt(1)
                 payload.putInt(1)
                 
@@ -581,15 +599,20 @@ class ParcelManager(
     /**
      * Send parcel properties update
      */
-    private suspend fun sendParcelPropertiesUpdate(localId: Int) {
+    private suspend fun sendParcelPropertiesUpdate(
+        localId: Int,
+        salePriceOverride: Int? = null,
+        parcelFlagsOverride: Long? = null
+    ) {
         val parcel = parcels[localId] ?: return
         
-        val nameBytes = parcel.name.toByteArray(Charsets.UTF_8)
-        val descBytes = parcel.description.toByteArray(Charsets.UTF_8)
-        val musicBytes = (parcel.musicUrl ?: "").toByteArray(Charsets.UTF_8)
-        val mediaBytes = (parcel.mediaUrl ?: "").toByteArray(Charsets.UTF_8)
-        
-        val payload = ByteBuffer.allocate(200 + nameBytes.size + descBytes.size + musicBytes.size + mediaBytes.size)
+        val nameSize = minOf(parcel.name.toByteArray(Charsets.UTF_8).size, 255)
+        val descSize = minOf(parcel.description.toByteArray(Charsets.UTF_8).size, 255)
+        val musicSize = minOf((parcel.musicUrl ?: "").toByteArray(Charsets.UTF_8).size, 255)
+        val mediaSize = minOf((parcel.mediaUrl ?: "").toByteArray(Charsets.UTF_8).size, 255)
+        val payloadSize = 126 + nameSize + descSize + musicSize + mediaSize
+
+        val payload = ByteBuffer.allocate(payloadSize)
             .order(ByteOrder.LITTLE_ENDIAN)
         
         // AgentData
@@ -597,25 +620,40 @@ class ParcelManager(
         
         // ParcelData
         payload.putInt(localId)
-        payload.putInt(parcel.flags.toInt())
-        payload.putInt(parcel.landingType)
+        payload.putInt(parcelFlagsOverride?.toInt() ?: parcel.flags.toInt()) // Flags
+        payload.putInt(parcel.flags.toInt()) // ParcelFlags
+        payload.putInt(salePriceOverride ?: parcel.claimPrice.coerceAtLeast(0)) // SalePrice
         
-        // Strings
-        payload.put(nameBytes.size.toByte())
-        payload.put(nameBytes)
-        payload.putShort(descBytes.size.toShort())
-        payload.put(descBytes)
-        payload.put(musicBytes.size.toByte())
-        payload.put(musicBytes)
-        payload.put(mediaBytes.size.toByte())
-        payload.put(mediaBytes)
-        
+        // Variable-length 1-byte strings
+        putVariable1String(payload, parcel.name)
+        putVariable1String(payload, parcel.description)
+        putVariable1String(payload, parcel.musicUrl)
+        putVariable1String(payload, parcel.mediaUrl)
+
         // Media info
-        repeat(16) { payload.put(0) }  // MediaID
+        writeUUID(payload, parcel.mediaId ?: UUID(0L, 0L))
         payload.put(if (parcel.mediaAutoScale) 1 else 0)
         
         // Group
-        repeat(16) { payload.put(0) }  // GroupID
+        writeUUID(payload, parcel.groupId ?: UUID(0L, 0L))
+
+        // Pass settings
+        payload.putInt(parcel.passPrice)
+        payload.putFloat(parcel.passHours)
+
+        // Category
+        payload.put(parcel.category.toByte())
+
+        // AuthBuyerID (none / any buyer), SnapshotID, landing vectors
+        writeUUID(payload, UUID(0L, 0L))
+        writeUUID(payload, parcel.snapshotId ?: UUID(0L, 0L))
+        payload.putFloat(parcel.userLocation.x)
+        payload.putFloat(parcel.userLocation.y)
+        payload.putFloat(parcel.userLocation.z)
+        payload.putFloat(parcel.userLookAt.x)
+        payload.putFloat(parcel.userLookAt.y)
+        payload.putFloat(parcel.userLookAt.z)
+        payload.put(parcel.landingType.toByte())
         
         udpConnection.sendPacket(MessageIds.PARCEL_PROPERTIES_UPDATE, payload.array(), reliable = true)
     }


### PR DESCRIPTION
### Motivation
- Fix parity gaps with the decompiled Lumiya viewer where outbound parcel/economy packets were using placeholder or mismatched field layouts causing simulator rejections or undefined behavior. 
- Ensure parcel buy, parcel properties updates and access-list operations send the fields and UUID packing Lumiya expects so server-side flows (buy, set-for-sale, access/ban lists) behave correctly.

### Description
- Reworked `ParcelManager` outbound `ParcelBuy` packet construction to match Lumiya ordering and sizes, including `AgentData`, `Data` (GroupID, IsGroupOwned, RemoveContribution, LocalID, Final) and `ParcelData` (Price, Area) and using cached `groupId` when `forGroup` is requested (see `ParcelManager.buyLand`).
- Replaced underspecified `setForSale` partial packet with an update path that updates local parcel flags and sends a full `ParcelPropertiesUpdate` payload via `sendParcelPropertiesUpdate`, exposing `salePriceOverride` and `parcelFlagsOverride` options.
- Implemented full `ParcelPropertiesUpdate` packing parity: `Flags`, `ParcelFlags`, `SalePrice`, variable-length 1-byte strings for name/desc/music/media (helper `putVariable1String`), `MediaID`, `MediaAutoScale`, `GroupID`, pass settings, category, `AuthBuyerID`, `SnapshotID`, `UserLocation`/`UserLookAt` floats and `LandingType`.
- Fixed `ParcelAccessListUpdate` family to use proper UUID `TransactionID` (instead of two placeholder ints) and corrected per-entry sizing/payload allocation for single-entry updates (`addToAccessList`, `removeFromAccessList`, `addToBanList`, `removeFromBanList`).

### Testing
- Attempted to run the unit test suite with `./gradlew testDebugUnitTest` but the build failed in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties sdk.dir`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e237dba31c8323a1ee775a39505f06)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes protocol compatibility issues in the `ParcelManager` by aligning outbound parcel packets (`ParcelBuy`, `ParcelPropertiesUpdate`, `ParcelAccessListUpdate`) with the Lumiya viewer's expected field layouts and data types. Key changes include: correcting the `ParcelBuy` packet structure to use proper GroupID handling and field ordering (67 bytes total), refactoring `setForSale` to use a full `ParcelPropertiesUpdate` with flag management instead of partial payloads, implementing complete `ParcelPropertiesUpdate` packing with variable-length strings and all required fields (media, group, landing vectors), and fixing `ParcelAccessListUpdate` operations to use proper UUID `TransactionID` instead of placeholder integers with corrected payload sizing (93 bytes). A new helper method `putVariable1String` was added to handle 1-byte length-prefixed UTF-8 strings capped at 255 bytes.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->