### PR TITLE
Implement AISv3 inventory client/repository with UDP fallback and Room cache

### DIFF
--- a/Linkpoint/build.gradle.kts
+++ b/Linkpoint/build.gradle.kts
@@ -257,6 +257,10 @@ dependencies {
     // Preferences
     implementation("androidx.preference:preference-ktx:1.2.1")
 
+    // Room (inventory cache persistence)
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+
     // Background orchestration
     implementation("androidx.work:work-runtime-ktx:2.9.1")
     

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/AisClient.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/AisClient.kt
@@ -1,0 +1,257 @@
+package com.linkpoint.inventory
+
+import kotlinx.coroutines.delay
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.util.UUID
+import kotlin.math.min
+
+/**
+ * AISv3 HTTP client that supports CRUD operations with bounded exponential backoff.
+ */
+interface AisOperations {
+    suspend fun getSubtree(folderId: UUID): InventorySubtreeData
+    suspend fun getItem(itemId: UUID): InventoryItemData
+    suspend fun patchItem(itemId: UUID, patch: InventoryItemPatch)
+    suspend fun postFolder(request: CreateFolderRequest): UUID
+    suspend fun deleteNode(relativePath: String)
+}
+
+class AisClient(
+    private val endpointProvider: InventoryApiEndpointProvider,
+    private val transport: AisTransport = OkHttpAisTransport(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val baseDelayMs: Long = 150,
+    private val maxDelayMs: Long = 2_000,
+    private val maxServerRetries: Int = 3,
+    private val sleeper: suspend (Long) -> Unit = { delay(it) }
+) : AisOperations {
+
+    override suspend fun getSubtree(folderId: UUID): InventorySubtreeData {
+        val response = executeWithRetry("GET", "category/$folderId")
+        return json.decodeFromString(InventorySubtreePayload.serializer(), response.body).toDomain()
+    }
+
+    override suspend fun getItem(itemId: UUID): InventoryItemData {
+        val response = executeWithRetry("GET", "item/$itemId")
+        return json.decodeFromString(InventoryItemPayload.serializer(), response.body).toDomain()
+    }
+
+    override suspend fun patchItem(itemId: UUID, patch: InventoryItemPatch) {
+        executeWithRetry(
+            method = "PATCH",
+            relativePath = "item/$itemId",
+            body = json.encodeToString(InventoryItemPatch.serializer(), patch)
+        )
+    }
+
+    override suspend fun postFolder(request: CreateFolderRequest): UUID {
+        val response = executeWithRetry(
+            method = "POST",
+            relativePath = "category",
+            body = json.encodeToString(CreateFolderRequest.serializer(), request)
+        )
+        return UUID.fromString(
+            json.decodeFromString(CreateFolderResponse.serializer(), response.body).folderId
+        )
+    }
+
+    override suspend fun deleteNode(relativePath: String) {
+        executeWithRetry(method = "DELETE", relativePath = relativePath)
+    }
+
+    private suspend fun executeWithRetry(
+        method: String,
+        relativePath: String,
+        body: String? = null
+    ): AisHttpResponse {
+        var attempt = 0
+        var lastIOException: IOException? = null
+
+        while (attempt <= maxServerRetries) {
+            try {
+                val url = endpointProvider.getInventoryApiBaseUrl()?.trimEnd('/')
+                    ?: throw AisCapabilityUnavailableException("InventoryAPIv3 capability unavailable")
+                val response = transport.execute(
+                    AisHttpRequest(
+                        method = method,
+                        url = "$url/$relativePath",
+                        body = body
+                    )
+                )
+
+                when {
+                    response.code == 404 -> throw AisCapabilityUnavailableException("AIS endpoint returned 404")
+                    response.code in 200..299 -> return response
+                    response.code in 500..599 -> {
+                        if (attempt == maxServerRetries) {
+                            throw AisServerException(response.code, "AIS server error after retries")
+                        }
+                        val delayMs = min(maxDelayMs, baseDelayMs * (1L shl attempt))
+                        sleeper(delayMs)
+                    }
+                    else -> throw AisHttpException(response.code, "AIS request failed with HTTP ${response.code}")
+                }
+            } catch (io: IOException) {
+                lastIOException = io
+                if (attempt == maxServerRetries) {
+                    throw io
+                }
+                val delayMs = min(maxDelayMs, baseDelayMs * (1L shl attempt))
+                sleeper(delayMs)
+            }
+            attempt++
+        }
+
+        throw lastIOException ?: AisServerException(599, "AIS retries exhausted")
+    }
+}
+
+interface InventoryApiEndpointProvider {
+    fun getInventoryApiBaseUrl(): String?
+}
+
+interface AisTransport {
+    suspend fun execute(request: AisHttpRequest): AisHttpResponse
+}
+
+data class AisHttpRequest(
+    val method: String,
+    val url: String,
+    val body: String? = null
+)
+
+data class AisHttpResponse(
+    val code: Int,
+    val body: String
+)
+
+class OkHttpAisTransport(
+    private val client: OkHttpClient = OkHttpClient()
+) : AisTransport {
+    override suspend fun execute(request: AisHttpRequest): AisHttpResponse {
+        val builder = Request.Builder().url(request.url)
+        val requestBody = request.body?.toRequestBody("application/json".toMediaType())
+
+        when (request.method) {
+            "GET" -> builder.get()
+            "POST" -> builder.post(requestBody ?: "{}".toRequestBody("application/json".toMediaType()))
+            "PATCH" -> builder.patch(requestBody ?: "{}".toRequestBody("application/json".toMediaType()))
+            "DELETE" -> if (requestBody != null) builder.delete(requestBody) else builder.delete()
+            else -> throw IllegalArgumentException("Unsupported method ${request.method}")
+        }
+
+        client.newCall(builder.build()).execute().use { response ->
+            return AisHttpResponse(
+                code = response.code,
+                body = response.body?.string().orEmpty()
+            )
+        }
+    }
+}
+
+class AisCapabilityUnavailableException(message: String) : Exception(message)
+class AisServerException(val status: Int, message: String) : Exception(message)
+class AisHttpException(val status: Int, message: String) : Exception(message)
+
+@Serializable
+data class InventorySubtreePayload(
+    val folder: InventoryFolderPayload,
+    @SerialName("categories") val folders: List<InventoryFolderPayload> = emptyList(),
+    val items: List<InventoryItemPayload> = emptyList()
+)
+
+@Serializable
+data class InventoryFolderPayload(
+    @SerialName("folder_id") val folderId: String,
+    @SerialName("parent_id") val parentId: String,
+    val name: String,
+    val version: Int = 0,
+    val type: Int = -1
+)
+
+@Serializable
+data class InventoryItemPayload(
+    @SerialName("item_id") val itemId: String,
+    @SerialName("parent_id") val parentId: String,
+    val name: String,
+    @SerialName("asset_id") val assetId: String,
+    @SerialName("inv_type") val inventoryType: Int,
+    @SerialName("asset_type") val assetType: Int,
+    val version: Int = 0
+)
+
+@Serializable
+data class InventoryItemPatch(
+    val name: String? = null,
+    @SerialName("parent_id") val parentId: String? = null
+)
+
+@Serializable
+data class CreateFolderRequest(
+    @SerialName("parent_id") val parentId: String,
+    val name: String,
+    val type: Int = -1
+)
+
+@Serializable
+data class CreateFolderResponse(
+    @SerialName("folder_id") val folderId: String
+)
+
+data class InventorySubtreeData(
+    val folder: InventoryFolderData,
+    val folders: List<InventoryFolderData>,
+    val items: List<InventoryItemData>
+)
+
+data class InventoryFolderData(
+    val folderId: UUID,
+    val parentId: UUID,
+    val name: String,
+    val version: Int,
+    val type: Int
+)
+
+data class InventoryItemData(
+    val itemId: UUID,
+    val parentId: UUID,
+    val name: String,
+    val assetId: UUID,
+    val inventoryType: Int,
+    val assetType: Int,
+    val version: Int
+)
+
+private fun InventorySubtreePayload.toDomain(): InventorySubtreeData =
+    InventorySubtreeData(
+        folder = folder.toDomain(),
+        folders = folders.map { it.toDomain() },
+        items = items.map { it.toDomain() }
+    )
+
+private fun InventoryFolderPayload.toDomain(): InventoryFolderData =
+    InventoryFolderData(
+        folderId = UUID.fromString(folderId),
+        parentId = UUID.fromString(parentId),
+        name = name,
+        version = version,
+        type = type
+    )
+
+private fun InventoryItemPayload.toDomain(): InventoryItemData =
+    InventoryItemData(
+        itemId = UUID.fromString(itemId),
+        parentId = UUID.fromString(parentId),
+        name = name,
+        assetId = UUID.fromString(assetId),
+        inventoryType = inventoryType,
+        assetType = assetType,
+        version = version
+    )

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/InventoryRepository.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/InventoryRepository.kt
@@ -1,0 +1,177 @@
+package com.linkpoint.inventory
+
+import com.linkpoint.inventory.persistence.InventoryFolderDao
+import com.linkpoint.inventory.persistence.InventoryFolderEntity
+import com.linkpoint.inventory.persistence.InventoryFolderVersionDao
+import com.linkpoint.inventory.persistence.InventoryFolderVersionEntity
+import com.linkpoint.inventory.persistence.InventoryItemDao
+import com.linkpoint.inventory.persistence.InventoryItemEntity
+import java.util.UUID
+
+/**
+ * Inventory repository with AISv3 primary path and UDP fallback.
+ */
+class InventoryRepository(
+    private val aisClient: AisOperations,
+    private val folderDao: InventoryFolderDao,
+    private val itemDao: InventoryItemDao,
+    private val folderVersionDao: InventoryFolderVersionDao,
+    private val udpFallback: UdpInventoryDataSource
+) {
+
+    suspend fun getSubtree(folderId: UUID, knownFolderVersion: Int? = null): InventorySubtreeData {
+        val cachedVersion = folderVersionDao.getVersion(folderId.toString())?.version
+        val hasCache = folderDao.getFolder(folderId.toString()) != null
+
+        if (hasCache && (knownFolderVersion == null || knownFolderVersion == cachedVersion)) {
+            return cachedSubtree(folderId)
+        }
+
+        val remote = try {
+            aisClient.getSubtree(folderId)
+        } catch (_: AisCapabilityUnavailableException) {
+            udpFallback.fetchInventoryDescendents2(folderId)
+        }
+
+        persistSubtree(remote)
+        return remote
+    }
+
+    suspend fun getItem(itemId: UUID, parentFolderIdForFallback: UUID): InventoryItemData? {
+        val cached = itemDao.getItem(itemId.toString())?.toDomain()
+        if (cached != null) return cached
+
+        val remote = try {
+            aisClient.getItem(itemId)
+        } catch (_: AisCapabilityUnavailableException) {
+            val subtree = udpFallback.fetchInventoryDescendents2(parentFolderIdForFallback)
+            subtree.items.firstOrNull { it.itemId == itemId } ?: return null
+        }
+
+        itemDao.upsert(remote.toEntity())
+        return remote
+    }
+
+    suspend fun patchItem(itemId: UUID, patch: InventoryItemPatch): Boolean {
+        aisClient.patchItem(itemId, patch)
+        val existing = itemDao.getItem(itemId.toString()) ?: return true
+        itemDao.upsert(
+            existing.copy(
+                name = patch.name ?: existing.name,
+                parentId = patch.parentId ?: existing.parentId,
+                updatedAtEpochMs = System.currentTimeMillis()
+            )
+        )
+        return true
+    }
+
+    suspend fun createFolder(parentId: UUID, name: String, type: Int = -1): UUID {
+        val createdId = aisClient.postFolder(CreateFolderRequest(parentId.toString(), name, type))
+        folderDao.upsert(
+            InventoryFolderEntity(
+                folderId = createdId.toString(),
+                parentId = parentId.toString(),
+                name = name,
+                type = type,
+                version = 0,
+                updatedAtEpochMs = System.currentTimeMillis()
+            )
+        )
+        return createdId
+    }
+
+    suspend fun deleteItem(itemId: UUID): Boolean {
+        aisClient.deleteNode("item/$itemId")
+        itemDao.delete(itemId.toString())
+        return true
+    }
+
+    suspend fun deleteFolder(folderId: UUID): Boolean {
+        aisClient.deleteNode("category/$folderId")
+        folderDao.delete(folderId.toString())
+        folderVersionDao.delete(folderId.toString())
+        return true
+    }
+
+    private suspend fun persistSubtree(subtree: InventorySubtreeData) {
+        val now = System.currentTimeMillis()
+        folderDao.upsert(
+            InventoryFolderEntity(
+                folderId = subtree.folder.folderId.toString(),
+                parentId = subtree.folder.parentId.toString(),
+                name = subtree.folder.name,
+                type = subtree.folder.type,
+                version = subtree.folder.version,
+                updatedAtEpochMs = now
+            )
+        )
+        folderDao.deleteChildrenOfParent(subtree.folder.folderId.toString())
+        itemDao.deleteByParentId(subtree.folder.folderId.toString())
+
+        folderDao.upsertAll(
+            subtree.folders.map {
+                InventoryFolderEntity(
+                    folderId = it.folderId.toString(),
+                    parentId = it.parentId.toString(),
+                    name = it.name,
+                    type = it.type,
+                    version = it.version,
+                    updatedAtEpochMs = now
+                )
+            }
+        )
+        itemDao.upsertAll(subtree.items.map { it.toEntity(now) })
+        folderVersionDao.upsert(
+            InventoryFolderVersionEntity(
+                folderId = subtree.folder.folderId.toString(),
+                version = subtree.folder.version,
+                updatedAtEpochMs = now
+            )
+        )
+    }
+
+    private suspend fun cachedSubtree(folderId: UUID): InventorySubtreeData {
+        val folder = requireNotNull(folderDao.getFolder(folderId.toString()))
+        return InventorySubtreeData(
+            folder = folder.toDomain(),
+            folders = folderDao.getFoldersByParent(folderId.toString()).map { it.toDomain() },
+            items = itemDao.getItemsByParent(folderId.toString()).map { it.toDomain() }
+        )
+    }
+}
+
+interface UdpInventoryDataSource {
+    suspend fun fetchInventoryDescendents2(folderId: UUID): InventorySubtreeData
+}
+
+private fun InventoryFolderEntity.toDomain(): InventoryFolderData =
+    InventoryFolderData(
+        folderId = UUID.fromString(folderId),
+        parentId = UUID.fromString(parentId),
+        name = name,
+        version = version,
+        type = type
+    )
+
+private fun InventoryItemEntity.toDomain(): InventoryItemData =
+    InventoryItemData(
+        itemId = UUID.fromString(itemId),
+        parentId = UUID.fromString(parentId),
+        name = name,
+        assetId = UUID.fromString(assetId),
+        inventoryType = inventoryType,
+        assetType = assetType,
+        version = version
+    )
+
+private fun InventoryItemData.toEntity(now: Long = System.currentTimeMillis()): InventoryItemEntity =
+    InventoryItemEntity(
+        itemId = itemId.toString(),
+        parentId = parentId.toString(),
+        name = name,
+        assetId = assetId.toString(),
+        inventoryType = inventoryType,
+        assetType = assetType,
+        version = version,
+        updatedAtEpochMs = now
+    )

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryDao.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryDao.kt
@@ -1,0 +1,60 @@
+package com.linkpoint.inventory.persistence
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface InventoryFolderDao {
+    @Query("SELECT * FROM inventory_folders WHERE folderId = :folderId LIMIT 1")
+    suspend fun getFolder(folderId: String): InventoryFolderEntity?
+
+    @Query("SELECT * FROM inventory_folders WHERE parentId = :parentId")
+    suspend fun getFoldersByParent(parentId: String): List<InventoryFolderEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: InventoryFolderEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entities: List<InventoryFolderEntity>)
+
+    @Query("DELETE FROM inventory_folders WHERE folderId = :folderId")
+    suspend fun delete(folderId: String)
+
+    @Query("DELETE FROM inventory_folders WHERE parentId = :parentId")
+    suspend fun deleteChildrenOfParent(parentId: String)
+}
+
+@Dao
+interface InventoryItemDao {
+    @Query("SELECT * FROM inventory_items WHERE itemId = :itemId LIMIT 1")
+    suspend fun getItem(itemId: String): InventoryItemEntity?
+
+    @Query("SELECT * FROM inventory_items WHERE parentId = :parentId")
+    suspend fun getItemsByParent(parentId: String): List<InventoryItemEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: InventoryItemEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entities: List<InventoryItemEntity>)
+
+    @Query("DELETE FROM inventory_items WHERE itemId = :itemId")
+    suspend fun delete(itemId: String)
+
+    @Query("DELETE FROM inventory_items WHERE parentId = :parentId")
+    suspend fun deleteByParentId(parentId: String)
+}
+
+@Dao
+interface InventoryFolderVersionDao {
+    @Query("SELECT * FROM inventory_folder_versions WHERE folderId = :folderId LIMIT 1")
+    suspend fun getVersion(folderId: String): InventoryFolderVersionEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: InventoryFolderVersionEntity)
+
+    @Query("DELETE FROM inventory_folder_versions WHERE folderId = :folderId")
+    suspend fun delete(folderId: String)
+}

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryDatabase.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryDatabase.kt
@@ -1,0 +1,19 @@
+package com.linkpoint.inventory.persistence
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [
+        InventoryFolderEntity::class,
+        InventoryItemEntity::class,
+        InventoryFolderVersionEntity::class
+    ],
+    version = 1,
+    exportSchema = false
+)
+abstract class InventoryDatabase : RoomDatabase() {
+    abstract fun inventoryFolderDao(): InventoryFolderDao
+    abstract fun inventoryItemDao(): InventoryItemDao
+    abstract fun inventoryFolderVersionDao(): InventoryFolderVersionDao
+}

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryEntities.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryEntities.kt
@@ -1,0 +1,33 @@
+package com.linkpoint.inventory.persistence
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "inventory_folders")
+data class InventoryFolderEntity(
+    @PrimaryKey val folderId: String,
+    val parentId: String,
+    val name: String,
+    val type: Int,
+    val version: Int,
+    val updatedAtEpochMs: Long
+)
+
+@Entity(tableName = "inventory_items")
+data class InventoryItemEntity(
+    @PrimaryKey val itemId: String,
+    val parentId: String,
+    val name: String,
+    val assetId: String,
+    val inventoryType: Int,
+    val assetType: Int,
+    val version: Int,
+    val updatedAtEpochMs: Long
+)
+
+@Entity(tableName = "inventory_folder_versions")
+data class InventoryFolderVersionEntity(
+    @PrimaryKey val folderId: String,
+    val version: Int,
+    val updatedAtEpochMs: Long
+)

