### PR TITLE
Require clean git tree for parity snapshot scripts and remove accidental gradle.properties proxy block

### DIFF
--- a/.github/workflows/build-linkpoint.yml
+++ b/.github/workflows/build-linkpoint.yml
@@ -68,6 +68,10 @@ jobs:
       
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Validate parity snapshot clean-tree guards
+        run: bash scripts/check_parity_snapshot_guards.sh
+
       
       - name: Display Gradle version
         run: ./gradlew --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: parity-snapshot-guard
+        name: parity snapshot scripts enforce clean tree
+        entry: bash scripts/check_parity_snapshot_guards.sh
+        language: system
+        pass_filenames: false

--- a/scripts/check_parity_snapshot_guards.sh
+++ b/scripts/check_parity_snapshot_guards.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+PARITY_SNAPSHOT_SCRIPTS=(
+  "scripts/generate_file_inventory.sh"
+  "scripts/generate_individual_reviews.sh"
+)
+
+missing=0
+for script in "${PARITY_SNAPSHOT_SCRIPTS[@]}"; do
+  if [[ ! -f "$script" ]]; then
+    echo "ERROR: expected parity snapshot script not found: $script" >&2
+    missing=1
+    continue
+  fi
+
+  if ! rg -q 'require_clean_worktree\.sh' "$script"; then
+    echo "ERROR: $script does not enforce clean working tree guard." >&2
+    missing=1
+  fi
+done
+
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Parity snapshot guard check passed."

--- a/scripts/generate_file_inventory.sh
+++ b/scripts/generate_file_inventory.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/require_clean_worktree.sh"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/generate_individual_reviews.sh
+++ b/scripts/generate_individual_reviews.sh
@@ -6,6 +6,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/require_clean_worktree.sh"
+
 # Colors
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'

--- a/scripts/require_clean_worktree.sh
+++ b/scripts/require_clean_worktree.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+  echo "ERROR: parity snapshot scripts require a clean working tree (no staged, unstaged, or untracked files)." >&2
+  echo "Resolve local changes first (commit, stash, or clean) before running parity snapshot scripts." >&2
+  git status --short >&2
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- The `gradle.properties` diff contained an environment-specific proxy/JVM block that appears to be accidental local drift and should not be committed.
- Parity snapshot generators create repository artifacts and must be reproducible and isolated from local working-tree changes.
- Add automated checks so CI and local pre-commit prevent accidental inclusion of unstaged/untracked changes into parity snapshots.

### Description
- Reverted the accidental proxy/JVM marker block from `gradle.properties` instead of committing environment-specific settings.
- Added a clean-tree guard script `scripts/require_clean_worktree.sh` that exits if there are staged/unstaged/untracked changes.
- Enforced the guard at the top of parity snapshot generators by updating `scripts/generate_file_inventory.sh` and `scripts/generate_individual_reviews.sh` to invoke the new guard.
- Added `scripts/check_parity_snapshot_guards.sh` and a local pre-commit config (`.pre-commit-config.yaml`) and wired the guard verification into the CI workflow `/.github/workflows/build-linkpoint.yml` to run `bash scripts/check_parity_snapshot_guards.sh` during builds.

### Testing
- Ran `bash scripts/check_parity_snapshot_guards.sh` locally and it reported the guard check passed.
- Validated `scripts/require_clean_worktree.sh` fails when the tree is dirty and passes when the tree is clean (observed both behaviors during verification using `git status --short`).
- Verified the updated snapshot generator scripts invoke the guard by running the guard-check script against them (`rg`-based check) and confirming success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf607a80832382a67d828a09b632)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the reproducibility of parity snapshot generation by enforcing a clean git working tree before execution. It introduces a reusable guard script (`require_clean_worktree.sh`) that checks for uncommitted changes and integrates it into the two parity snapshot generator scripts. The PR also adds automated validation through a pre-commit hook and CI workflow check to ensure snapshot scripts maintain the clean-tree guard, and reverts an accidental environment-specific proxy configuration from `gradle.properties` (though that file change is not included in this diff).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/require_clean_worktree.sh` |
| 2 | `scripts/check_parity_snapshot_guards.sh` |
| 3 | `scripts/generate_file_inventory.sh` |
| 4 | `scripts/generate_individual_reviews.sh` |
| 5 | `.pre-commit-config.yaml` |
| 6 | `.github/workflows/build-linkpoint.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->