### PR TITLE
Complete HUD pass routing with viewport-aware HUD render queue

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
@@ -108,6 +108,7 @@ class LumiyaRenderer : RenderEngineProvider {
 
             ctx.updateCamera()
             rebuildHudMatrices(width, height)
+            hudStore.setViewportSize(width, height)
 
             isInitialized = true
             Log.i(TAG, "Lumiya renderer initialised  (GPU: ${ctx.gpuRenderer})")
@@ -125,6 +126,7 @@ class LumiyaRenderer : RenderEngineProvider {
         GLES32.glViewport(0, 0, width, height)
         if (ctx.fxaaEnabled) ctx.createFXAAFramebuffer(width, height)
         rebuildHudMatrices(width, height)
+        hudStore.setViewportSize(width, height)
     }
 
     override fun onSurfaceDestroyed() {
@@ -326,10 +328,11 @@ class LumiyaRenderer : RenderEngineProvider {
         posZ: Float,
         layer: Int = 0
     ) {
-        if (AttachmentPoints.isHudPoint(attachmentPoint)) {
+        val normalizedAttachmentPoint = normalizeAttachmentPoint(attachmentPoint)
+        if (AttachmentPoints.isHudPoint(normalizedAttachmentPoint)) {
             hudStore.addHudPrim(
                 id = id,
-                attachmentPoint = attachmentPoint,
+                attachmentPoint = normalizedAttachmentPoint,
                 posX = posX,
                 posY = posY,
                 posZ = posZ,
@@ -379,5 +382,10 @@ class LumiyaRenderer : RenderEngineProvider {
             -1f,
             1f
         )
+    }
+
+    private fun normalizeAttachmentPoint(attachmentPoint: Int): Int {
+        // Attachment points on the wire may carry APPEND flag in the upper bit (0x80).
+        return attachmentPoint and 0x7F
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt
@@ -10,18 +10,31 @@ import com.linkpoint.render.lumiya.core.LumiyaRenderContext
  * HUD entities are sorted deterministically by layer, attachment point and id.
  */
 class DrawableHudStore {
+    companion object {
+        private const val DEFAULT_VIEWPORT_WIDTH = 1
+        private const val DEFAULT_VIEWPORT_HEIGHT = 1
+        private const val LAYER_Z_STEP = 0.001f
+        private const val ITEM_Z_STEP = 0.00001f
+    }
 
     data class HudPrimInstance(
         val id: Long,
         val attachmentPoint: Int,
         var layer: Int,
+        var offsetX: Float,
+        var offsetY: Float,
+        var offsetZ: Float,
         val modelMatrix: FloatArray = FloatArray(16).also { Matrix.setIdentityM(it, 0) },
         val texMatrix: FloatArray = FloatArray(16).also { Matrix.setIdentityM(it, 0) },
         var colorR: Float = 1f, var colorG: Float = 1f, var colorB: Float = 1f, var colorA: Float = 1f,
-        var textureHandle: Int = 0
+        var textureHandle: Int = 0,
+        var screenX: Float = 0f,
+        var screenY: Float = 0f
     )
 
     private val hudPrims = linkedMapOf<Long, HudPrimInstance>()
+    private var viewportWidth: Int = DEFAULT_VIEWPORT_WIDTH
+    private var viewportHeight: Int = DEFAULT_VIEWPORT_HEIGHT
 
     fun addHudPrim(
         id: Long,
@@ -31,9 +44,17 @@ class DrawableHudStore {
         posZ: Float,
         layer: Int
     ) {
-        val instance = HudPrimInstance(id = id, attachmentPoint = attachmentPoint, layer = layer)
-        Matrix.translateM(instance.modelMatrix, 0, posX, posY, posZ)
+        val instance = HudPrimInstance(
+            id = id,
+            attachmentPoint = attachmentPoint,
+            layer = layer,
+            offsetX = posX,
+            offsetY = posY,
+            offsetZ = posZ
+        )
+        updateModelMatrix(instance, zOrder = 0)
         hudPrims[id] = instance
+        updateHudLayout()
     }
 
     fun removeHudPrim(id: Long) {
@@ -47,6 +68,14 @@ class DrawableHudStore {
     fun destroy() = hudPrims.clear()
 
     internal fun debugSortedIds(): List<Long> = sortedHudPrims().map { it.id }
+    internal fun debugScreenPosition(id: Long): Pair<Float, Float>? = hudPrims[id]?.let { it.screenX to it.screenY }
+    internal fun debugModelZ(id: Long): Float? = hudPrims[id]?.modelMatrix?.get(14)
+
+    fun setViewportSize(width: Int, height: Int) {
+        viewportWidth = width.coerceAtLeast(1)
+        viewportHeight = height.coerceAtLeast(1)
+        updateHudLayout()
+    }
 
     fun draw(ctx: LumiyaRenderContext) {
         val program = ctx.primProgram ?: return
@@ -56,7 +85,7 @@ class DrawableHudStore {
         program.setLighting(0f, 0f, 1f, 1f, 1f, 1f, 1f, 1f, 1f)
 
         GLES32.glBindVertexArray(boxVao.vao)
-        sortedHudPrims().forEach { hud ->
+        buildRenderQueue().forEach { hud ->
             program.setModelMatrix(hud.modelMatrix)
             program.setTexMatrix(hud.texMatrix)
             program.setColor(hud.colorR, hud.colorG, hud.colorB, hud.colorA)
@@ -71,11 +100,51 @@ class DrawableHudStore {
         GLES32.glBindVertexArray(0)
     }
 
+    private fun buildRenderQueue(): List<HudPrimInstance> = sortedHudPrims()
+
     private fun sortedHudPrims(): List<HudPrimInstance> {
         return hudPrims.values.sortedWith(
             compareBy<HudPrimInstance> { it.layer }
                 .thenBy { it.attachmentPoint }
                 .thenBy { it.id }
         )
+    }
+
+    private fun updateHudLayout() {
+        buildRenderQueue().forEachIndexed { index, hud ->
+            updateModelMatrix(hud, index)
+        }
+    }
+
+    private fun updateModelMatrix(hud: HudPrimInstance, zOrder: Int) {
+        val (anchorX, anchorY) = hudAnchor(attachmentPoint = hud.attachmentPoint)
+        val baseX = anchorX * viewportWidth
+        val baseY = anchorY * viewportHeight
+        val zBias = (hud.layer * LAYER_Z_STEP) + (zOrder * ITEM_Z_STEP)
+
+        hud.screenX = baseX + hud.offsetX
+        hud.screenY = baseY + hud.offsetY
+        Matrix.setIdentityM(hud.modelMatrix, 0)
+        Matrix.translateM(
+            hud.modelMatrix,
+            0,
+            hud.screenX,
+            hud.screenY,
+            hud.offsetZ + zBias
+        )
+    }
+
+    private fun hudAnchor(attachmentPoint: Int): Pair<Float, Float> {
+        return when (attachmentPoint) {
+            34 -> 0.05f to 0.05f // ATTACH_HUD_TOP_LEFT
+            33 -> 0.5f to 0.05f // ATTACH_HUD_TOP_CENTER
+            32 -> 0.95f to 0.05f // ATTACH_HUD_TOP_RIGHT
+            35 -> 0.5f to 0.5f // ATTACH_HUD_CENTER_1
+            31 -> 0.5f to 0.6f // ATTACH_HUD_CENTER_2
+            36 -> 0.05f to 0.95f // ATTACH_HUD_BOTTOM_LEFT
+            37 -> 0.5f to 0.95f // ATTACH_HUD_BOTTOM
+            38 -> 0.95f to 0.95f // ATTACH_HUD_BOTTOM_RIGHT
+            else -> 0.5f to 0.5f
+        }
     }
 }

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt
@@ -2,6 +2,7 @@ package com.linkpoint.render.lumiya.core
 
 import com.linkpoint.render.lumiya.drawable.DrawableHudStore
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -25,5 +26,56 @@ class LumiyaFramePlannerTest {
 
         assertEquals(listOf(3L, 4L, 7L), store.debugSortedIds())
         assertTrue(store.hasElements())
+    }
+
+    @Test
+    fun `hud layout follows viewport changes for resize and orientation`() {
+        val store = DrawableHudStore()
+        store.setViewportSize(width = 1000, height = 500)
+        store.addHudPrim(id = 9L, attachmentPoint = 32, posX = 0f, posY = 0f, posZ = 0f, layer = 0)
+
+        val landscapePosition = store.debugScreenPosition(9L)
+        assertEquals(950f, landscapePosition?.first ?: -1f, 0.01f)
+        assertEquals(25f, landscapePosition?.second ?: -1f, 0.01f)
+
+        store.setViewportSize(width = 500, height = 1000)
+        val portraitPosition = store.debugScreenPosition(9L)
+        assertEquals(475f, portraitPosition?.first ?: -1f, 0.01f)
+        assertEquals(50f, portraitPosition?.second ?: -1f, 0.01f)
+    }
+
+    @Test
+    fun `hud z-order is deterministic for overlapping elements`() {
+        val store = DrawableHudStore()
+        store.setViewportSize(width = 800, height = 600)
+        store.addHudPrim(id = 3L, attachmentPoint = 31, posX = 0f, posY = 0f, posZ = 0f, layer = 1)
+        store.addHudPrim(id = 4L, attachmentPoint = 31, posX = 0f, posY = 0f, posZ = 0f, layer = 1)
+
+        val firstZ = store.debugModelZ(3L) ?: 0f
+        val secondZ = store.debugModelZ(4L) ?: 0f
+        assertTrue("Second HUD should render above first HUD", secondZ > firstZ)
+    }
+
+    @Test
+    fun `attachment point append flag still routes to HUD pipeline`() {
+        val renderer = LumiyaRenderer()
+        renderer.addAttachmentObject(
+            id = 123L,
+            attachmentPoint = 32 or 0x80,
+            posX = 0f,
+            posY = 0f,
+            posZ = 0f,
+            layer = 0
+        )
+
+        val hudStoreField = LumiyaRenderer::class.java.getDeclaredField("hudStore").apply { isAccessible = true }
+        val hudStore = hudStoreField.get(renderer) as DrawableHudStore
+        assertEquals(listOf(123L), hudStore.debugSortedIds())
+
+        val primStoreField = LumiyaRenderer::class.java.getDeclaredField("primStore").apply { isAccessible = true }
+        val primStore = primStoreField.get(renderer)
+        val primsField = primStore.javaClass.getDeclaredField("prims").apply { isAccessible = true }
+        val prims = primsField.get(primStore) as Map<*, *>
+        assertFalse(prims.containsKey(123L))
     }
 }


### PR DESCRIPTION
### Motivation
- HUD attachments must be rendered in screen-space (not in world-depth) and layered deterministically, and the renderer previously lacked a dedicated HUD pass and deterministic z-bias for overlapping HUD elements.
- Attachment IDs coming over the wire may include append flags (upper bit) and must still route to the HUD pipeline.
- HUD anchoring must remain stable across surface resizes and orientation changes so HUDs remain at predictable screen positions.

### Description
- Add attachment normalization and routing in `LumiyaRenderer` so append-flagged attachment points are masked and HUD points are dispatched to the HUD pipeline, and bind HUD viewport updates on initialization and `onSurfaceChanged` by calling `hudStore.setViewportSize(width, height)`; also add `normalizeAttachmentPoint` helper. (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt`).
- Implement a viewport-aware `DrawableHudStore` that stores per-prim offsets, computes screen-space anchors, maintains `screenX`/`screenY`, updates a model matrix with an explicit z-bias computed from `layer` + stable queue index, and exposes debug helpers for sorted ids, screen positions and model Z. (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt`).
- Ensure HUD draw order is deterministic by preserving the sort key (`layer`, `attachmentPoint`, `id`) and using a render queue that applies z-bias so overlapping HUD elements render in a stable order.
- Add unit/harness checks to `LumiyaFramePlannerTest` that verify HUD ordering, viewport relayout on resize/orientation changes, deterministic z-ordering for overlapping HUDs, and routing of append-flagged attachment points into the HUD pipeline. (`Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt`).

### Testing
- Added unit tests in `com.linkpoint.render.lumiya.core.LumiyaFramePlannerTest` covering deterministic HUD ordering, HUD layout following viewport changes, HUD z-order determinism, and append-flag routing to the HUD pipeline. (`Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt`).
- Attempted to run the focused unit test with `./gradlew :Linkpoint:testDebugUnitTest --tests com.linkpoint.render.lumiya.core.LumiyaFramePlannerTest`, but the build failed in this environment due to missing Android SDK configuration (no `ANDROID_HOME` and no `sdk.dir` in `Linkpoint/local.properties`).
- No other automated tests were executed in this environment due to the same SDK/local properties constraint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabfc8eb8c83239571ee40610ad9cc)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a complete HUD rendering pipeline that ensures HUD elements are rendered in screen-space with deterministic layering and stable positioning across viewport changes. The changes introduce attachment point normalization to handle append flags from the wire protocol, route HUD attachments to a dedicated HUD store, implement viewport-aware screen-space anchor calculations with explicit z-bias ordering based on layer and queue position, and ensure HUD elements maintain predictable positions during surface resizes and orientation changes. The implementation includes comprehensive unit tests verifying deterministic ordering, viewport relayout behavior, z-order stability, and append-flag routing.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHudStore.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->