### PR TITLE
Audit capability constants and guard against orphan CAP declarations

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/assets/ScriptManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/assets/ScriptManager.kt
@@ -105,7 +105,7 @@ class ScriptManager(
                     this["item_id"] = LLSDUUID(itemId)
                 }
                 
-                val response = capabilityManager.request("GetScriptRunning", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_GET_SCRIPT_RUNNING, request)
                 
                 if (response is LLSDMap) {
                     ScriptRunningInfo(
@@ -134,7 +134,7 @@ class ScriptManager(
                     this["running"] = LLSDBoolean(running)
                 }
                 
-                val response = capabilityManager.request("SetScriptRunning", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_SET_SCRIPT_RUNNING, request)
                 
                 if (response is LLSDMap) {
                     val success = response.getBoolean("success") ?: false
@@ -180,7 +180,7 @@ class ScriptManager(
                     this["object_id"] = LLSDUUID(objectId)
                 }
                 
-                val response = capabilityManager.request("GetScriptTaskInfo", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_GET_SCRIPT_TASK_INFO, request)
                 
                 if (response is LLSDMap) {
                     val scripts = response.getArray("scripts")

--- a/Linkpoint/src/main/java/com/linkpoint/bom/BakesOnMeshManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/bom/BakesOnMeshManager.kt
@@ -140,7 +140,7 @@ class BakesOnMeshManager(
                     this["agent_id"] = LLSDUUID(avatarId)
                 }
                 
-                val response = capabilityManager.request("UploadAgentBakedTexture", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_UPLOAD_AGENT_BAKED_TEXTURE, request)
                 
                 if (response is LLSDMap) {
                     // Server will send new baked textures via AgentCachedTexture

--- a/Linkpoint/src/main/java/com/linkpoint/groups/GroupsManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/groups/GroupsManager.kt
@@ -237,7 +237,7 @@ class GroupsManager(
                     this["session-id"] = LLSDUUID(groupId)
                 }
                 
-                val response = capabilityManager.request("ChatSessionRequest", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_CHAT_PASS, request)
                 if (response is LLSDMap) {
                     UUID.fromString(response.getString("session_id"))
                 } else {

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/LandmarkManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/LandmarkManager.kt
@@ -70,7 +70,7 @@ class LandmarkManager(
                 val assetData = buildLandmarkAsset(regionHandle, position)
                 
                 // Create the inventory item via CreateInventoryItem capability
-                val createCap = capabilityManager.getCapability("CreateInventoryItem")
+                val createCap = capabilityManager.getCapability(CapabilityManager.CAP_CREATE_INVENTORY_ITEM)
                 if (createCap != null) {
                     val request = LLSDMap().apply {
                         this["type"] = LLSDInteger(3) // Landmark asset type
@@ -84,7 +84,7 @@ class LandmarkManager(
                         }
                     }
                     
-                    val response = capabilityManager.request("CreateInventoryItem", request)
+                    val response = capabilityManager.request(CapabilityManager.CAP_CREATE_INVENTORY_ITEM, request)
                     if (response is LLSDMap) {
                         val itemId = response.getUUID("item_id")
                         if (itemId != null) {

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt
@@ -49,7 +49,6 @@ class CapabilityManager : CapabilityRequester {
         private const val UTF8_BOM = '\uFEFF'
         
         // Common capability names
-        const val CAP_SEED = "Seed"
         const val CAP_EVENT_QUEUE = "EventQueueGet"
         const val CAP_FETCH_INVENTORY = "FetchInventory2"
         const val CAP_FETCH_LIB_INVENTORY = "FetchLib2"
@@ -63,7 +62,7 @@ class CapabilityManager : CapabilityRequester {
         const val CAP_UPDATE_AGENT_INFO = "UpdateAgentInformation"
         const val CAP_UPLOAD_BAKED_TEXTURE = "UploadBakedTexture"
         const val CAP_OBJECT_MEDIA = "ObjectMedia"
-        // Deferred (2026-04-23): viewer-side media browser integration not wired yet.
+        // @cap-status deferred since=2026-04-24 issue=https://github.com/Kaleaon/Linkpoint/issues/1688 rationale="Viewer-side media browser integration is not wired into current UI flows."
         const val CAP_OBJECT_MEDIA_NAVIGATE = "ObjectMediaNavigate"
         const val CAP_PARCEL_VOICE = "ParcelVoiceInfoRequest"
         const val CAP_PROVISION_VOICE = "ProvisionVoiceAccountRequest"
@@ -76,7 +75,7 @@ class CapabilityManager : CapabilityRequester {
         const val CAP_GROUP_PROFILE = "GroupProfile"
         const val CAP_ENVIRONMENT = "EnvironmentSettings"
         const val CAP_EXT_ENVIRONMENT = "ExtEnvironment"
-        // Deferred (2026-04-23): no consumer yet; keep declared for handshake parity.
+        // @cap-status deferred since=2026-04-24 issue=https://github.com/Kaleaon/Linkpoint/issues/1689 rationale="Region Experiences capability has no in-app consumer; retained for seed handshake parity."
         const val CAP_REGION_EXPERIENCE = "RegionExperiences"
         const val CAP_SIMULATE_LURE = "SimulatorLure"
         const val CAP_AVATAR_PICKER = "AvatarPickerSearch"
@@ -105,6 +104,16 @@ class CapabilityManager : CapabilityRequester {
         const val CAP_GROUP_MEMBER_DATA = "GroupMemberData"
         const val CAP_CHAT_SEND = "ChatSend"
         const val CAP_FRIENDSHIP_TERMINATE = "FriendshipTerminate"
+
+        const val CAP_TELEPORT_LOCATION = "TeleportLocation"
+        const val CAP_SEARCH_LAND = "SearchLand"
+        const val CAP_GET_SCRIPT_RUNNING = "GetScriptRunning"
+        const val CAP_SET_SCRIPT_RUNNING = "SetScriptRunning"
+        const val CAP_GET_SCRIPT_TASK_INFO = "GetScriptTaskInfo"
+        const val CAP_CREATE_INVENTORY_ITEM = "CreateInventoryItem"
+        const val CAP_NEW_FILE_AGENT_INVENTORY = "NewFileAgentInventory"
+        const val CAP_UPLOAD_AGENT_PROFILE_IMAGE = "UploadAgentProfileImage"
+        const val CAP_UPLOAD_AGENT_BAKED_TEXTURE = "UploadAgentBakedTexture"
         
         // Capabilities that are inventory-related (for throttling)
         private val INVENTORY_CAPS = setOf(

--- a/Linkpoint/src/main/java/com/linkpoint/snapshot/SnapshotManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/snapshot/SnapshotManager.kt
@@ -198,7 +198,7 @@ class SnapshotManager(
                 val imageBytes = outputStream.toByteArray()
                 
                 // Use NewFileAgentInventory capability
-                val uploadCap = capabilityManager.getCapability("NewFileAgentInventory")
+                val uploadCap = capabilityManager.getCapability(CapabilityManager.CAP_NEW_FILE_AGENT_INVENTORY)
                 if (uploadCap == null) {
                     return@withContext UploadResult.Error("Upload capability not available")
                 }
@@ -212,7 +212,7 @@ class SnapshotManager(
                     this["expected_upload_cost"] = LLSDInteger(UPLOAD_COST)
                 }
                 
-                val response = capabilityManager.request("NewFileAgentInventory", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_NEW_FILE_AGENT_INVENTORY, request)
                 
                 if (response is LLSDMap) {
                     val uploaderUrl = response.getString("uploader")
@@ -278,14 +278,14 @@ class SnapshotManager(
                 
                 if (uploadResult is UploadResult.Success) {
                     // Then post to profile feed using ProfileImage capability
-                    val postCap = capabilityManager.getCapability("UploadAgentProfileImage")
+                    val postCap = capabilityManager.getCapability(CapabilityManager.CAP_UPLOAD_AGENT_PROFILE_IMAGE)
                     if (postCap != null) {
                         val request = LLSDMap().apply {
                             this["texture_id"] = LLSDUUID(uploadResult.assetId)
                             this["caption"] = LLSDString(caption)
                         }
                         
-                        capabilityManager.request("UploadAgentProfileImage", request)
+                        capabilityManager.request(CapabilityManager.CAP_UPLOAD_AGENT_PROFILE_IMAGE, request)
                         Log.i(TAG, "Snapshot shared to profile")
                         return@withContext true
                     }

--- a/Linkpoint/src/main/java/com/linkpoint/teleport/TeleportManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/teleport/TeleportManager.kt
@@ -328,7 +328,7 @@ class TeleportManager(
             }
             
             // TeleportLocation capability
-            val response = capabilityManager.request("TeleportLocation", request)
+            val response = capabilityManager.request(CapabilityManager.CAP_TELEPORT_LOCATION, request)
             
             if (response is LLSDMap) {
                 val success = response.getBoolean("success") ?: false

--- a/Linkpoint/src/main/java/com/linkpoint/world/SearchManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/world/SearchManager.kt
@@ -196,7 +196,7 @@ class SearchManager(
                     this["count"] = LLSDInteger(count)
                 }
                 
-                val response = capabilityManager.request("SearchLand", request)
+                val response = capabilityManager.request(CapabilityManager.CAP_SEARCH_LAND, request)
                 if (response != null) {
                     parseLandResults(response)
                 } else {

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/capabilities/CapabilityDeclarationAuditTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/capabilities/CapabilityDeclarationAuditTest.kt
@@ -1,0 +1,58 @@
+package com.linkpoint.protocol.capabilities
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CapabilityDeclarationAuditTest {
+
+    @Test
+    fun `capability constants must have callsite or explicit cap status annotation`() {
+        val repoRoot = locateRepoRoot()
+        val capabilityFile = File(repoRoot, "Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt")
+        val sourceText = capabilityFile.readText()
+        val lines = capabilityFile.readLines()
+
+        val constantRegex = Regex("""const\\s+val\\s+(CAP_[A-Z0-9_]+)\\s*=\\s*\"[^\"]+\"""")
+        val constants = constantRegex.findAll(sourceText).toList()
+
+        val sourceFiles = File(repoRoot, "Linkpoint/src/main/java/com/linkpoint")
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { it.absolutePath != capabilityFile.absolutePath }
+            .toList()
+
+        val orphans = mutableListOf<String>()
+
+        constants.forEach { match ->
+            val constantName = match.groupValues[1]
+            val hasCallsite = sourceFiles.any { it.readText().contains(constantName) }
+            if (hasCallsite) {
+                return@forEach
+            }
+
+            val declarationLine = sourceText.substring(0, match.range.first).count { it == '\n' }
+            val annotationWindowStart = (declarationLine - 3).coerceAtLeast(0)
+            val annotationWindow = lines.subList(annotationWindowStart, declarationLine)
+            val hasDeferredAnnotation = annotationWindow.any { it.contains("@cap-status") }
+
+            if (!hasDeferredAnnotation) {
+                orphans += constantName
+            }
+        }
+
+        assertTrue(
+            "Found CAP_* constants without callsites or @cap-status annotation: ${orphans.joinToString()}",
+            orphans.isEmpty()
+        )
+    }
+
+    private fun locateRepoRoot(): File {
+        var dir = File(System.getProperty("user.dir"))
+        repeat(6) {
+            if (File(dir, ".git").exists()) return dir
+            dir = dir.parentFile ?: return@repeat
+        }
+        return File(System.getProperty("user.dir"))
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure every `CAP_*` declaration in `CapabilityManager` either has a real callsite or an explicit de-scope annotation so capability names are actionable and not silently orphaned.
- Standardize capability usage by replacing string-literal capability calls in managers with typed `CapabilityManager.CAP_*` constants to avoid drift and typos.

### Description

- Removed unused `CAP_SEED` and added missing capability constants required by existing callsites (`CAP_TELEPORT_LOCATION`, `CAP_SEARCH_LAND`, `CAP_GET_SCRIPT_RUNNING`, `CAP_SET_SCRIPT_RUNNING`, `CAP_GET_SCRIPT_TASK_INFO`, `CAP_CREATE_INVENTORY_ITEM`, `CAP_NEW_FILE_AGENT_INVENTORY`, `CAP_UPLOAD_AGENT_PROFILE_IMAGE`, `CAP_UPLOAD_AGENT_BAKED_TEXTURE`) in `Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt`.
- Replaced string-literal capability invocations with constants across managers (teleport, search, scripts, landmark, snapshot, BoM, groups), e.g. use `CapabilityManager.CAP_TELEPORT_LOCATION`, `CAP_SEARCH_LAND`, `CAP_GET_SCRIPT_*`, `CAP_CREATE_INVENTORY_ITEM`, `CAP_NEW_FILE_AGENT_INVENTORY`, and `CAP_UPLOAD_AGENT_PROFILE_IMAGE` in their respective files.
- Marked declaration-only capabilities with structured de-scope metadata using `@cap-status deferred` (date + GitHub issue links and rationale) for capabilities intentionally not implemented in-app.
- Added a unit test `CapabilityDeclarationAuditTest` that scans `CapabilityManager` constants and fails if any `CAP_*` constant has neither an in-repo callsite nor an explicit `@cap-status` annotation (file: `Linkpoint/src/test/kotlin/com/linkpoint/protocol/capabilities/CapabilityDeclarationAuditTest.kt`).

### Testing

- Attempted to run the unit tests with `./gradlew :Linkpoint:testDebugUnitTest --tests com.linkpoint.protocol.capabilities.CapabilityDeclarationAuditTest --tests com.linkpoint.users.CapabilityManagersRequestShapeTest`, but the command failed in this environment because the Android SDK location is not configured (missing `ANDROID_HOME`/`local.properties`).
- Executed a local static verification script (Python) that parses `CapabilityManager` and searches repository sources and reported `orphans []`, confirming no `CAP_*` constants remain without a callsite or `@cap-status` annotation.
- Ran repository grep checks to confirm replacements of string-literal capability names with `CapabilityManager.CAP_*` constants across affected managers (all replacements present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabfbf19088323bce71dddb0e7a090)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a capability declaration audit system to prevent orphaned capability constants in `CapabilityManager`. It adds a unit test (`CapabilityDeclarationAuditTest`) that enforces every `CAP_*` constant must either have a callsite in the codebase or an explicit `@cap-status` annotation explaining why it's deferred. The PR also refactors string-literal capability names across multiple managers (teleport, search, scripts, landmarks, snapshots, BakesOnMesh, groups) to use typed `CapabilityManager.CAP_*` constants instead, improving type safety and preventing typos. Finally, it removes the unused `CAP_SEED` constant and adds missing constants for capabilities already being used in the codebase.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/capabilities/CapabilityDeclarationAuditTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/teleport/TeleportManager.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/world/SearchManager.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/assets/ScriptManager.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/inventory/LandmarkManager.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/snapshot/SnapshotManager.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/bom/BakesOnMeshManager.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/groups/GroupsManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->