--- a/Linkpoint/src/test/kotlin/com/linkpoint/inventory/AisClientTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/inventory/AisClientTest.kt
@@ -1,0 +1,66 @@
+package com.linkpoint.inventory
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+class AisClientTest {
+
+    @Test
+    fun `retries on 5xx with bounded exponential backoff`() = runBlocking {
+        val responses = ArrayDeque(
+            listOf(
+                AisHttpResponse(503, ""),
+                AisHttpResponse(502, ""),
+                AisHttpResponse(
+                    200,
+                    """
+                    {"folder":{"folder_id":"00000000-0000-0000-0000-000000000001","parent_id":"00000000-0000-0000-0000-000000000000","name":"Root","version":4,"type":9},"categories":[],"items":[]}
+                    """.trimIndent()
+                )
+            )
+        )
+        val recordedDelays = mutableListOf<Long>()
+
+        val client = AisClient(
+            endpointProvider = object : InventoryApiEndpointProvider {
+                override fun getInventoryApiBaseUrl(): String = "https://example.test/ais"
+            },
+            transport = object : AisTransport {
+                override suspend fun execute(request: AisHttpRequest): AisHttpResponse = responses.removeFirst()
+            },
+            baseDelayMs = 100,
+            maxDelayMs = 150,
+            maxServerRetries = 4,
+            sleeper = { recordedDelays += it }
+        )
+
+        val subtree = client.getSubtree(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+
+        assertEquals(4, subtree.folder.version)
+        assertEquals(listOf(100L, 150L), recordedDelays)
+    }
+
+    @Test
+    fun `404 raises capability unavailable`() = runBlocking {
+        val client = AisClient(
+            endpointProvider = object : InventoryApiEndpointProvider {
+                override fun getInventoryApiBaseUrl(): String = "https://example.test/ais"
+            },
+            transport = object : AisTransport {
+                override suspend fun execute(request: AisHttpRequest): AisHttpResponse = AisHttpResponse(404, "")
+            }
+        )
+
+        var raised = false
+        try {
+            client.getSubtree(UUID.randomUUID())
+        } catch (e: AisCapabilityUnavailableException) {
+            raised = true
+        }
+
+        assertTrue(raised)
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/inventory/InventoryRepositoryTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/inventory/InventoryRepositoryTest.kt
@@ -1,0 +1,193 @@
+package com.linkpoint.inventory
+
+import com.linkpoint.inventory.persistence.InventoryFolderDao
+import com.linkpoint.inventory.persistence.InventoryFolderEntity
+import com.linkpoint.inventory.persistence.InventoryFolderVersionDao
+import com.linkpoint.inventory.persistence.InventoryFolderVersionEntity
+import com.linkpoint.inventory.persistence.InventoryItemDao
+import com.linkpoint.inventory.persistence.InventoryItemEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.util.UUID
+
+class InventoryRepositoryTest {
+
+    @Test
+    fun `cold cache fetches from AIS and persists subtree`() = runBlocking {
+        val fixture = subtreeFixture(version = 3)
+        val ais = RecordingAisClient(fixture)
+        val repo = createRepository(aisClient = ais)
+
+        val result = repo.getSubtree(fixture.folder.folderId, knownFolderVersion = 3)
+
+        assertEquals(1, ais.subtreeRequests)
+        assertEquals(3, result.folder.version)
+        assertEquals(1, result.items.size)
+    }
+
+    @Test
+    fun `warm cache with matching version avoids network`() = runBlocking {
+        val fixture = subtreeFixture(version = 5)
+        val ais = RecordingAisClient(fixture)
+        val repo = createRepository(aisClient = ais)
+        repo.getSubtree(fixture.folder.folderId, knownFolderVersion = 5)
+
+        ais.subtreeRequests = 0
+        val cached = repo.getSubtree(fixture.folder.folderId, knownFolderVersion = 5)
+
+        assertEquals(0, ais.subtreeRequests)
+        assertEquals(5, cached.folder.version)
+    }
+
+    @Test
+    fun `version mismatch invalidates warm cache and refetches`() = runBlocking {
+        val oldFixture = subtreeFixture(version = 1)
+        val newFixture = subtreeFixture(version = 2)
+        val ais = RecordingAisClient(oldFixture)
+        val repo = createRepository(aisClient = ais)
+        repo.getSubtree(oldFixture.folder.folderId, knownFolderVersion = 1)
+
+        ais.fixture = newFixture
+        ais.subtreeRequests = 0
+        val refreshed = repo.getSubtree(oldFixture.folder.folderId, knownFolderVersion = 2)
+
+        assertEquals(1, ais.subtreeRequests)
+        assertEquals(2, refreshed.folder.version)
+    }
+
+    @Test
+    fun `404 from AIS falls back to UDP FetchInventoryDescendents2`() = runBlocking {
+        val folderId = UUID.randomUUID()
+        val fallbackFixture = subtreeFixture(folderId = folderId, version = 7)
+        val ais = RecordingAisClient(fallbackFixture, throwCapabilityUnavailable = true)
+        val udp = RecordingUdpSource(fallbackFixture)
+        val repo = createRepository(aisClient = ais, udpSource = udp)
+
+        val result = repo.getSubtree(folderId, knownFolderVersion = 7)
+
+        assertEquals(1, udp.fetchCalls)
+        assertEquals(7, result.folder.version)
+        val cachedItem = repo.getItem(result.items.first().itemId, folderId)
+        assertNotNull(cachedItem)
+    }
+
+    private fun createRepository(
+        aisClient: RecordingAisClient,
+        udpSource: RecordingUdpSource = RecordingUdpSource(subtreeFixture())
+    ): InventoryRepository {
+        return InventoryRepository(
+            aisClient = aisClient,
+            folderDao = InMemoryFolderDao(),
+            itemDao = InMemoryItemDao(),
+            folderVersionDao = InMemoryFolderVersionDao(),
+            udpFallback = udpSource
+        )
+    }
+
+    private fun subtreeFixture(folderId: UUID = UUID.randomUUID(), version: Int = 1): InventorySubtreeData {
+        val childFolderId = UUID.randomUUID()
+        val itemId = UUID.randomUUID()
+        return InventorySubtreeData(
+            folder = InventoryFolderData(folderId, UUID(0L, 0L), "Root", version, 9),
+            folders = listOf(InventoryFolderData(childFolderId, folderId, "Clothes", 1, 5)),
+            items = listOf(InventoryItemData(itemId, folderId, "Shirt", UUID.randomUUID(), 18, 5, version))
+        )
+    }
+}
+
+private class RecordingAisClient(
+    var fixture: InventorySubtreeData,
+    private val throwCapabilityUnavailable: Boolean = false
+) : AisOperations {
+    var subtreeRequests: Int = 0
+
+    override suspend fun getSubtree(folderId: UUID): InventorySubtreeData {
+        subtreeRequests++
+        if (throwCapabilityUnavailable) throw AisCapabilityUnavailableException("404")
+        return fixture
+    }
+
+    override suspend fun getItem(itemId: UUID): InventoryItemData {
+        return fixture.items.first { it.itemId == itemId }
+    }
+
+    override suspend fun patchItem(itemId: UUID, patch: InventoryItemPatch) = Unit
+
+    override suspend fun postFolder(request: CreateFolderRequest): UUID = UUID.randomUUID()
+
+    override suspend fun deleteNode(relativePath: String) = Unit
+}
+
+private class RecordingUdpSource(private val fixture: InventorySubtreeData) : UdpInventoryDataSource {
+    var fetchCalls: Int = 0
+    override suspend fun fetchInventoryDescendents2(folderId: UUID): InventorySubtreeData {
+        fetchCalls++
+        return fixture
+    }
+}
+
+private class InMemoryFolderDao : InventoryFolderDao {
+    private val folders = linkedMapOf<String, InventoryFolderEntity>()
+
+    override suspend fun getFolder(folderId: String): InventoryFolderEntity? = folders[folderId]
+    override suspend fun getFoldersByParent(parentId: String): List<InventoryFolderEntity> =
+        folders.values.filter { it.parentId == parentId }
+
+    override suspend fun upsert(entity: InventoryFolderEntity) {
+        folders[entity.folderId] = entity
+    }
+
+    override suspend fun upsertAll(entities: List<InventoryFolderEntity>) {
+        entities.forEach { upsert(it) }
+    }
+
+    override suspend fun delete(folderId: String) {
+        folders.remove(folderId)
+    }
+
+    override suspend fun deleteChildrenOfParent(parentId: String) {
+        val keys = folders.values.filter { it.parentId == parentId }.map { it.folderId }
+        keys.forEach { folders.remove(it) }
+    }
+}
+
+private class InMemoryItemDao : InventoryItemDao {
+    private val items = linkedMapOf<String, InventoryItemEntity>()
+
+    override suspend fun getItem(itemId: String): InventoryItemEntity? = items[itemId]
+    override suspend fun getItemsByParent(parentId: String): List<InventoryItemEntity> =
+        items.values.filter { it.parentId == parentId }
+
+    override suspend fun upsert(entity: InventoryItemEntity) {
+        items[entity.itemId] = entity
+    }
+
+    override suspend fun upsertAll(entities: List<InventoryItemEntity>) {
+        entities.forEach { upsert(it) }
+    }
+
+    override suspend fun delete(itemId: String) {
+        items.remove(itemId)
+    }
+
+    override suspend fun deleteByParentId(parentId: String) {
+        val keys = items.values.filter { it.parentId == parentId }.map { it.itemId }
+        keys.forEach { items.remove(it) }
+    }
+}
+
+private class InMemoryFolderVersionDao : InventoryFolderVersionDao {
+    private val versions = mutableMapOf<String, InventoryFolderVersionEntity>()
+
+    override suspend fun getVersion(folderId: String): InventoryFolderVersionEntity? = versions[folderId]
+
+    override suspend fun upsert(entity: InventoryFolderVersionEntity) {
+        versions[entity.folderId] = entity
+    }
+
+    override suspend fun delete(folderId: String) {
+        versions.remove(folderId)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a capability-backed AIS v3 path for inventory operations while preserving UDP fallback for grids that lack or return errors from AIS. 
- Add persistent, version-aware caching for inventory subtrees so warm-cache reads avoid unnecessary network traffic. 
- Ensure robust network behavior for AIS v3 with bounded exponential backoff on server errors and explicit 404 signaling to trigger UDP fallback.

### Description
- Add `AisClient` (implements `AisOperations`) providing GET subtree/item, `PATCH`/`POST`/`DELETE` mutations, bounded exponential backoff for 5xx/IO failures, and throws `AisCapabilityUnavailableException` on HTTP `404` to signal capability failure. (`src/main/java/com/linkpoint/inventory/AisClient.kt`)
- Add `InventoryRepository` that prefers warm-cache when folder versions match, invalidates and refreshes on version mismatch, persists inventory subtree into Room, and falls back to UDP `FetchInventoryDescendents2` when AIS is unavailable. (`src/main/java/com/linkpoint/inventory/InventoryRepository.kt`)
- Add Room persistence primitives for inventory caching and version tracking: `InventoryFolderEntity`, `InventoryItemEntity`, `InventoryFolderVersionEntity`, DAOs, and `InventoryDatabase`. (`src/main/java/com/linkpoint/inventory/persistence/*`)
- Add unit tests that validate AIS backoff behavior, HTTP 404 capability-failure handling, cold-cache/warm-cache/version invalidation behavior, and the UDP fallback path; and add Room runtime dependencies in `build.gradle.kts`.

### Testing
- Added targeted unit tests `AisClientTest` and `InventoryRepositoryTest` covering AIS retry/backoff, 404 handling, cold-cache persistence, warm-cache hit, version-aware invalidation, and UDP fallback (files: `src/test/kotlin/com/linkpoint/inventory/AisClientTest.kt`, `src/test/kotlin/com/linkpoint/inventory/InventoryRepositoryTest.kt`).
- Attempted to run the tests via Gradle (`testStableDebugUnitTest` for the targeted tests) in this environment, but test execution did not complete because the project build encountered unrelated pre-existing compile errors in other modules, so the new tests were not able to be executed to completion here.
- The AIS client unit tests are designed to run offline (use injected `AisTransport` stubs) and should pass once the overall project compiles successfully in a CI or developer environment with Android SDK configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabfc1a9908323bc9d34a5ead0e9c4)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces an **AISv3 inventory client** with intelligent UDP fallback and Room-based persistent caching for inventory data. The implementation adds `AisClient` with bounded exponential backoff for network resilience, `InventoryRepository` that uses version-aware caching to minimize network traffic (warm-cache reads when folder versions match, invalidation and refresh on version mismatch), and Room database persistence primitives (`InventoryFolderEntity`, `InventoryItemEntity`, DAOs, and database definition). When the AIS capability is unavailable (HTTP 404 or endpoint missing), the repository automatically falls back to the legacy UDP `FetchInventoryDescendents2` protocol. Comprehensive unit tests validate the retry logic, capability-failure handling, caching behavior, and fallback mechanisms.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/build.gradle.kts` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryEntities.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryDao.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/inventory/persistence/InventoryDatabase.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/inventory/AisClient.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/inventory/InventoryRepository.kt` |
| 7 | `Linkpoint/src/test/kotlin/com/linkpoint/inventory/AisClientTest.kt` |
| 8 | `Linkpoint/src/test/kotlin/com/linkpoint/inventory/InventoryRepositoryTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->