### PR TITLE
Implement Lumiya HUD pass 10 with orthographic isolation and deterministic ordering

### DIFF
--- a/Linkpoint/FILAMENT.md
+++ b/Linkpoint/FILAMENT.md
@@ -225,6 +225,18 @@ All 12 components implemented:
 - `FILAMENT_NEXT_STEPS.md` - Future enhancements
 - Root `FILAMENT_*.md` files - Additional guides
 
+## Lumiya HUD pass lifecycle (Phase 4 alignment)
+
+The GL-based Lumiya renderer now executes HUD rendering as an explicit pass 10 stage:
+
+1. World passes (opaque/avatar/sky/transparent/water/particles) run only when world rendering is enabled.
+2. HUD attachments are routed into a dedicated HUD draw list whenever the attachment point is `ATTACHMENT_HUD_*`.
+3. Pass 10 switches to an orthographic camera matrix rebuilt from current surface width/height.
+4. HUD pass disables depth testing and depth writes, isolating HUD visuals from world geometry depth state.
+5. HUD overlap ordering is deterministic: `layer` → `attachmentPoint` → `entityId`.
+6. Surface resize/orientation changes trigger HUD projection rebuilds so anchors remain consistent.
+7. Deterministic frame-planner tests validate that HUD still renders when world pass execution is disabled.
+
 ## 🎓 Learning Resources
 
 - [Filament Docs](https://google.github.io/filament/)

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt
@@ -1,0 +1,33 @@
+package com.linkpoint.render.lumiya.core
+
+enum class LumiyaRenderPass {
+    WORLD_OPAQUE,
+    WORLD_AVATAR,
+    WORLD_SKY,
+    WORLD_TRANSPARENT,
+    WORLD_WATER,
+    WORLD_PARTICLES,
+    HUD
+}
+
+object LumiyaFramePlanner {
+
+    fun createPlan(
+        worldPassEnabled: Boolean,
+        hasHudElements: Boolean
+    ): List<LumiyaRenderPass> {
+        val passes = mutableListOf<LumiyaRenderPass>()
+        if (worldPassEnabled) {
+            passes += LumiyaRenderPass.WORLD_OPAQUE
+            passes += LumiyaRenderPass.WORLD_AVATAR
+            passes += LumiyaRenderPass.WORLD_SKY
+            passes += LumiyaRenderPass.WORLD_TRANSPARENT
+            passes += LumiyaRenderPass.WORLD_WATER
+            passes += LumiyaRenderPass.WORLD_PARTICLES
+        }
+        if (hasHudElements) {
+            passes += LumiyaRenderPass.HUD
+        }
+        return passes
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
@@ -5,6 +5,7 @@ import android.opengl.GLES32
 import android.opengl.Matrix
 import android.util.Log
 import android.view.Surface
+import com.linkpoint.avatar.AttachmentPoints
 import com.linkpoint.render.lumiya.drawable.*
 
 /**
@@ -47,12 +48,16 @@ class LumiyaRenderer : RenderEngineProvider {
     private var waterDrawable: DrawableWater? = null
     private var skyDrawable: DrawableSky? = null
     private var primStore = DrawablePrimStore()
+    private var hudStore = DrawableHudStore()
     private var avatarStore = DrawableAvatarStore()
     private var particleManager: DrawableParticleManager? = null
 
     // Full-screen quad VAO for FXAA resolve
     private var quadVAO = 0
     private var quadVBO = 0
+    private val hudViewMatrix = FloatArray(16)
+    private val hudProjectionMatrix = FloatArray(16)
+    private var worldPassEnabled = true
 
     // =====================================================================
     // Lifecycle
@@ -102,6 +107,7 @@ class LumiyaRenderer : RenderEngineProvider {
             particleManager = DrawableParticleManager(ctx)
 
             ctx.updateCamera()
+            rebuildHudMatrices(width, height)
 
             isInitialized = true
             Log.i(TAG, "Lumiya renderer initialised  (GPU: ${ctx.gpuRenderer})")
@@ -118,6 +124,7 @@ class LumiyaRenderer : RenderEngineProvider {
         ctx.aspectRatio = width.toFloat() / height.toFloat()
         GLES32.glViewport(0, 0, width, height)
         if (ctx.fxaaEnabled) ctx.createFXAAFramebuffer(width, height)
+        rebuildHudMatrices(width, height)
     }
 
     override fun onSurfaceDestroyed() {
@@ -146,36 +153,36 @@ class LumiyaRenderer : RenderEngineProvider {
         // ── 3. Clear ─────────────────────────────────────────────────────
         GLES32.glClear(GLES32.GL_COLOR_BUFFER_BIT or GLES32.GL_DEPTH_BUFFER_BIT or GLES32.GL_STENCIL_BUFFER_BIT)
 
-        // ── 4. Opaque pass ───────────────────────────────────────────────
-        GLES32.glDepthMask(true)
-        GLES32.glDisable(GLES32.GL_BLEND)
-
-        terrainDrawable?.draw(ctx)
-
-        primStore.drawOpaque(ctx)
-
-        // ── 5. Avatar pass ───────────────────────────────────────────────
-        avatarStore.draw(ctx)
-
-        // ── 6. Sky pass (render behind everything) ───────────────────────
-        GLES32.glDepthFunc(GLES32.GL_LEQUAL)
-        GLES32.glDepthMask(false)
-        skyDrawable?.draw(ctx)
-        GLES32.glDepthMask(true)
-        GLES32.glDepthFunc(GLES32.GL_LEQUAL)
-
-        // ── 7. Transparent pass ──────────────────────────────────────────
-        GLES32.glEnable(GLES32.GL_BLEND)
-        GLES32.glBlendFunc(GLES32.GL_SRC_ALPHA, GLES32.GL_ONE_MINUS_SRC_ALPHA)
-        primStore.drawTransparent(ctx)
-
-        // ── 8. Water pass ────────────────────────────────────────────────
-        waterDrawable?.draw(ctx)
-
-        // ── 9. Particle pass ─────────────────────────────────────────────
-        particleManager?.draw(ctx)
-
-        // ── 10. HUD pass (not implemented yet) ───────────────────────────
+        val framePlan = LumiyaFramePlanner.createPlan(
+            worldPassEnabled = worldPassEnabled,
+            hasHudElements = hudStore.hasElements()
+        )
+        framePlan.forEach { pass ->
+            when (pass) {
+                LumiyaRenderPass.WORLD_OPAQUE -> {
+                    GLES32.glDepthMask(true)
+                    GLES32.glDisable(GLES32.GL_BLEND)
+                    terrainDrawable?.draw(ctx)
+                    primStore.drawOpaque(ctx)
+                }
+                LumiyaRenderPass.WORLD_AVATAR -> avatarStore.draw(ctx)
+                LumiyaRenderPass.WORLD_SKY -> {
+                    GLES32.glDepthFunc(GLES32.GL_LEQUAL)
+                    GLES32.glDepthMask(false)
+                    skyDrawable?.draw(ctx)
+                    GLES32.glDepthMask(true)
+                    GLES32.glDepthFunc(GLES32.GL_LEQUAL)
+                }
+                LumiyaRenderPass.WORLD_TRANSPARENT -> {
+                    GLES32.glEnable(GLES32.GL_BLEND)
+                    GLES32.glBlendFunc(GLES32.GL_SRC_ALPHA, GLES32.GL_ONE_MINUS_SRC_ALPHA)
+                    primStore.drawTransparent(ctx)
+                }
+                LumiyaRenderPass.WORLD_WATER -> waterDrawable?.draw(ctx)
+                LumiyaRenderPass.WORLD_PARTICLES -> particleManager?.draw(ctx)
+                LumiyaRenderPass.HUD -> renderHudPass()
+            }
+        }
 
         // ── 11. FXAA resolve ─────────────────────────────────────────────
         if (ctx.fxaaEnabled && ctx.fxaaFramebuffer != 0) {
@@ -222,6 +229,7 @@ class LumiyaRenderer : RenderEngineProvider {
 
     override fun removeObject(id: Long) {
         primStore.removePrim(id)
+        hudStore.removeHudPrim(id)
     }
 
     override fun updateTerrain(heightmap: FloatArray, width: Int, depth: Int) {
@@ -230,6 +238,7 @@ class LumiyaRenderer : RenderEngineProvider {
 
     override fun clearScene() {
         primStore.clear()
+        hudStore.clear()
         avatarStore.clear()
         terrainDrawable?.clear()
     }
@@ -246,6 +255,7 @@ class LumiyaRenderer : RenderEngineProvider {
         skyDrawable?.destroy()
         particleManager?.destroy()
         primStore.destroy()
+        hudStore.destroy()
         avatarStore.destroy()
         destroyFullScreenQuad()
         ctx.shutdown()
@@ -306,5 +316,68 @@ class LumiyaRenderer : RenderEngineProvider {
     private fun destroyFullScreenQuad() {
         if (quadVAO != 0) { GLES32.glDeleteVertexArrays(1, intArrayOf(quadVAO), 0); quadVAO = 0 }
         if (quadVBO != 0) { GLES32.glDeleteBuffers(1, intArrayOf(quadVBO), 0); quadVBO = 0 }
+    }
+
+    fun addAttachmentObject(
+        id: Long,
+        attachmentPoint: Int,
+        posX: Float,
+        posY: Float,
+        posZ: Float,
+        layer: Int = 0
+    ) {
+        if (AttachmentPoints.isHudPoint(attachmentPoint)) {
+            hudStore.addHudPrim(
+                id = id,
+                attachmentPoint = attachmentPoint,
+                posX = posX,
+                posY = posY,
+                posZ = posZ,
+                layer = layer
+            )
+        } else {
+            primStore.addPrim(id, posX, posY, posZ)
+        }
+    }
+
+    fun setWorldPassEnabled(enabled: Boolean) {
+        worldPassEnabled = enabled
+    }
+
+    private fun renderHudPass() {
+        val previousProjection = ctx.projectionMatrix.clone()
+        val previousView = ctx.viewMatrix.clone()
+        try {
+            System.arraycopy(hudProjectionMatrix, 0, ctx.projectionMatrix, 0, 16)
+            System.arraycopy(hudViewMatrix, 0, ctx.viewMatrix, 0, 16)
+            ctx.uploadGlobalUBO()
+
+            // Isolate HUD depth behavior from world geometry.
+            GLES32.glDisable(GLES32.GL_DEPTH_TEST)
+            GLES32.glDepthMask(false)
+            GLES32.glEnable(GLES32.GL_BLEND)
+            GLES32.glBlendFunc(GLES32.GL_SRC_ALPHA, GLES32.GL_ONE_MINUS_SRC_ALPHA)
+            hudStore.draw(ctx)
+        } finally {
+            System.arraycopy(previousProjection, 0, ctx.projectionMatrix, 0, 16)
+            System.arraycopy(previousView, 0, ctx.viewMatrix, 0, 16)
+            ctx.uploadGlobalUBO()
+            GLES32.glDepthMask(true)
+            GLES32.glEnable(GLES32.GL_DEPTH_TEST)
+        }
+    }
+
+    private fun rebuildHudMatrices(width: Int, height: Int) {
+        Matrix.setIdentityM(hudViewMatrix, 0)
+        Matrix.orthoM(
+            hudProjectionMatrix,
+            0,
+            0f,
+            width.toFloat(),
+            height.toFloat(),
+            0f,
+            -1f,
+            1f
+        )
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudMeshCache.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudMeshCache.kt
@@ -1,0 +1,40 @@
+package com.linkpoint.render.lumiya.drawable
+
+import com.linkpoint.render.lumiya.core.LumiyaRenderContext
+import com.linkpoint.render.lumiya.glres.GLBufferManager
+
+internal object DrawableHudMeshCache {
+    private var bufferManager: GLBufferManager? = null
+    private var box: GLBufferManager.MeshVAO? = null
+
+    fun boxVao(ctx: LumiyaRenderContext): GLBufferManager.MeshVAO? {
+        if (box != null) return box
+        val bm = GLBufferManager(ctx.resourceManager)
+        bufferManager = bm
+        box = buildBox(bm)
+        return box
+    }
+
+    private fun buildBox(bm: GLBufferManager): GLBufferManager.MeshVAO {
+        val h = 0.5f
+        val v = floatArrayOf(
+            -h,-h, h,  0f,0f,1f,  0f,0f,   h,-h, h,  0f,0f,1f,  1f,0f,
+            h, h, h,  0f,0f,1f,  1f,1f,  -h, h, h,  0f,0f,1f,  0f,1f,
+            h,-h,-h,  0f,0f,-1f, 0f,0f,  -h,-h,-h,  0f,0f,-1f, 1f,0f,
+            -h, h,-h,  0f,0f,-1f, 1f,1f,   h, h,-h,  0f,0f,-1f, 0f,1f,
+            -h, h, h,  0f,1f,0f,  0f,0f,   h, h, h,  0f,1f,0f,  1f,0f,
+            h, h,-h,  0f,1f,0f,  1f,1f,  -h, h,-h,  0f,1f,0f,  0f,1f,
+            -h,-h,-h,  0f,-1f,0f, 0f,0f,   h,-h,-h,  0f,-1f,0f, 1f,0f,
+            h,-h, h,  0f,-1f,0f, 1f,1f,  -h,-h, h,  0f,-1f,0f, 0f,1f,
+            h,-h, h,  1f,0f,0f,  0f,0f,   h,-h,-h,  1f,0f,0f,  1f,0f,
+            h, h,-h,  1f,0f,0f,  1f,1f,   h, h, h,  1f,0f,0f,  0f,1f,
+            -h,-h,-h, -1f,0f,0f,  0f,0f,  -h,-h, h, -1f,0f,0f,  1f,0f,
+            -h, h, h, -1f,0f,0f,  1f,1f,  -h, h,-h, -1f,0f,0f,  0f,1f
+        )
+        val idx = shortArrayOf(
+            0,1,2, 0,2,3,   4,5,6, 4,6,7,   8,9,10, 8,10,11,
+            12,13,14, 12,14,15, 16,17,18, 16,18,19, 20,21,22, 20,22,23
+        )
+        return bm.buildVAO(v, idx, listOf(0 to 3, 1 to 3, 2 to 2))
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt
@@ -1,0 +1,81 @@
+package com.linkpoint.render.lumiya.drawable
+
+import android.opengl.GLES32
+import android.opengl.Matrix
+import com.linkpoint.render.lumiya.core.LumiyaRenderContext
+
+/**
+ * Dedicated draw list for HUD attachments.
+ *
+ * HUD entities are sorted deterministically by layer, attachment point and id.
+ */
+class DrawableHudStore {
+
+    data class HudPrimInstance(
+        val id: Long,
+        val attachmentPoint: Int,
+        var layer: Int,
+        val modelMatrix: FloatArray = FloatArray(16).also { Matrix.setIdentityM(it, 0) },
+        val texMatrix: FloatArray = FloatArray(16).also { Matrix.setIdentityM(it, 0) },
+        var colorR: Float = 1f, var colorG: Float = 1f, var colorB: Float = 1f, var colorA: Float = 1f,
+        var textureHandle: Int = 0
+    )
+
+    private val hudPrims = linkedMapOf<Long, HudPrimInstance>()
+
+    fun addHudPrim(
+        id: Long,
+        attachmentPoint: Int,
+        posX: Float,
+        posY: Float,
+        posZ: Float,
+        layer: Int
+    ) {
+        val instance = HudPrimInstance(id = id, attachmentPoint = attachmentPoint, layer = layer)
+        Matrix.translateM(instance.modelMatrix, 0, posX, posY, posZ)
+        hudPrims[id] = instance
+    }
+
+    fun removeHudPrim(id: Long) {
+        hudPrims.remove(id)
+    }
+
+    fun hasElements(): Boolean = hudPrims.isNotEmpty()
+
+    fun clear() = hudPrims.clear()
+
+    fun destroy() = hudPrims.clear()
+
+    internal fun debugSortedIds(): List<Long> = sortedHudPrims().map { it.id }
+
+    fun draw(ctx: LumiyaRenderContext) {
+        val program = ctx.primProgram ?: return
+        val boxVao = DrawableHudMeshCache.boxVao(ctx) ?: return
+
+        program.use()
+        program.setLighting(0f, 0f, 1f, 1f, 1f, 1f, 1f, 1f, 1f)
+
+        GLES32.glBindVertexArray(boxVao.vao)
+        sortedHudPrims().forEach { hud ->
+            program.setModelMatrix(hud.modelMatrix)
+            program.setTexMatrix(hud.texMatrix)
+            program.setColor(hud.colorR, hud.colorG, hud.colorB, hud.colorA)
+            program.setUseTexture(hud.textureHandle != 0)
+            if (hud.textureHandle != 0) {
+                GLES32.glActiveTexture(GLES32.GL_TEXTURE0)
+                GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, hud.textureHandle)
+                program.setTextureSampler(0)
+            }
+            GLES32.glDrawElements(GLES32.GL_TRIANGLES, boxVao.indexCount, GLES32.GL_UNSIGNED_SHORT, 0)
+        }
+        GLES32.glBindVertexArray(0)
+    }
+
+    private fun sortedHudPrims(): List<HudPrimInstance> {
+        return hudPrims.values.sortedWith(
+            compareBy<HudPrimInstance> { it.layer }
+                .thenBy { it.attachmentPoint }
+                .thenBy { it.id }
+        )
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt
@@ -1,0 +1,29 @@
+package com.linkpoint.render.lumiya.core
+
+import com.linkpoint.render.lumiya.drawable.DrawableHudStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LumiyaFramePlannerTest {
+
+    @Test
+    fun `includes HUD pass when world pass is disabled`() {
+        val plan = LumiyaFramePlanner.createPlan(
+            worldPassEnabled = false,
+            hasHudElements = true
+        )
+        assertEquals(listOf(LumiyaRenderPass.HUD), plan)
+    }
+
+    @Test
+    fun `orders overlapping HUDs deterministically by layer then attachment then id`() {
+        val store = DrawableHudStore()
+        store.addHudPrim(id = 7L, attachmentPoint = 38, posX = 20f, posY = 20f, posZ = 0f, layer = 2)
+        store.addHudPrim(id = 4L, attachmentPoint = 31, posX = 20f, posY = 20f, posZ = 0f, layer = 1)
+        store.addHudPrim(id = 3L, attachmentPoint = 31, posX = 20f, posY = 20f, posZ = 0f, layer = 1)
+
+        assertEquals(listOf(3L, 4L, 7L), store.debugSortedIds())
+        assertTrue(store.hasElements())
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a dedicated HUD rendering pass (pass 10) that draws HUD attachments independently of world geometry and obeys Phase 4 lifecycle expectations.
- Route HUD attachment points away from the world attachment list so HUD objects can be staged, ordered and rendered with an orthographic camera.
- Provide deterministic layering/ordering for overlapping HUD elements and ensure HUD projection is rebuilt on resize/orientation updates.
- Add a small deterministic harness to assert HUD rendering behavior when the world pass is disabled and document the lifecycle for maintainers.

### Description
- Implemented the HUD pass in `LumiyaRenderer` by introducing an orthographic HUD view/projection path, isolating depth behavior during the HUD pass, and restoring world matrices afterwards (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt`).
- Added a dedicated HUD draw list `DrawableHudStore` and a mesh cache `DrawableHudMeshCache` to route `ATTACHMENT_HUD_*` attachments to the HUD render list instead of the world prim store (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt`, `DrawableHudMeshCache.kt`).
- Introduced deterministic layering and ordering rules for HUD elements (`layer -> attachmentPoint -> entityId`) in `DrawableHudStore`, and exposed a debug helper `debugSortedIds()` for deterministic checks.
- Added a simple frame planner `LumiyaFramePlanner` to sequence passes and allow rendering HUD when the world pass is disabled (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt`).
- Added a unit test harness `LumiyaFramePlannerTest` asserting HUD-only plans and deterministic HUD ordering (`Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt`).
- Wired surface changes and initialization to rebuild HUD projection matrices via `rebuildHudMatrices(width,height)` so anchors remain stable on resize, and documented the HUD pass lifecycle in `FILAMENT.md`.

### Testing
- Added unit tests in `LumiyaFramePlannerTest` which validate that `LumiyaFramePlanner.createPlan(...)` includes the `HUD` pass when world passes are disabled and that `DrawableHudStore` sorts HUD prims deterministically; these tests are included in the repo under `Linkpoint/src/test`.
- Attempted to run the unit tests with `./gradlew :Linkpoint:testDebugUnitTest --tests com.linkpoint.render.lumiya.core.LumiyaFramePlannerTest`, but the test run failed early due to the build environment reporting `Unsupported class file major version 69` (Gradle/Java toolchain incompatibility), so tests did not execute in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea74cbf6888323939215609d9ba3c1)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a dedicated HUD rendering pass (pass 10) to the Lumiya GL-based renderer that renders HUD attachments independently from world geometry using an orthographic camera. The implementation routes HUD attachment points (`ATTACHMENT_HUD_*`) into a separate draw list (`DrawableHudStore`) with deterministic layering by *layer → attachmentPoint → entityId*, isolates depth state during HUD rendering, and ensures HUD projection matrices are rebuilt on surface resize. A frame planner (`LumiyaFramePlanner`) sequences world and HUD passes so HUD can render even when world passes are disabled, with unit tests validating the planner logic and deterministic HUD ordering.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/FILAMENT.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudMeshCache.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->