### PR TITLE
Harden LLSD binary parsing with explicit limits and safe reads

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/llsd/LLSDParser.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/llsd/LLSDParser.kt
@@ -2,6 +2,7 @@ package com.linkpoint.protocol.llsd
 
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.io.PushbackInputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.*
@@ -11,13 +12,33 @@ import java.util.*
  * See https://wiki.secondlife.com/wiki/LLSD for canonical formatting details.
  */
 object LLSDParser {
-    
+    private data class ParseLimits(
+        val maxStringBytes: Int = 1024 * 1024,
+        val maxBinaryBytes: Int = 1024 * 1024,
+        val maxArrayLength: Int = 10_000,
+        val maxMapEntries: Int = 10_000,
+        val maxNestingDepth: Int = 128,
+        val maxTotalBytes: Int = 4 * 1024 * 1024,
+    )
+
+    private data class ParseLimitsState(
+        var currentDepth: Int = 0,
+        var accumulatedBytes: Int = 0,
+        var collectionElementsRead: Int = 0,
+    )
+
+    private open class LLSDParseException(message: String) : RuntimeException(message)
+    private class TruncatedBinaryPayloadException(expectedBytes: Int) :
+        LLSDParseException("Truncated binary LLSD payload while reading $expectedBytes bytes.")
+    private class ParseLimitExceededException(message: String) : LLSDParseException(message)
+    private class MalformedBinaryDataException(message: String) : LLSDParseException(message)
+
     /**
      * Parse LLSD from bytes (auto-detect format)
      */
     fun parse(data: ByteArray): LLSDValue {
         if (data.isEmpty()) return LLSDUndefined
-        
+
         return when {
             data.size >= 2 && data[0] == '<'.code.toByte() -> parseXML(String(data))
             data.size >= 4 && String(data.sliceArray(0..3)) == "<?xm" -> parseXML(String(data))
@@ -38,112 +59,200 @@ object LLSDParser {
             LLSDContentTypeDetector.LLSDContentType.LLSD_XML -> parseXML(String(data, Charsets.UTF_8))
         }
     }
-    
+
     /**
      * Parse LLSD Binary format
      */
     fun parseBinary(data: ByteArray): LLSDValue {
-        val stream = ByteArrayInputStream(data)
-        return parseBinaryValue(stream)
+        val stream = PushbackInputStream(ByteArrayInputStream(data), 1)
+        val limits = ParseLimits()
+        val state = ParseLimitsState()
+
+        return try {
+            parseBinaryValue(stream, state, limits)
+        } catch (_: LLSDParseException) {
+            LLSDUndefined
+        } catch (_: IllegalArgumentException) {
+            LLSDUndefined
+        }
     }
-    
-    private fun parseBinaryValue(stream: InputStream): LLSDValue {
-        val marker = stream.read()
-        if (marker == -1) return LLSDUndefined
-        
-        return when (marker.toChar()) {
+
+    private fun parseBinaryValue(
+        stream: PushbackInputStream,
+        state: ParseLimitsState,
+        limits: ParseLimits,
+    ): LLSDValue {
+        if (state.currentDepth >= limits.maxNestingDepth) {
+            throw ParseLimitExceededException("Maximum nesting depth exceeded.")
+        }
+
+        state.currentDepth++
+        try {
+            val marker = readByte(stream, state, limits)
+            return parseByMarker(marker.toChar(), stream, state, limits)
+        } finally {
+            state.currentDepth--
+        }
+    }
+
+    private fun parseByMarker(
+        marker: Char,
+        stream: PushbackInputStream,
+        state: ParseLimitsState,
+        limits: ParseLimits,
+    ): LLSDValue {
+        return when (marker) {
             LLSDValue.MARKER_UNDEF -> LLSDUndefined
             LLSDValue.MARKER_TRUE -> LLSDBoolean(true)
             LLSDValue.MARKER_FALSE -> LLSDBoolean(false)
             LLSDValue.MARKER_INTEGER -> {
-                val bytes = ByteArray(4)
-                stream.read(bytes)
+                val bytes = readExact(stream, 4, state, limits)
                 LLSDInteger(ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).int)
             }
             LLSDValue.MARKER_REAL -> {
-                val bytes = ByteArray(8)
-                stream.read(bytes)
+                val bytes = readExact(stream, 8, state, limits)
                 LLSDReal(ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).double)
             }
             LLSDValue.MARKER_UUID -> {
-                val bytes = ByteArray(16)
-                stream.read(bytes)
+                val bytes = readExact(stream, 16, state, limits)
                 val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
                 LLSDUUID(UUID(buffer.long, buffer.long))
             }
             LLSDValue.MARKER_STRING, 's' -> {
-                val lenBytes = ByteArray(4)
-                stream.read(lenBytes)
-                val len = ByteBuffer.wrap(lenBytes).order(ByteOrder.BIG_ENDIAN).int
-                val bytes = ByteArray(len)
-                stream.read(bytes)
-                LLSDString(String(bytes, Charsets.UTF_8))
+                val len = readLength(stream, state, limits)
+                if (len > limits.maxStringBytes) {
+                    throw ParseLimitExceededException("String length exceeds maxStringBytes.")
+                }
+                LLSDString(String(readExact(stream, len, state, limits), Charsets.UTF_8))
             }
             LLSDValue.MARKER_BINARY, 'b' -> {
-                val lenBytes = ByteArray(4)
-                stream.read(lenBytes)
-                val len = ByteBuffer.wrap(lenBytes).order(ByteOrder.BIG_ENDIAN).int
-                val bytes = ByteArray(len)
-                stream.read(bytes)
-                LLSDBinary(bytes)
+                val len = readLength(stream, state, limits)
+                if (len > limits.maxBinaryBytes) {
+                    throw ParseLimitExceededException("Binary length exceeds maxBinaryBytes.")
+                }
+                LLSDBinary(readExact(stream, len, state, limits))
             }
             LLSDValue.MARKER_DATE -> {
-                val bytes = ByteArray(8)
-                stream.read(bytes)
+                val bytes = readExact(stream, 8, state, limits)
                 val seconds = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).double
                 LLSDDate((seconds * 1000).toLong())
             }
             LLSDValue.MARKER_URI, 'l' -> {
-                val lenBytes = ByteArray(4)
-                stream.read(lenBytes)
-                val len = ByteBuffer.wrap(lenBytes).order(ByteOrder.BIG_ENDIAN).int
-                val bytes = ByteArray(len)
-                stream.read(bytes)
-                LLSDURI(String(bytes, Charsets.UTF_8))
+                val len = readLength(stream, state, limits)
+                if (len > limits.maxStringBytes) {
+                    throw ParseLimitExceededException("URI length exceeds maxStringBytes.")
+                }
+                LLSDURI(String(readExact(stream, len, state, limits), Charsets.UTF_8))
             }
             LLSDValue.MARKER_MAP, '{' -> {
                 val map = LLSDMap()
+                var entries = 0
+
                 while (true) {
-                    val keyMarker = stream.read()
-                    if (keyMarker == -1 || keyMarker.toChar() == LLSDValue.MARKER_MAP_END) break
-                    
-                    if (keyMarker.toChar() == 'k') {
-                        val lenBytes = ByteArray(4)
-                        stream.read(lenBytes)
-                        val len = ByteBuffer.wrap(lenBytes).order(ByteOrder.BIG_ENDIAN).int
-                        val keyBytes = ByteArray(len)
-                        stream.read(keyBytes)
-                        val key = String(keyBytes, Charsets.UTF_8)
-                        val value = parseBinaryValue(stream)
-                        map[key] = value
+                    val keyMarker = readByte(stream, state, limits).toChar()
+                    if (keyMarker == LLSDValue.MARKER_MAP_END) break
+                    if (keyMarker != 'k') {
+                        throw MalformedBinaryDataException("Malformed map: expected key marker 'k'.")
                     }
+
+                    entries++
+                    state.collectionElementsRead++
+                    if (entries > limits.maxMapEntries) {
+                        throw ParseLimitExceededException("Map entry count exceeds maxMapEntries.")
+                    }
+
+                    val keyLength = readLength(stream, state, limits)
+                    if (keyLength > limits.maxStringBytes) {
+                        throw ParseLimitExceededException("Map key length exceeds maxStringBytes.")
+                    }
+                    val key = String(readExact(stream, keyLength, state, limits), Charsets.UTF_8)
+                    map[key] = parseBinaryValue(stream, state, limits)
                 }
+
                 map
             }
             LLSDValue.MARKER_ARRAY, '[' -> {
                 val array = LLSDArray()
+                var elements = 0
+
                 while (true) {
-                    val peek = stream.read()
-                    if (peek == -1 || peek.toChar() == LLSDValue.MARKER_ARRAY_END) break
-                    
-                    // We need to unread this byte - simulate by wrapping
-                    val wrappedStream = ByteArrayInputStream(byteArrayOf(peek.toByte()) + stream.readBytes())
-                    val value = parseBinaryValue(wrappedStream)
-                    array.add(value)
+                    val peek = readByte(stream, state, limits)
+                    if (peek.toChar() == LLSDValue.MARKER_ARRAY_END) break
+
+                    stream.unread(peek)
+                    state.accumulatedBytes--
+
+                    elements++
+                    state.collectionElementsRead++
+                    if (elements > limits.maxArrayLength) {
+                        throw ParseLimitExceededException("Array length exceeds maxArrayLength.")
+                    }
+
+                    array.add(parseBinaryValue(stream, state, limits))
                 }
+
                 array
             }
             else -> LLSDUndefined
         }
     }
-    
+
+    private fun readLength(
+        stream: PushbackInputStream,
+        state: ParseLimitsState,
+        limits: ParseLimits,
+    ): Int {
+        val lenBytes = readExact(stream, 4, state, limits)
+        val len = ByteBuffer.wrap(lenBytes).order(ByteOrder.BIG_ENDIAN).int
+        if (len < 0) {
+            throw MalformedBinaryDataException("Negative length in binary LLSD payload.")
+        }
+        return len
+    }
+
+    private fun readByte(stream: InputStream, state: ParseLimitsState, limits: ParseLimits): Int {
+        val value = stream.read()
+        if (value == -1) {
+            throw TruncatedBinaryPayloadException(1)
+        }
+        state.accumulatedBytes++
+        enforceTotalBytesLimit(state, limits)
+        return value
+    }
+
+    private fun readExact(
+        stream: InputStream,
+        size: Int,
+        state: ParseLimitsState,
+        limits: ParseLimits,
+    ): ByteArray {
+        val bytes = ByteArray(size)
+        var offset = 0
+        while (offset < size) {
+            val read = stream.read(bytes, offset, size - offset)
+            if (read == -1) {
+                throw TruncatedBinaryPayloadException(size)
+            }
+            offset += read
+            state.accumulatedBytes += read
+            enforceTotalBytesLimit(state, limits)
+        }
+        return bytes
+    }
+
+    private fun enforceTotalBytesLimit(state: ParseLimitsState, limits: ParseLimits) {
+        if (state.accumulatedBytes > limits.maxTotalBytes) {
+            throw ParseLimitExceededException("Total bytes exceed maxTotalBytes.")
+        }
+    }
+
     /**
      * Parse LLSD XML format
      */
     fun parseXML(xml: String): LLSDValue {
         // Simple XML parser for LLSD
         var cleaned = xml.trim()
-        
+
         // Strip XML declaration if present so we can parse the <llsd> root element
         if (cleaned.startsWith("<?xml", ignoreCase = true)) {
             val declEnd = cleaned.indexOf("?>")
@@ -152,39 +261,39 @@ object LLSDParser {
             }
             cleaned = cleaned.substring(declEnd + 2).trimStart()
         }
-        
+
         return try {
             parseXMLElement(cleaned, 0).first
         } catch (e: Exception) {
             LLSDUndefined
         }
     }
-    
+
     private fun parseXMLElement(xml: String, startPos: Int): Pair<LLSDValue, Int> {
         var pos = startPos
-        
+
         // Skip whitespace
         while (pos < xml.length && xml[pos].isWhitespace()) pos++
-        
+
         if (pos >= xml.length || xml[pos] != '<') {
             return LLSDUndefined to pos
         }
-        
+
         // Find tag name
         val tagStart = pos + 1
         var tagEnd = tagStart
         while (tagEnd < xml.length && xml[tagEnd] != '>' && xml[tagEnd] != ' ' && xml[tagEnd] != '/') {
             tagEnd++
         }
-        
+
         val tagName = xml.substring(tagStart, tagEnd).lowercase()
-        
+
         // Handle self-closing tags
         val closePos = xml.indexOf('>', pos)
         if (closePos == -1) return LLSDUndefined to xml.length
-        
+
         val isSelfClosing = xml[closePos - 1] == '/'
-        
+
         if (isSelfClosing) {
             return when (tagName) {
                 "undef" -> LLSDUndefined to closePos + 1
@@ -199,16 +308,16 @@ object LLSDParser {
                 else -> LLSDUndefined to closePos + 1
             }
         }
-        
+
         // Find content and closing tag
         val contentStart = closePos + 1
         val closingTag = "</$tagName>"
         val closingPos = xml.indexOf(closingTag, contentStart, ignoreCase = true)
         if (closingPos == -1) return LLSDUndefined to xml.length
-        
+
         val content = xml.substring(contentStart, closingPos).trim()
         val endPos = closingPos + closingTag.length
-        
+
         return when (tagName) {
             "llsd" -> parseXMLElement(content, 0).let { it.first to endPos }
             "undef" -> LLSDUndefined to endPos
@@ -236,14 +345,14 @@ object LLSDParser {
                     // Skip whitespace
                     while (mapPos < content.length && content[mapPos].isWhitespace()) mapPos++
                     if (mapPos >= content.length) break
-                    
+
                     // Find key
                     val keyStart = content.indexOf("<key>", mapPos, ignoreCase = true)
                     if (keyStart == -1) break
                     val keyEnd = content.indexOf("</key>", keyStart, ignoreCase = true)
                     if (keyEnd == -1) break
                     val key = content.substring(keyStart + 5, keyEnd)
-                    
+
                     // Find value
                     mapPos = keyEnd + 6
                     val (value, newPos) = parseXMLElement(content, mapPos)
@@ -260,7 +369,7 @@ object LLSDParser {
                     while (arrayPos < content.length && content[arrayPos].isWhitespace()) arrayPos++
                     if (arrayPos >= content.length) break
                     if (content[arrayPos] != '<') break
-                    
+
                     val (value, newPos) = parseXMLElement(content, arrayPos)
                     if (value != LLSDUndefined || content.substring(arrayPos).startsWith("<undef", ignoreCase = true)) {
                         array.add(value)
@@ -273,7 +382,7 @@ object LLSDParser {
             else -> LLSDUndefined to endPos
         }
     }
-    
+
     private fun unescapeXML(s: String): String {
         return s
             .replace("&lt;", "<")

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt
@@ -1,5 +1,7 @@
 package com.linkpoint.protocol.llsd
 
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -33,5 +35,103 @@ class LLSDParserTest {
         }.parse("2024-01-02T03:04:05Z")
 
         assertEquals(expected?.time, (value as LLSDDate).value.time)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for truncated integer payload`() {
+        val payload = byteArrayOf('i'.code.toByte(), 0x00, 0x00)
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for truncated string payload`() {
+        val payload = byteArrayOf(
+            's'.code.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x05,
+            'h'.code.toByte(),
+            'i'.code.toByte(),
+        )
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for truncated binary payload`() {
+        val payload = byteArrayOf(
+            'b'.code.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            0x01,
+        )
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for oversized string field`() {
+        val length = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(1024 * 1024 + 1).array()
+        val payload = byteArrayOf('s'.code.toByte()) + length
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for oversized binary field`() {
+        val length = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(1024 * 1024 + 1).array()
+        val payload = byteArrayOf('b'.code.toByte()) + length
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for excessive nesting`() {
+        val payload = ByteArray(130) { '['.code.toByte() } + ByteArray(130) { ']'.code.toByte() }
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for malformed map termination`() {
+        val payload = byteArrayOf(
+            '{'.code.toByte(),
+            'k'.code.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            'a'.code.toByte(),
+            '1'.code.toByte(),
+        )
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for malformed array termination`() {
+        val payload = byteArrayOf('['.code.toByte(), '1'.code.toByte())
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent unbounded/unsafe binary parsing (truncated reads, huge allocations, excessive nesting) that can lead to OOM or uncaught exceptions. 
- Provide predictable failure behavior by returning `LLSDUndefined` for invalid or malicious input instead of crashing. 
- Avoid full-stream duplication during array lookahead to reduce memory pressure.

### Description
- Introduce `ParseLimits` and `ParseLimitsState` and enforce limits for `maxStringBytes`, `maxBinaryBytes`, `maxArrayLength`, `maxMapEntries`, `maxNestingDepth`, and `maxTotalBytes`.
- Add focused exceptions (`LLSDParseException`, `TruncatedBinaryPayloadException`, `ParseLimitExceededException`, `MalformedBinaryDataException`) and catch them at top-level so invalid payloads produce `LLSDUndefined`.
- Replace direct `stream.read(...)` calls with `readByte`, `readExact`, and `readLength` helpers that ensure exact-length reads or throw a truncation error while tracking accumulated bytes.
- Replace stream-wrapping array lookahead with a `PushbackInputStream` and `unread` to avoid concatenating the remainder of the stream into memory, and enforce element and key-count/length limits and map formatting checks.
- Add unit tests in `src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt` covering truncated integer/string/binary payloads, oversized string/binary fields, excessive nesting, and malformed map/array termination.

### Testing
- Added tests in `src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt` exercising truncation, oversize limits, excessive nesting, and malformed collections.
- Attempted to run `./gradlew test --tests com.linkpoint.protocol.llsd.LLSDParserTest`, but the build in this environment failed during configuration due to a missing Android SDK (`ANDROID_HOME` / `local.properties sdk.dir`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea74a9920883239e35ca00757fc20e)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the LLSD binary parser against malicious or malformed input by introducing explicit parsing limits and safe read operations. It adds a `ParseLimits` configuration to enforce constraints on string/binary sizes, array/map lengths, nesting depth, and total bytes consumed. The parser now uses safe read helpers (`readByte`, `readExact`, `readLength`) that guarantee exact-length reads or throw custom exceptions, replacing the previous unbounded stream operations. Array lookahead is reimplemented using `PushbackInputStream` to avoid duplicating the entire stream in memory. Custom exceptions (`TruncatedBinaryPayloadException`, `ParseLimitExceededException`, `MalformedBinaryDataException`) are caught at the top level to return `LLSDUndefined` instead of crashing on invalid input. Comprehensive unit tests validate the hardening against truncated payloads, oversized fields, excessive nesting, and malformed collections.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/llsd/LLSDParser.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced robustness of binary data parsing with stricter input validation and improved error handling for malformed or truncated data.
  * Added configurable limits on nesting depth, string/binary sizes, and accumulated bytes to prevent resource exhaustion.

* **Tests**
  * Added comprehensive test coverage for malformed input scenarios including truncated payloads, oversized fields, excessive nesting, and invalid terminators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->