### PR TITLE
Harden LLSD parser bounds and truncation handling

### DIFF
--- a/.github/workflows/build-linkpoint.yml
+++ b/.github/workflows/build-linkpoint.yml
@@ -107,7 +107,10 @@ jobs:
       - name: Run unit tests
         run: ./gradlew :Linkpoint:testStableDebugUnitTest --stacktrace --continue
         continue-on-error: true
-      
+
+      - name: Run LLSD parser fuzz target
+        run: ./gradlew :Linkpoint:testStableDebugUnitTest --tests "com.linkpoint.protocol.llsd.LLSDParserFuzzTargetTest" --stacktrace
+
       - name: Run lint analysis
         run: ./gradlew :Linkpoint:lintStableDebug --stacktrace
         continue-on-error: true

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/llsd/LLSDParser.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/llsd/LLSDParser.kt
@@ -17,6 +17,7 @@ object LLSDParser {
         val maxBinaryBytes: Int = 1024 * 1024,
         val maxArrayLength: Int = 10_000,
         val maxMapEntries: Int = 10_000,
+        val maxCollectionElementsTotal: Int = 20_000,
         val maxNestingDepth: Int = 128,
         val maxTotalBytes: Int = 4 * 1024 * 1024,
     )
@@ -160,6 +161,7 @@ object LLSDParser {
                     if (entries > limits.maxMapEntries) {
                         throw ParseLimitExceededException("Map entry count exceeds maxMapEntries.")
                     }
+                    enforceCollectionElementLimit(state, limits)
 
                     val keyLength = readLength(stream, state, limits)
                     if (keyLength > limits.maxStringBytes) {
@@ -176,17 +178,17 @@ object LLSDParser {
                 var elements = 0
 
                 while (true) {
-                    val peek = readByte(stream, state, limits)
-                    if (peek.toChar() == LLSDValue.MARKER_ARRAY_END) break
-
-                    stream.unread(peek)
-                    state.accumulatedBytes--
+                    if (peekByte(stream, state, limits).toChar() == LLSDValue.MARKER_ARRAY_END) {
+                        readByte(stream, state, limits)
+                        break
+                    }
 
                     elements++
                     state.collectionElementsRead++
                     if (elements > limits.maxArrayLength) {
                         throw ParseLimitExceededException("Array length exceeds maxArrayLength.")
                     }
+                    enforceCollectionElementLimit(state, limits)
 
                     array.add(parseBinaryValue(stream, state, limits))
                 }
@@ -220,6 +222,17 @@ object LLSDParser {
         return value
     }
 
+    private fun peekByte(
+        stream: PushbackInputStream,
+        state: ParseLimitsState,
+        limits: ParseLimits,
+    ): Int {
+        val value = readByte(stream, state, limits)
+        stream.unread(value)
+        state.accumulatedBytes--
+        return value
+    }
+
     private fun readExact(
         stream: InputStream,
         size: Int,
@@ -243,6 +256,12 @@ object LLSDParser {
     private fun enforceTotalBytesLimit(state: ParseLimitsState, limits: ParseLimits) {
         if (state.accumulatedBytes > limits.maxTotalBytes) {
             throw ParseLimitExceededException("Total bytes exceed maxTotalBytes.")
+        }
+    }
+
+    private fun enforceCollectionElementLimit(state: ParseLimitsState, limits: ParseLimits) {
+        if (state.collectionElementsRead > limits.maxCollectionElementsTotal) {
+            throw ParseLimitExceededException("Total collection elements exceed maxCollectionElementsTotal.")
         }
     }
 

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserFuzzTargetTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserFuzzTargetTest.kt
@@ -1,0 +1,24 @@
+package com.linkpoint.protocol.llsd
+
+import kotlin.random.Random
+import org.junit.Test
+
+/**
+ * Fuzz-style entrypoint for LLSD binary parser hardening.
+ *
+ * Kept intentionally deterministic so it can run in CI.
+ */
+class LLSDParserFuzzTargetTest {
+    @Test
+    fun fuzzBinaryParserDeterministicCorpus() {
+        val seeds = intArrayOf(0, 1, 7, 42, 99, 777, 1024, 4096, 65_535)
+        for (seed in seeds) {
+            val random = Random(seed)
+            repeat(250) {
+                val size = random.nextInt(0, 2048)
+                val input = ByteArray(size) { random.nextInt(0, 256).toByte() }
+                LLSDParser.parseBinary(input)
+            }
+        }
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt
@@ -3,8 +3,10 @@ package com.linkpoint.protocol.llsd
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.text.SimpleDateFormat
+import java.io.ByteArrayOutputStream
 import java.util.Locale
 import java.util.TimeZone
+import kotlin.random.Random
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -133,5 +135,84 @@ class LLSDParserTest {
         val result = LLSDParser.parseBinary(payload)
 
         assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for truncated map key bytes`() {
+        val payload = byteArrayOf(
+            '{'.code.toByte(),
+            'k'.code.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x03,
+            'a'.code.toByte(),
+            'b'.code.toByte(),
+        )
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for malformed map key marker`() {
+        val payload = byteArrayOf(
+            '{'.code.toByte(),
+            'x'.code.toByte(),
+            '}'.code.toByte(),
+        )
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for negative binary length`() {
+        val payload = byteArrayOf(
+            'b'.code.toByte(),
+            0xFF.toByte(),
+            0xFF.toByte(),
+            0xFF.toByte(),
+            0xFF.toByte(),
+        )
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary returns undefined for oversized map entries`() {
+        val entry = byteArrayOf(
+            'k'.code.toByte(),
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            'a'.code.toByte(),
+            '1'.code.toByte(),
+        )
+        val payload = ByteArrayOutputStream().apply {
+            write('{'.code)
+            repeat(10_001) {
+                write(entry)
+            }
+            write('}'.code)
+        }.toByteArray()
+
+        val result = LLSDParser.parseBinary(payload)
+
+        assertEquals(LLSDUndefined, result)
+    }
+
+    @Test
+    fun `parseBinary fuzz smoke never throws`() {
+        repeat(2_000) { seed ->
+            val random = Random(seed)
+            val payload = ByteArray(random.nextInt(0, 512)) { random.nextInt(0, 256).toByte() }
+            LLSDParser.parseBinary(payload)
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent unchecked/unchecked-length reads and resource exhaustion by enforcing explicit bounds for strings, binaries, collections, nesting depth, and overall bytes during binary LLSD parsing.
- Replace fragile array-end probing and unread accounting with a safer pushback/peek approach to avoid inconsistent byte accounting and truncation errors.
- Improve parser robustness against truncated and malformed inputs and add deterministic fuzz coverage to catch edge cases early in CI.

### Description
- Added `maxCollectionElementsTotal` and `enforceCollectionElementLimit` to aggregate collection element accounting and applied the check during map/array traversal (`LLSDParser.kt`).
- Reworked array termination logic to use a `peekByte` helper backed by `PushbackInputStream` and removed the previous manual unread/byte-decrement pattern (`LLSDParser.kt`).
- Continued use of exact-length reads via `readExact` with typed `TruncatedBinaryPayloadException`/`MalformedBinaryDataException` for clear failures on early EOF or invalid lengths (`LLSDParser.kt`).
- Expanded unit tests (`LLSDParserTest.kt`) to cover truncated map keys, malformed map markers, negative lengths, oversized maps, and added a deterministic fuzz-style test entrypoint (`LLSDParserFuzzTargetTest.kt`), and wired the fuzz target into CI (`.github/workflows/build-linkpoint.yml`).

### Testing
- Added and updated unit tests: `LLSDParserTest` (additional truncation/malformed/oversize cases) and `LLSDParserFuzzTargetTest` (deterministic fuzz corpus); these tests are included in the repository test suite.
- CI workflow was updated to explicitly run the fuzz-target test class (`build-linkpoint.yml`).
- Attempted to run the LLSD parser tests locally via Gradle (`./gradlew :Linkpoint:testStableDebugUnitTest --tests "com.linkpoint.protocol.llsd.LLSDParserTest" --tests "com.linkpoint.protocol.llsd.LLSDParserFuzzTargetTest" --stacktrace`), but the run failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`Linkpoint/local.properties sdk.dir`).
- No test failures were observed in code-level checks; full unit test execution is expected to run in CI where the Android SDK is configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabfbc6c5883238194e38951679007)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the LLSD binary parser against malformed and truncated inputs by introducing additional resource limits (total collection elements), replacing fragile byte accounting with a safer `peekByte` approach using `PushbackInputStream`, and enforcing explicit bounds throughout parsing. The changes improve robustness against potential denial-of-service and parser crashes by catching truncation and malformed data early, and add comprehensive fuzz testing integrated into CI to ensure the parser handles adversarial inputs gracefully.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/llsd/LLSDParser.kt` |
| 2 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserTest.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/llsd/LLSDParserFuzzTargetTest.kt` |
| 4 | `.github/workflows/build-linkpoint.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->