### PR TITLE
Add task-context notecard save support with capability routing and tests

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/inventory/notecard/NotecardManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/notecard/NotecardManager.kt
@@ -39,7 +39,10 @@ import java.util.concurrent.ConcurrentHashMap
 class NotecardManager(
     private val transferManager: TransferManager,
     private val capabilityManager: CapabilityManager,
-    private val httpClient: OkHttpClient = OkHttpClient()
+    private val httpClient: OkHttpClient = OkHttpClient(),
+    private val capabilityRequest: suspend (String, LLSDMap) -> com.linkpoint.protocol.llsd.LLSDValue? = { capName, body ->
+        capabilityManager.request(capName, body)
+    }
 ) {
     companion object {
         private const val TAG = "NotecardManager"
@@ -416,20 +419,32 @@ class NotecardManager(
      * Note: Full implementation requires UpdateNotecardAgentInventory capability.
      */
     suspend fun saveNotecard(itemId: UUID, newText: String): Boolean {
+        return saveNotecard(itemId, newText, taskId = null, objectId = null)
+    }
+
+    /**
+     * Save a notecard (update text content), supporting both agent and task inventory uploads.
+     */
+    suspend fun saveNotecard(itemId: UUID, newText: String, taskId: UUID?, objectId: UUID?): Boolean {
         return withContext(Dispatchers.IO) {
             try {
                 val notecardData = createNotecardData(newText)
+                val isTaskInventory = (taskId != null || objectId != null)
+                val capability = if (isTaskInventory) {
+                    CapabilityManager.CAP_UPDATE_NOTECARD_TASK
+                } else {
+                    CapabilityManager.CAP_UPDATE_NOTECARD_AGENT
+                }
                 val request = LLSDMap().apply {
                     this["item_id"] = LLSDUUID(itemId)
+                    taskId?.let { this["task_id"] = LLSDUUID(it) }
+                    objectId?.let { this["object_id"] = LLSDUUID(it) }
                 }
 
-                val capResponse = capabilityManager.request(
-                    CapabilityManager.CAP_UPDATE_NOTECARD_AGENT,
-                    request
-                ) as? LLSDMap
+                val capResponse = capabilityRequest(capability, request) as? LLSDMap
 
                 if (capResponse == null) {
-                    Log.w(TAG, "Notecard save failed: UpdateNotecardAgentInventory returned no payload")
+                    Log.w(TAG, "Notecard save failed: $capability returned no payload")
                     return@withContext false
                 }
 
@@ -475,7 +490,7 @@ class NotecardManager(
                     }
                 }
 
-                Log.i(TAG, "Notecard $itemId saved successfully (${newText.length} chars)")
+                Log.i(TAG, "Notecard $itemId saved successfully (${newText.length} chars, taskInventory=$isTaskInventory)")
                 true
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save notecard $itemId", e)

--- a/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryActivity.kt
@@ -138,6 +138,8 @@ class InventoryActivity : AppCompatActivity() {
             putExtra(NotecardEditorActivity.EXTRA_ITEM_ID, item.id.toString())
             putExtra(NotecardEditorActivity.EXTRA_NOTECARD_NAME, item.name)
             item.assetId?.let { putExtra(NotecardEditorActivity.EXTRA_ASSET_ID, it.toString()) }
+            item.taskId?.let { putExtra(NotecardEditorActivity.EXTRA_TASK_ID, it.toString()) }
+            item.objectId?.let { putExtra(NotecardEditorActivity.EXTRA_OBJECT_ID, it.toString()) }
 
             // Allow editing by default for now
             putExtra(NotecardEditorActivity.EXTRA_READ_ONLY, false)
@@ -229,6 +231,8 @@ data class ActivityInventoryItem(
     val parentId: UUID?,
     val type: InventoryType,
     val assetId: UUID? = null,
+    val taskId: UUID? = null,
+    val objectId: UUID? = null,
     val creatorId: UUID? = null,
     val permissions: Int = 0
 ) {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/notecard/NotecardEditorActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/notecard/NotecardEditorActivity.kt
@@ -31,6 +31,8 @@ class NotecardEditorActivity : ComponentActivity() {
     companion object {
         const val EXTRA_ASSET_ID = "asset_id"
         const val EXTRA_ITEM_ID = "item_id"
+        const val EXTRA_TASK_ID = "task_id"
+        const val EXTRA_OBJECT_ID = "object_id"
         const val EXTRA_NOTECARD_NAME = "notecard_name"
         const val EXTRA_READ_ONLY = "read_only"
     }
@@ -40,6 +42,8 @@ class NotecardEditorActivity : ComponentActivity() {
         
         val assetId = intent.getStringExtra(EXTRA_ASSET_ID)?.let { UUID.fromString(it) }
         val itemId = intent.getStringExtra(EXTRA_ITEM_ID)?.let { UUID.fromString(it) }
+        val taskId = intent.getStringExtra(EXTRA_TASK_ID)?.let { UUID.fromString(it) }
+        val objectId = intent.getStringExtra(EXTRA_OBJECT_ID)?.let { UUID.fromString(it) }
         val notecardName = intent.getStringExtra(EXTRA_NOTECARD_NAME) ?: "Notecard"
         val isReadOnly = intent.getBooleanExtra(EXTRA_READ_ONLY, true)
         
@@ -60,7 +64,7 @@ class NotecardEditorActivity : ComponentActivity() {
                             app.notecardManager.fetchNotecard(assetUuid)
                         },
                         onSaveNotecard = { itmId, newText ->
-                            app.notecardManager.saveNotecard(itmId, newText)
+                            app.notecardManager.saveNotecard(itmId, newText, taskId = taskId, objectId = objectId)
                         },
                         onNavigateBack = { finish() }
                     )

--- a/Linkpoint/src/test/kotlin/com/linkpoint/inventory/notecard/NotecardManagerSaveTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/inventory/notecard/NotecardManagerSaveTest.kt
@@ -1,0 +1,121 @@
+package com.linkpoint.inventory.notecard
+
+import com.linkpoint.protocol.capabilities.CapabilityManager
+import com.linkpoint.protocol.llsd.LLSDMap
+import com.linkpoint.protocol.llsd.LLSDString
+import com.linkpoint.protocol.llsd.LLSDUUID
+import com.linkpoint.protocol.llsd.LLSDXmlUtils
+import com.linkpoint.protocol.messages.UDPConnectionFixed
+import com.linkpoint.protocol.transfer.TransferManager
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetSocketAddress
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+class NotecardManagerSaveTest {
+
+    @Test
+    fun `saveNotecard uses agent capability and succeeds`() = runTest {
+        val requestInfo = AtomicReference<Pair<String, LLSDMap>>()
+
+        withTestServer(responseXml = llsdState("complete")) { serverUrl ->
+            val manager = buildManager { capName, body ->
+                requestInfo.set(capName to body)
+                LLSDMap(mutableMapOf("uploader" to LLSDString(serverUrl)))
+            }
+
+            val success = manager.saveNotecard(UUID.randomUUID(), "hello agent")
+            assertTrue(success)
+        }
+
+        val (capName, body) = requestInfo.get()
+        assertEquals(CapabilityManager.CAP_UPDATE_NOTECARD_AGENT, capName)
+        assertTrue(body["item_id"] is LLSDUUID)
+        assertEquals(null, body["task_id"])
+        assertEquals(null, body["object_id"])
+    }
+
+    @Test
+    fun `saveNotecard uses task capability and includes task and object identifiers`() = runTest {
+        val requestInfo = AtomicReference<Pair<String, LLSDMap>>()
+        val taskId = UUID.randomUUID()
+        val objectId = UUID.randomUUID()
+
+        withTestServer(responseXml = llsdState("complete")) { serverUrl ->
+            val manager = buildManager { capName, body ->
+                requestInfo.set(capName to body)
+                LLSDMap(mutableMapOf("uploader" to LLSDString(serverUrl)))
+            }
+
+            val success = manager.saveNotecard(
+                itemId = UUID.randomUUID(),
+                newText = "hello task",
+                taskId = taskId,
+                objectId = objectId
+            )
+            assertTrue(success)
+        }
+
+        val (capName, body) = requestInfo.get()
+        assertEquals(CapabilityManager.CAP_UPDATE_NOTECARD_TASK, capName)
+        assertEquals(taskId, (body["task_id"] as LLSDUUID).value)
+        assertEquals(objectId, (body["object_id"] as LLSDUUID).value)
+    }
+
+    @Test
+    fun `saveNotecard fails when capability response omits uploader`() = runTest {
+        val manager = buildManager { _, _ -> LLSDMap() }
+        val success = manager.saveNotecard(UUID.randomUUID(), "no uploader")
+        assertFalse(success)
+    }
+
+    @Test
+    fun `saveNotecard fails when uploader response state is not complete`() = runTest {
+        withTestServer(responseXml = llsdState("queued")) { serverUrl ->
+            val manager = buildManager { _, _ ->
+                LLSDMap(mutableMapOf("uploader" to LLSDString(serverUrl)))
+            }
+
+            val success = manager.saveNotecard(UUID.randomUUID(), "queued state")
+            assertFalse(success)
+        }
+    }
+
+    private fun buildManager(
+        capRequest: suspend (String, LLSDMap) -> com.linkpoint.protocol.llsd.LLSDValue?
+    ): NotecardManager {
+        val transferManager = TransferManager(UDPConnectionFixed(), UUID(0, 0), UUID(0, 0))
+        return NotecardManager(
+            transferManager = transferManager,
+            capabilityManager = CapabilityManager(),
+            httpClient = OkHttpClient(),
+            capabilityRequest = capRequest
+        )
+    }
+
+    private fun llsdState(state: String): String {
+        return LLSDXmlUtils.wrap(LLSDMap(mutableMapOf("state" to LLSDString(state))))
+    }
+
+    private fun withTestServer(responseXml: String, block: (String) -> Unit) {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/") { exchange ->
+            val bytes = responseXml.toByteArray(Charsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/llsd+xml")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            block("http://127.0.0.1:${server.address.port}/")
+        } finally {
+            server.stop(0)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Close the gap for saving notecards stored in object (task) inventory by adding a task-aware save path and LLSD fields expected by the simulator. 
- Ensure the uploader-based POST flow remains unchanged while validating both agent and task uploader responses consistently.

### Description
- Added an overload `saveNotecard(itemId, newText, taskId: UUID?, objectId: UUID?)` and kept the existing two-argument API delegating to it for backward compatibility. 
- Selects capability based on context: uses `CapabilityManager.CAP_UPDATE_NOTECARD_TASK` when `taskId`/`objectId` are present, otherwise `CapabilityManager.CAP_UPDATE_NOTECARD_AGENT`. 
- Includes `task_id` and `object_id` in the LLSD request payload when provided and preserves the existing uploader POST flow while requiring uploader response `state == "complete"`. 
- Added a constructor-injectable `capabilityRequest` hook (defaulting to `CapabilityManager.request`) to enable deterministic unit testing, and updated UI call sites to propagate optional `taskId`/`objectId` via intent extras. 
- Added unit tests in `Linkpoint/src/test/kotlin/com/linkpoint/inventory/notecard/NotecardManagerSaveTest.kt` covering agent path, task path (with identifiers), missing uploader, and non-`complete` uploader responses.

### Testing
- Added tests: `saveNotecard uses agent capability and succeeds`, `saveNotecard uses task capability and includes task and object identifiers`, `saveNotecard fails when capability response omits uploader`, and `saveNotecard fails when uploader response state is not complete` (found at `Linkpoint/src/test/kotlin/.../NotecardManagerSaveTest.kt`).
- Attempted to run the unit tests with `./gradlew :Linkpoint:testDebugUnitTest --tests com.linkpoint.inventory.notecard.NotecardManagerSaveTest`, but the invocation failed in this environment with a Gradle/JDK compatibility error: `Unsupported class file major version 69` (test execution did not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea74b44a6c8323ab5409214074b2df)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extends notecard save functionality to support task (object) inventory in addition to agent inventory. The implementation adds an overloaded `saveNotecard` method that accepts optional `taskId` and `objectId` parameters, automatically routing to the appropriate capability (`CAP_UPDATE_NOTECARD_TASK` vs `CAP_UPDATE_NOTECARD_AGENT`) and including the required LLSD fields. The existing two-argument API is preserved for backward compatibility. UI components (`InventoryActivity` and `NotecardEditorActivity`) are updated to propagate these optional identifiers through intent extras. Comprehensive unit tests validate both the agent and task save paths, missing uploader scenarios, and non-complete uploader responses.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/inventory/notecard/NotecardManagerSaveTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/inventory/notecard/NotecardManager.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryActivity.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/notecard/NotecardEditorActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->