### PR TITLE
Add AgentIdentity validation and require it for outbound packet builders

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/chat/ChatManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/chat/ChatManager.kt
@@ -2,6 +2,7 @@ package com.linkpoint.chat
 
 import android.util.Log
 import com.linkpoint.messaging.MessagingDispatcher
+import com.linkpoint.protocol.core.AgentIdentity
 import com.linkpoint.protocol.messages.ChatData
 import com.linkpoint.protocol.messages.ChatSourceType
 import com.linkpoint.protocol.messages.ChatType
@@ -148,6 +149,12 @@ class ChatManager(
     }
     
     private fun buildChatPacket(message: String, type: ChatType, channel: Int): ByteArray {
+        val identity = AgentIdentity(
+            agentId = agentId,
+            sessionId = udpConnection.getSessionId(),
+            circuitCode = udpConnection.getCircuitCode()
+        ).requireValid("ChatManager.buildChatPacket")
+
         val messageBytes = message.toByteArray(Charsets.UTF_8)
         
         // ChatFromViewer message format per SL protocol:
@@ -164,11 +171,8 @@ class ChatManager(
             .order(ByteOrder.LITTLE_ENDIAN)
         
         // AgentData block - UUIDs use big-endian per SL protocol
-        buffer.putUUID(agentId)
-        
-        // SessionID - get from UDPConnection
-        val sessionId = udpConnection.getSessionId()
-        buffer.putUUID(sessionId)
+        buffer.putUUID(identity.agentId)
+        buffer.putUUID(identity.sessionId)
         
         // ChatData block
         // Message - Variable 2 (2-byte length prefix + string + null terminator)

--- a/Linkpoint/src/main/java/com/linkpoint/chat/IMManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/chat/IMManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.linkpoint.messaging.MessagingDispatcher
 import com.linkpoint.protocol.capabilities.CapabilityManager
 import com.linkpoint.protocol.capabilities.EventHandler
+import com.linkpoint.protocol.core.AgentIdentity
 import com.linkpoint.protocol.llsd.*
 import com.linkpoint.protocol.messages.UDPConnectionFixed
 import com.linkpoint.protocol.types.putUUID
@@ -104,6 +105,12 @@ class IMManager(
     private val processedPushIds = ConcurrentHashMap.newKeySet<String>()
     private val pendingSyncSessions = MutableStateFlow<Set<UUID>>(emptySet())
     val syncNeededSessions: StateFlow<Set<UUID>> = pendingSyncSessions
+
+    private fun outboundIdentity(): AgentIdentity = AgentIdentity(
+        agentId = agentId,
+        sessionId = udpConnection.getSessionId(),
+        circuitCode = udpConnection.getCircuitCode()
+    ).requireValid("IMManager outbound packet")
     
     init {
         // Register for event queue events
@@ -485,8 +492,9 @@ class IMManager(
                 val payload = java.nio.ByteBuffer.allocate(100).order(java.nio.ByteOrder.LITTLE_ENDIAN)
                 
                 // AgentData block - UUIDs are big-endian per SL protocol
-                payload.putUUID(agentId)
-                payload.putUUID(udpConnection.getSessionId())  // Proper session ID
+                val identity = outboundIdentity()
+                payload.putUUID(identity.agentId)
+                payload.putUUID(identity.sessionId)
                 
                 // MessageBlock
                 payload.put(0)  // FromGroup (BOOL)
@@ -544,8 +552,9 @@ class IMManager(
                 val payload = java.nio.ByteBuffer.allocate(100).order(java.nio.ByteOrder.LITTLE_ENDIAN)
                 
                 // AgentData block - UUIDs are big-endian per SL protocol
-                payload.putUUID(agentId)
-                payload.putUUID(udpConnection.getSessionId())  // Proper session ID
+                val identity = outboundIdentity()
+                payload.putUUID(identity.agentId)
+                payload.putUUID(identity.sessionId)
                 
                 // MessageBlock
                 payload.put(0)  // FromGroup (BOOL)

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/InventoryManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/InventoryManager.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import android.util.Log
 import com.linkpoint.assets.AssetType
 import com.linkpoint.protocol.capabilities.CapabilityManager
+import com.linkpoint.protocol.core.AgentIdentity
 import com.linkpoint.protocol.messages.MessageIds
 import com.linkpoint.protocol.messages.UDPConnectionFixed
 import com.linkpoint.protocol.types.getUUID
@@ -75,6 +76,12 @@ class InventoryManager(
     
     private val _currentFolder = MutableStateFlow<UUID?>(null)
     val currentFolder: StateFlow<UUID?> = _currentFolder
+
+    private fun outboundIdentity(): AgentIdentity = AgentIdentity(
+        agentId = agentId,
+        sessionId = udpConnection.getSessionId(),
+        circuitCode = udpConnection.getCircuitCode()
+    ).requireValid("InventoryManager outbound packet")
     
     /**
      * Set root folder ID
@@ -399,11 +406,11 @@ class InventoryManager(
                     // Total payload: 70 bytes
 
                     val payload = ByteBuffer.allocate(70).order(ByteOrder.LITTLE_ENDIAN)
-                    val sessionId = udpConnection.getSessionId()
+                    val identity = outboundIdentity()
 
                     // AgentData
-                    payload.putUUID(agentId)
-                    payload.putUUID(sessionId)
+                    payload.putUUID(identity.agentId)
+                    payload.putUUID(identity.sessionId)
                     payload.putInt(0) // Stamp = 0 (false/default)
 
                     // InventoryData count (Variable block)
@@ -525,8 +532,9 @@ class InventoryManager(
                     val payload = ByteBuffer.allocate(payloadSize).order(ByteOrder.LITTLE_ENDIAN)
 
                     // AgentData block
-                    payload.putUUID(agentId)
-                    payload.putUUID(udpConnection.getSessionId())
+                    val identity = outboundIdentity()
+                    payload.putUUID(identity.agentId)
+                    payload.putUUID(identity.sessionId)
 
                     // FolderData block
                     payload.putUUID(folderId)
@@ -673,8 +681,9 @@ class InventoryManager(
         val buffer = ByteBuffer.allocate(payloadSize).order(ByteOrder.LITTLE_ENDIAN)
 
         // AgentData Block
-        buffer.putUUID(agentId)
-        buffer.putUUID(udpConnection.getSessionId())
+        val identity = outboundIdentity()
+        buffer.putUUID(identity.agentId)
+        buffer.putUUID(identity.sessionId)
         buffer.putUUID(UUID.randomUUID()) // TransactionID
 
         // InventoryData Block Count
@@ -772,8 +781,9 @@ class InventoryManager(
         val payload = ByteBuffer.allocate(payloadSize).order(ByteOrder.LITTLE_ENDIAN)
 
         // AgentData
-        payload.putUUID(agentId)
-        payload.putUUID(udpConnection.getSessionId())
+        val identity = outboundIdentity()
+        payload.putUUID(identity.agentId)
+        payload.putUUID(identity.sessionId)
 
         // InventoryData Block Count
         payload.put(1.toByte())

--- a/Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt
@@ -3,6 +3,7 @@ package com.linkpoint.objects
 import android.os.Parcelable
 import android.util.Log
 import com.linkpoint.diagnostics.ScenePopulationDiagnostics
+import com.linkpoint.protocol.core.AgentIdentity
 import com.linkpoint.protocol.messages.MessageIds
 import com.linkpoint.protocol.messages.ObjectPropertyEntry
 import com.linkpoint.protocol.messages.ObjectUpdateData
@@ -84,8 +85,13 @@ class ObjectManager(
     val editMode: StateFlow<EditMode> = _editMode
 
     private fun writeAgentData(buffer: ByteBuffer) {
-        buffer.putUUID(udpConnection.getAgentId())
-        buffer.putUUID(udpConnection.getSessionId())
+        val identity = AgentIdentity(
+            agentId = udpConnection.getAgentId(),
+            sessionId = udpConnection.getSessionId(),
+            circuitCode = udpConnection.getCircuitCode()
+        ).requireValid("ObjectManager outbound packet")
+        buffer.putUUID(identity.agentId)
+        buffer.putUUID(identity.sessionId)
     }
 
     private fun writeAgentGroupData(buffer: ByteBuffer, groupId: UUID = ZERO_UUID) {

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/core/AgentIdentity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/core/AgentIdentity.kt
@@ -1,0 +1,40 @@
+package com.linkpoint.protocol.core
+
+import java.util.UUID
+
+/**
+ * Shared outbound identity required for packet builders.
+ *
+ * At minimum, agent/session IDs must be non-zero UUIDs. For circuit-routed UDP
+ * messages we also require a non-zero circuit code.
+ */
+data class AgentIdentity(
+    val agentId: UUID,
+    val sessionId: UUID,
+    val regionId: UUID? = null,
+    val circuitCode: Int? = null
+) {
+    companion object {
+        val ZERO_UUID: UUID = UUID(0L, 0L)
+    }
+
+    fun validate(requireCircuitOrRegion: Boolean = true): String? {
+        if (agentId == ZERO_UUID) return "agentId is zero UUID"
+        if (sessionId == ZERO_UUID) return "sessionId is zero UUID"
+        if (requireCircuitOrRegion) {
+            val hasRegion = regionId != null && regionId != ZERO_UUID
+            val hasCircuit = circuitCode != null && circuitCode != 0
+            if (!hasRegion && !hasCircuit) {
+                return "regionId/circuit is missing or invalid"
+            }
+        }
+        return null
+    }
+
+    fun requireValid(context: String, requireCircuitOrRegion: Boolean = true): AgentIdentity {
+        val error = validate(requireCircuitOrRegion)
+        require(error == null) { "$context: invalid AgentIdentity ($error)" }
+        return this
+    }
+}
+

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -7,6 +7,7 @@ import com.linkpoint.network.events.ConnectionState
 import com.linkpoint.network.events.CircuitEstablishedEvent
 import com.linkpoint.network.events.MessageReceivedEvent
 import com.linkpoint.network.NetworkLogger
+import com.linkpoint.protocol.core.AgentIdentity
 import com.linkpoint.protocol.circuit.LinkpointConstants
 import com.linkpoint.protocol.types.putUUID
 import com.linkpoint.utils.SessionLogRecorder
@@ -568,6 +569,13 @@ class UDPConnectionFixed {
      * Get the circuit code for this connection
      */
     fun getCircuitCode(): Int = circuitCode
+
+    private fun outboundIdentity(context: String): AgentIdentity =
+        AgentIdentity(
+            agentId = agentId,
+            sessionId = sessionId,
+            circuitCode = circuitCode
+        ).requireValid(context)
 
     /**
      * Guards ownership of movement/reliable-send lifecycle for shared circuits.
@@ -1757,6 +1765,7 @@ class UDPConnectionFixed {
      * Uses mobile-optimized packet construction
      */
     private fun sendUseCircuitCode() {
+        val identity = outboundIdentity("UDPConnectionFixed.sendUseCircuitCode")
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "→ Sending UseCircuitCode")
         
         // UseCircuitCode message format:
@@ -1764,9 +1773,9 @@ class UDPConnectionFixed {
         // - SessionID (16 bytes, UUID)
         // - AgentID (16 bytes, UUID)
         val payload = ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN)
-        payload.putInt(circuitCode)
-        payload.put(sessionId.asBytes())
-        payload.put(agentId.asBytes())
+        payload.putInt(identity.circuitCode ?: 0)
+        payload.put(identity.sessionId.asBytes())
+        payload.put(identity.agentId.asBytes())
         
         // Message ID for UseCircuitCode (low frequency: -65533)
         val messageId = MessageIds.USE_CIRCUIT_CODE
@@ -1841,6 +1850,7 @@ class UDPConnectionFixed {
      * Uses mobile-optimized packet construction
      */
     fun sendCompleteAgentMovement() {
+        val identity = outboundIdentity("UDPConnectionFixed.sendCompleteAgentMovement")
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "→ Sending CompleteAgentMovement")
         
         // CompleteAgentMovement message format:
@@ -1848,9 +1858,9 @@ class UDPConnectionFixed {
         // - SessionID (16 bytes, UUID)
         // - CircuitCode (4 bytes, little-endian)
         val payload = ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN)
-        payload.put(agentId.asBytes())
-        payload.put(sessionId.asBytes())
-        payload.putInt(circuitCode)
+        payload.put(identity.agentId.asBytes())
+        payload.put(identity.sessionId.asBytes())
+        payload.putInt(identity.circuitCode ?: 0)
         
         // Message ID for CompleteAgentMovement (low frequency message)
         val messageId = MessageIds.COMPLETE_AGENT_MOVEMENT
@@ -1864,6 +1874,7 @@ class UDPConnectionFixed {
      * Mobile-optimized: 10 updates/sec to balance responsiveness and battery
      */
     fun sendAgentUpdate() {
+        val identity = outboundIdentity("UDPConnectionFixed.sendAgentUpdate")
         if (!_isConnected.value) {
             return
         }
@@ -1884,8 +1895,8 @@ class UDPConnectionFixed {
         val payload = ByteBuffer.allocate(114).order(ByteOrder.LITTLE_ENDIAN)
         
         // AgentID and SessionID
-        payload.put(agentId.asBytes())
-        payload.put(sessionId.asBytes())
+        payload.put(identity.agentId.asBytes())
+        payload.put(identity.sessionId.asBytes())
         
         // Body rotation (identity quaternion: x=0, y=0, z=0, w computed by server)
         payload.putFloat(0f)
@@ -1941,13 +1952,14 @@ class UDPConnectionFixed {
      * Must be sent in response to RegionHandshake from simulator.
      */
     fun sendRegionHandshakeReply(flags: Int = 0) {
+        val identity = outboundIdentity("UDPConnectionFixed.sendRegionHandshakeReply")
         val payload = ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN)
         
         // Agent ID
-        payload.putUUID(agentId)
+        payload.putUUID(identity.agentId)
         
         // Session ID
-        payload.putUUID(sessionId)
+        payload.putUUID(identity.sessionId)
         
         // Flags (typically 0)
         payload.putInt(flags)
@@ -1969,16 +1981,17 @@ class UDPConnectionFixed {
         texture: Float = 200000f,
         asset: Float = 100000f
     ) {
+        val identity = outboundIdentity("UDPConnectionFixed.sendAgentThrottle")
         val payload = ByteBuffer.allocate(36 + 4 + 28).order(ByteOrder.LITTLE_ENDIAN)
         
         // Agent ID
-        payload.putUUID(agentId)
+        payload.putUUID(identity.agentId)
         
         // Session ID
-        payload.putUUID(sessionId)
+        payload.putUUID(identity.sessionId)
         
         // Circuit code
-        payload.putInt(circuitCode)
+        payload.putInt(identity.circuitCode ?: 0)
         
         // GenCounter
         payload.putInt(1)
@@ -2007,6 +2020,7 @@ class UDPConnectionFixed {
      */
     fun sendRequestMultipleObjects(objectIds: List<Int>, cacheMissType: Int = 0) {
         if (objectIds.isEmpty()) return
+        val identity = outboundIdentity("UDPConnectionFixed.sendRequestMultipleObjects")
         
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, 
             "→ Sending RequestMultipleObjects for ${objectIds.size} objects")
@@ -2028,8 +2042,8 @@ class UDPConnectionFixed {
         val payload = ByteBuffer.allocate(payloadSize).order(ByteOrder.LITTLE_ENDIAN)
         
         // AgentData block
-        payload.put(agentId.asBytes())
-        payload.put(sessionId.asBytes())
+        payload.put(identity.agentId.asBytes())
+        payload.put(identity.sessionId.asBytes())
         
         // ObjectData count
         payload.put(objectIds.size.toByte())

--- a/Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt
@@ -1,6 +1,7 @@
 package com.linkpoint.world
 
 import android.util.Log
+import com.linkpoint.protocol.core.AgentIdentity
 import com.linkpoint.protocol.messages.MessageIds
 import com.linkpoint.protocol.messages.UDPConnectionFixed
 import com.linkpoint.protocol.types.LLVector3
@@ -72,8 +73,13 @@ class ParcelManager(
      * Message block fields remain little-endian per SL templates.
      */
     private fun writeAgentData(buffer: ByteBuffer) {
-        writeUUID(buffer, udpConnection.getAgentId())
-        writeUUID(buffer, udpConnection.getSessionId())
+        val identity = AgentIdentity(
+            agentId = udpConnection.getAgentId(),
+            sessionId = udpConnection.getSessionId(),
+            circuitCode = udpConnection.getCircuitCode()
+        ).requireValid("ParcelManager outbound packet")
+        writeUUID(buffer, identity.agentId)
+        writeUUID(buffer, identity.sessionId)
     }
     
     /**

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/core/AgentIdentityTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/core/AgentIdentityTest.kt
@@ -1,0 +1,54 @@
+package com.linkpoint.protocol.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.util.UUID
+
+class AgentIdentityTest {
+
+    @Test
+    fun packetIdentityValidation_failsFastForZeroAgentId() {
+        val identity = AgentIdentity(
+            agentId = UUID(0L, 0L),
+            sessionId = UUID.randomUUID(),
+            circuitCode = 100
+        )
+
+        try {
+            identity.requireValid("test")
+            fail("Expected invalid identity to throw")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("agentId is zero UUID") == true)
+        }
+    }
+
+    @Test
+    fun packetIdentityValidation_failsFastForMissingCircuitAndRegion() {
+        val identity = AgentIdentity(
+            agentId = UUID.randomUUID(),
+            sessionId = UUID.randomUUID(),
+            circuitCode = 0
+        )
+
+        try {
+            identity.requireValid("test")
+            fail("Expected invalid identity to throw")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("regionId/circuit is missing or invalid") == true)
+        }
+    }
+
+    @Test
+    fun packetIdentityValidation_succeedsForValidIdentity() {
+        val identity = AgentIdentity(
+            agentId = UUID.randomUUID(),
+            sessionId = UUID.randomUUID(),
+            circuitCode = 42
+        ).requireValid("test")
+
+        assertEquals(42, identity.circuitCode)
+    }
+}
+


### PR DESCRIPTION
### Motivation
- Centralize outbound identity (agent/session + optional region/circuit) so all UDP packet builders share a single validation policy. 
- Fail fast when building/sending outbound packets that would embed zero/blank UUIDs or missing circuit info to avoid subtle runtime networking bugs.

### Description
- Added a new model `AgentIdentity` under `protocol/core` with `validate(...)` and `requireValid(...)` helpers. (`Linkpoint/src/main/java/com/linkpoint/protocol/core/AgentIdentity.kt`).
- Refactored outbound builders to use `AgentIdentity` and call `requireValid(...)` before writing AgentData: `ObjectManager` (`Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt`) and `ParcelManager` (`Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt`).
- Updated chat and IM outbound construction to use validated identity: `ChatManager` and `IMManager` (`Linkpoint/src/main/java/com/linkpoint/chat/ChatManager.kt`, `Linkpoint/src/main/java/com/linkpoint/chat/IMManager.kt`).
- Updated inventory outbound builders to use validated identity (`Linkpoint/src/main/java/com/linkpoint/inventory/InventoryManager.kt`).
- Hardened low-level UDP message constructors in `UDPConnectionFixed` to require identity before constructing/sending critical packets (`UseCircuitCode`, `CompleteAgentMovement`, `AgentUpdate`, `RegionHandshakeReply`, `AgentThrottle`, `RequestMultipleObjects`) in `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt`.
- Added unit tests exercising `AgentIdentity` validation behavior (`Linkpoint/src/test/kotlin/com/linkpoint/protocol/core/AgentIdentityTest.kt`).

### Testing
- Added unit tests: `com.linkpoint.protocol.core.AgentIdentityTest` which checks fail-fast validation for zero `agentId`, missing `regionId/circuit`, and success for a valid identity (test file: `Linkpoint/src/test/kotlin/com/linkpoint/protocol/core/AgentIdentityTest.kt`).
- Attempted to run the new tests with `./gradlew testDebugUnitTest --tests com.linkpoint.protocol.core.AgentIdentityTest`, but the Gradle run failed in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties sdk.dir`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabfbb08f88323bbb22a08e4794567)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces centralized validation for agent identity information (agent/session UUIDs and circuit codes) used when building outbound UDP packets. A new `AgentIdentity` model with validation helpers ensures that all outbound packet builders fail fast when encountering zero/blank UUIDs or missing circuit information, preventing subtle networking bugs. The change refactors multiple managers (`ChatManager`, `IMManager`, `InventoryManager`, `ObjectManager`, `ParcelManager`) and low-level UDP message constructors in `UDPConnectionFixed` to use the validated identity before writing agent data to packets. Unit tests verify the validation behavior for invalid and valid identity scenarios.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/core/AgentIdentity.kt` |
| 2 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/core/AgentIdentityTest.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/world/ParcelManager.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/chat/ChatManager.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/chat/IMManager.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/inventory/InventoryManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->