### PR TITLE
feat(protocol): implement declared message slices and split deferred parity backlog

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -131,11 +131,15 @@ class LinkpointApp : Application() {
             "CoarseLocationUpdate",
             "CrossedRegion",
             "EnableSimulator",
+            "FetchInventory",
+            "FetchInventoryDescendents",
+            "GroupTitlesRequest",
             "HealthMessage",
             "ImprovedInstantMessage",
             "ImprovedTerseObjectUpdate",
             "KillObject",
             "LayerData",
+            "MapNameRequest",
             "ObjectProperties",
             "ObjectUpdate",
             "ObjectUpdateCached",
@@ -144,6 +148,7 @@ class LinkpointApp : Application() {
             "OnlineNotification",
             "PacketAck",
             "ParcelOverlay",
+            "RequestPayPrice",
             "RegionHandshake",
             "ScriptControlChange",
             "SoundTrigger",
@@ -152,6 +157,9 @@ class LinkpointApp : Application() {
             "TeleportFinish",
             "TeleportProgress",
             "TeleportStart",
+            "AgentPause",
+            "AgentResume",
+            "DirFindQuery",
         )
     }
     
@@ -2558,15 +2566,19 @@ class LinkpointApp : Application() {
         // --- Agent Messages ---
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.AGENT_PAUSE) { _, rawPacket ->
             try {
-                val payload = com.linkpoint.protocol.messages.MessageParser.extractPayload(rawPacket)
-                if (payload != null) Log.d(TAG, "⏸️ AgentPause (${payload.size} bytes)")
+                com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                    com.linkpoint.protocol.messages.MessageIds.AGENT_PAUSE,
+                    rawPacket
+                ) { summary -> Log.d(TAG, "⏸️ $summary") }
             } catch (e: Exception) { Log.e(TAG, "Error handling AgentPause", e) }
         }
         
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.AGENT_RESUME) { _, rawPacket ->
             try {
-                val payload = com.linkpoint.protocol.messages.MessageParser.extractPayload(rawPacket)
-                if (payload != null) Log.d(TAG, "▶️ AgentResume (${payload.size} bytes)")
+                com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                    com.linkpoint.protocol.messages.MessageIds.AGENT_RESUME,
+                    rawPacket
+                ) { summary -> Log.d(TAG, "▶️ $summary") }
             } catch (e: Exception) { Log.e(TAG, "Error handling AgentResume", e) }
         }
         
@@ -2765,19 +2777,19 @@ class LinkpointApp : Application() {
         // --- Inventory Messages (Extended) ---
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.FETCH_INVENTORY_DESCENDENTS) { _, rawPacket ->
             try {
-                val payload = com.linkpoint.protocol.messages.MessageParser.extractPayload(rawPacket)
-                if (payload != null && ::inventoryManager.isInitialized) {
-                    Log.d(TAG, "📦 FetchInventoryDescendents (${payload.size} bytes)")
-                }
+                com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                    com.linkpoint.protocol.messages.MessageIds.FETCH_INVENTORY_DESCENDENTS,
+                    rawPacket
+                ) { summary -> Log.d(TAG, "📦 $summary") }
             } catch (e: Exception) { Log.e(TAG, "Error handling FetchInventoryDescendents", e) }
         }
         
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.FETCH_INVENTORY) { _, rawPacket ->
             try {
-                val payload = com.linkpoint.protocol.messages.MessageParser.extractPayload(rawPacket)
-                if (payload != null && ::inventoryManager.isInitialized) {
-                    Log.d(TAG, "📦 FetchInventory (${payload.size} bytes)")
-                }
+                com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                    com.linkpoint.protocol.messages.MessageIds.FETCH_INVENTORY,
+                    rawPacket
+                ) { summary -> Log.d(TAG, "📦 $summary") }
             } catch (e: Exception) { Log.e(TAG, "Error handling FetchInventory", e) }
         }
         
@@ -3175,8 +3187,10 @@ class LinkpointApp : Application() {
         
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.MAP_NAME_REQUEST) { _, rawPacket ->
             try {
-                val payload = com.linkpoint.protocol.messages.MessageParser.extractPayload(rawPacket)
-                if (payload != null) Log.d(TAG, "🗺️ MapNameRequest (${payload.size} bytes)")
+                com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                    com.linkpoint.protocol.messages.MessageIds.MAP_NAME_REQUEST,
+                    rawPacket
+                ) { summary -> Log.d(TAG, "🗺️ $summary") }
             } catch (e: Exception) { Log.e(TAG, "Error handling MapNameRequest", e) }
         }
         
@@ -3692,7 +3706,10 @@ class LinkpointApp : Application() {
         
         // --- Directory Query Messages ---
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.DIR_FIND_QUERY) { _, rawPacket ->
-            Log.d(TAG, "🔍 DirFindQuery received")
+            com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                com.linkpoint.protocol.messages.MessageIds.DIR_FIND_QUERY,
+                rawPacket
+            ) { summary -> Log.d(TAG, "🔍 $summary") }
         }
         
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.DIR_PLACES_QUERY) { _, rawPacket ->
@@ -3758,7 +3775,10 @@ class LinkpointApp : Application() {
         }
         
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.GROUP_TITLES_REQUEST) { _, rawPacket ->
-            Log.d(TAG, "👥 GroupTitlesRequest received")
+            com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                com.linkpoint.protocol.messages.MessageIds.GROUP_TITLES_REQUEST,
+                rawPacket
+            ) { summary -> Log.d(TAG, "👥 $summary") }
         }
         
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.GROUP_MEMBERS_REQUEST) { _, rawPacket ->
@@ -4770,7 +4790,10 @@ class LinkpointApp : Application() {
         
         // --- Pay Price ---
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.REQUEST_PAY_PRICE) { _: Int, rawPacket: ByteArray ->
-            Log.d(TAG, "💰 RequestPayPrice received")
+            com.linkpoint.protocol.messages.DeclaredMessageSlices.handle(
+                com.linkpoint.protocol.messages.MessageIds.REQUEST_PAY_PRICE,
+                rawPacket
+            ) { summary -> Log.d(TAG, "💰 $summary") }
         }
         
         // --- Rez Extended ---

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt
@@ -1,0 +1,248 @@
+package com.linkpoint.protocol.messages
+
+import com.linkpoint.protocol.types.getUUID
+import com.linkpoint.protocol.types.putUUID
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.UUID
+
+/**
+ * Parser/writer coverage for messages that previously lived in the declared-only parity bucket.
+ */
+object DeclaredMessageSlices {
+
+    data class FetchInventoryDescendentsMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val folderId: UUID,
+        val ownerId: UUID,
+        val sortOrder: Int,
+        val fetchFolders: Boolean,
+        val fetchItems: Boolean,
+    )
+
+    data class FetchInventoryItemRequest(
+        val ownerId: UUID,
+        val itemId: UUID,
+    )
+
+    data class FetchInventoryMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val entries: List<FetchInventoryItemRequest>,
+    )
+
+    data class RequestPayPriceMessage(val objectId: UUID)
+
+    data class DirFindQueryMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val queryId: UUID,
+        val queryText: String,
+        val queryFlags: Long,
+        val queryStart: Int,
+    )
+
+    data class GroupTitlesRequestMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val groupId: UUID,
+        val requestId: UUID,
+    )
+
+    data class MapNameRequestMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val flags: Long,
+        val estateId: Long,
+        val godlike: Boolean,
+        val name: String,
+    )
+
+    data class AgentPauseMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val serialNum: Long,
+    )
+
+    typealias AgentResumeMessage = AgentPauseMessage
+
+    fun writeFetchInventoryDescendents(message: FetchInventoryDescendentsMessage): ByteArray =
+        ByteBuffer.allocate(70).order(ByteOrder.LITTLE_ENDIAN).apply {
+            putUUID(message.agentId)
+            putUUID(message.sessionId)
+            putUUID(message.folderId)
+            putUUID(message.ownerId)
+            putInt(message.sortOrder)
+            put(if (message.fetchFolders) 1 else 0)
+            put(if (message.fetchItems) 1 else 0)
+        }.array()
+
+    fun parseFetchInventoryDescendents(payload: ByteArray): FetchInventoryDescendentsMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        return FetchInventoryDescendentsMessage(
+            agentId = buffer.getUUID(),
+            sessionId = buffer.getUUID(),
+            folderId = buffer.getUUID(),
+            ownerId = buffer.getUUID(),
+            sortOrder = buffer.int,
+            fetchFolders = buffer.get().toInt() != 0,
+            fetchItems = buffer.get().toInt() != 0,
+        )
+    }
+
+    fun writeFetchInventory(message: FetchInventoryMessage): ByteArray {
+        val buffer = ByteBuffer.allocate(32 + 1 + (message.entries.size * 32)).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.putUUID(message.agentId)
+        buffer.putUUID(message.sessionId)
+        buffer.put(message.entries.size.toByte())
+        message.entries.forEach { entry ->
+            buffer.putUUID(entry.ownerId)
+            buffer.putUUID(entry.itemId)
+        }
+        return buffer.array()
+    }
+
+    fun parseFetchInventory(payload: ByteArray): FetchInventoryMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        val agentId = buffer.getUUID()
+        val sessionId = buffer.getUUID()
+        val count = buffer.get().toInt() and 0xFF
+        val entries = buildList(count) {
+            repeat(count) {
+                add(FetchInventoryItemRequest(ownerId = buffer.getUUID(), itemId = buffer.getUUID()))
+            }
+        }
+        return FetchInventoryMessage(
+            agentId = agentId,
+            sessionId = sessionId,
+            entries = entries,
+        )
+    }
+
+    fun writeRequestPayPrice(message: RequestPayPriceMessage): ByteArray =
+        ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN).apply { putUUID(message.objectId) }.array()
+
+    fun parseRequestPayPrice(payload: ByteArray): RequestPayPriceMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        return RequestPayPriceMessage(objectId = buffer.getUUID())
+    }
+
+    fun writeDirFindQuery(message: DirFindQueryMessage): ByteArray {
+        val queryBytes = message.queryText.toByteArray(Charsets.UTF_8)
+        val buffer = ByteBuffer.allocate(32 + 16 + 1 + queryBytes.size + 4 + 4).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.putUUID(message.agentId)
+        buffer.putUUID(message.sessionId)
+        buffer.putUUID(message.queryId)
+        buffer.putString1(queryBytes)
+        buffer.putInt(message.queryFlags.toInt())
+        buffer.putInt(message.queryStart)
+        return buffer.array()
+    }
+
+    fun parseDirFindQuery(payload: ByteArray): DirFindQueryMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        return DirFindQueryMessage(
+            agentId = buffer.getUUID(),
+            sessionId = buffer.getUUID(),
+            queryId = buffer.getUUID(),
+            queryText = buffer.readString1(),
+            queryFlags = buffer.int.toLong() and 0xFFFFFFFFL,
+            queryStart = buffer.int,
+        )
+    }
+
+    fun writeGroupTitlesRequest(message: GroupTitlesRequestMessage): ByteArray =
+        ByteBuffer.allocate(64).order(ByteOrder.LITTLE_ENDIAN).apply {
+            putUUID(message.agentId)
+            putUUID(message.sessionId)
+            putUUID(message.groupId)
+            putUUID(message.requestId)
+        }.array()
+
+    fun parseGroupTitlesRequest(payload: ByteArray): GroupTitlesRequestMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        return GroupTitlesRequestMessage(
+            agentId = buffer.getUUID(),
+            sessionId = buffer.getUUID(),
+            groupId = buffer.getUUID(),
+            requestId = buffer.getUUID(),
+        )
+    }
+
+    fun writeMapNameRequest(message: MapNameRequestMessage): ByteArray {
+        val nameBytes = message.name.toByteArray(Charsets.UTF_8)
+        val buffer = ByteBuffer.allocate(32 + 4 + 4 + 1 + 1 + nameBytes.size).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.putUUID(message.agentId)
+        buffer.putUUID(message.sessionId)
+        buffer.putInt(message.flags.toInt())
+        buffer.putInt(message.estateId.toInt())
+        buffer.put(if (message.godlike) 1 else 0)
+        buffer.putString1(nameBytes)
+        return buffer.array()
+    }
+
+    fun parseMapNameRequest(payload: ByteArray): MapNameRequestMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        return MapNameRequestMessage(
+            agentId = buffer.getUUID(),
+            sessionId = buffer.getUUID(),
+            flags = buffer.int.toLong() and 0xFFFFFFFFL,
+            estateId = buffer.int.toLong() and 0xFFFFFFFFL,
+            godlike = buffer.get().toInt() != 0,
+            name = buffer.readString1(),
+        )
+    }
+
+    fun writeAgentPause(message: AgentPauseMessage): ByteArray =
+        ByteBuffer.allocate(36).order(ByteOrder.LITTLE_ENDIAN).apply {
+            putUUID(message.agentId)
+            putUUID(message.sessionId)
+            putInt(message.serialNum.toInt())
+        }.array()
+
+    fun parseAgentPause(payload: ByteArray): AgentPauseMessage {
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+        return AgentPauseMessage(
+            agentId = buffer.getUUID(),
+            sessionId = buffer.getUUID(),
+            serialNum = buffer.int.toLong() and 0xFFFFFFFFL,
+        )
+    }
+
+    fun writeAgentResume(message: AgentResumeMessage): ByteArray = writeAgentPause(message)
+
+    fun parseAgentResume(payload: ByteArray): AgentResumeMessage = parseAgentPause(payload)
+
+    fun handle(messageId: Int, rawPacket: ByteArray, onHandled: (String) -> Unit): Boolean {
+        val payload = MessageParser.extractPayload(rawPacket) ?: return false
+        val summary = when (messageId) {
+            MessageIds.FETCH_INVENTORY_DESCENDENTS -> parseFetchInventoryDescendents(payload).let { "FetchInventoryDescendents folder=${it.folderId}" }
+            MessageIds.FETCH_INVENTORY -> parseFetchInventory(payload).let { "FetchInventory items=${it.entries.size}" }
+            MessageIds.REQUEST_PAY_PRICE -> parseRequestPayPrice(payload).let { "RequestPayPrice object=${it.objectId}" }
+            MessageIds.DIR_FIND_QUERY -> parseDirFindQuery(payload).let { "DirFindQuery text='${it.queryText}'" }
+            MessageIds.GROUP_TITLES_REQUEST -> parseGroupTitlesRequest(payload).let { "GroupTitlesRequest group=${it.groupId}" }
+            MessageIds.MAP_NAME_REQUEST -> parseMapNameRequest(payload).let { "MapNameRequest name='${it.name}'" }
+            MessageIds.AGENT_PAUSE -> parseAgentPause(payload).let { "AgentPause serial=${it.serialNum}" }
+            MessageIds.AGENT_RESUME -> parseAgentResume(payload).let { "AgentResume serial=${it.serialNum}" }
+            else -> return false
+        }
+        onHandled(summary)
+        return true
+    }
+
+    private fun ByteBuffer.readString1(): String {
+        val len = get().toInt() and 0xFF
+        if (len == 0) return ""
+        val bytes = ByteArray(len - 1)
+        get(bytes)
+        get()
+        return String(bytes, Charsets.UTF_8)
+    }
+
+    private fun ByteBuffer.putString1(content: ByteArray) {
+        put((content.size + 1).toByte())
+        put(content)
+        put(0)
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParserRegistry.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParserRegistry.kt
@@ -25,6 +25,14 @@ object MessageParserRegistry {
         register(MessageIds.CROSSED_REGION) { TeleportMessageParsers.parseCrossedRegion(it) }
 
         register(MessageIds.INVENTORY_DESCENDENTS) { AdditionalMessageParsers.parseInventoryDescendents(it) }
+        register(MessageIds.FETCH_INVENTORY_DESCENDENTS) { DeclaredMessageSlices.parseFetchInventoryDescendents(it) }
+        register(MessageIds.FETCH_INVENTORY) { DeclaredMessageSlices.parseFetchInventory(it) }
+        register(MessageIds.REQUEST_PAY_PRICE) { DeclaredMessageSlices.parseRequestPayPrice(it) }
+        register(MessageIds.DIR_FIND_QUERY) { DeclaredMessageSlices.parseDirFindQuery(it) }
+        register(MessageIds.GROUP_TITLES_REQUEST) { DeclaredMessageSlices.parseGroupTitlesRequest(it) }
+        register(MessageIds.MAP_NAME_REQUEST) { DeclaredMessageSlices.parseMapNameRequest(it) }
+        register(MessageIds.AGENT_PAUSE) { DeclaredMessageSlices.parseAgentPause(it) }
+        register(MessageIds.AGENT_RESUME) { DeclaredMessageSlices.parseAgentResume(it) }
     }
 
     fun register(messageId: Int, handler: (ByteArray) -> Any?) {

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageTemplateCatalog.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageTemplateCatalog.kt
@@ -175,7 +175,7 @@ object MessageTemplateCatalog {
         declaredParserOrWriterMessages + LinkpointApp.parserSupportedMessageNamesForConformance
 
     /** Declared-only messages kept for parity; each entry carries an explicit rationale. */
-    val declaredOnlyMessagesWithRationale: Map<String, String> = mapOf(
+    private val declaredOnlyBacklogMessages: Map<String, String> = mapOf(
         "AcceptCallingCard" to "Declared for protocol ID parity; parser/writer support is not implemented yet.",
         "AgentDataUpdateRequest" to "Declared for protocol ID parity; parser/writer support is not implemented yet.",
         "AgentFOV" to "Declared for protocol ID parity; parser/writer support is not implemented yet.",
@@ -470,6 +470,59 @@ object MessageTemplateCatalog {
         "ViewerFrozenMessage" to "Declared for protocol ID parity; parser/writer support is not implemented yet.",
         "ViewerStartAuction" to "Declared for protocol ID parity; parser/writer support is not implemented yet.",
     )
+
+    private val implementedDeclaredMessageNames: Set<String> = setOf(
+        "FetchInventoryDescendents",
+        "FetchInventory",
+        "RequestPayPrice",
+        "DirFindQuery",
+        "GroupTitlesRequest",
+        "MapNameRequest",
+        "AgentPause",
+        "AgentResume",
+    )
+
+    private const val DEFERRED_DATE = "2026-04-24"
+    private const val DEFERRED_ISSUE = "https://github.com/Kaleaon/Linkpoint/issues/1734"
+
+    private val userCriticalPrefixes = listOf("Chat", "Inventory", "Parcel", "Money", "Economy")
+    private val mediumUtilityPrefixes = listOf("Group", "Dir", "Map", "Search")
+
+    private fun classifyDeferredMessage(name: String): String = when {
+        userCriticalPrefixes.any { name.startsWith(it) } -> "user-critical"
+        mediumUtilityPrefixes.any { name.startsWith(it) } -> "medium-utility"
+        else -> "low-priority-admin"
+    }
+
+    private fun deferredRationale(category: String): String =
+        "@deferred category=$category since=$DEFERRED_DATE issue=$DEFERRED_ISSUE"
+
+    private val deferredMessageNames: Set<String> =
+        declaredOnlyBacklogMessages.keys - implementedDeclaredMessageNames
+
+    /** Declared-only backlog split by prioritization slice for parity tracking. */
+    val declaredOnlyUserCriticalMessagesWithRationale: Map<String, String> = deferredMessageNames
+        .filter { classifyDeferredMessage(it) == "user-critical" }
+        .sorted()
+        .associateWith { deferredRationale("user-critical") }
+
+    /** Declared-only backlog split by prioritization slice for parity tracking. */
+    val declaredOnlyMediumUtilityMessagesWithRationale: Map<String, String> = deferredMessageNames
+        .filter { classifyDeferredMessage(it) == "medium-utility" }
+        .sorted()
+        .associateWith { deferredRationale("medium-utility") }
+
+    /** Declared-only backlog split by prioritization slice for parity tracking. */
+    val declaredOnlyLowPriorityAdminMessagesWithRationale: Map<String, String> = deferredMessageNames
+        .filter { classifyDeferredMessage(it) == "low-priority-admin" }
+        .sorted()
+        .associateWith { deferredRationale("low-priority-admin") }
+
+    /** Declared-only messages kept for parity and explicitly deferred with dated issue linkage. */
+    val declaredOnlyMessagesWithRationale: Map<String, String> =
+        declaredOnlyUserCriticalMessagesWithRationale +
+            declaredOnlyMediumUtilityMessagesWithRationale +
+            declaredOnlyLowPriorityAdminMessagesWithRationale
 
     /** Deprecated template messages tracked explicitly to preserve historical parity. */
     val deprecatedMessagesWithRationale: Map<String, String> = mapOf(

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/DeclaredMessageSlicesTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/DeclaredMessageSlicesTest.kt
@@ -1,0 +1,117 @@
+package com.linkpoint.protocol.messages
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.UUID
+
+class DeclaredMessageSlicesTest {
+
+    @Test
+    fun `user-critical slice supports parser writer handler`() {
+        val message = DeclaredMessageSlices.FetchInventoryDescendentsMessage(
+            agentId = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            sessionId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            folderId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+            ownerId = UUID.fromString("44444444-4444-4444-4444-444444444444"),
+            sortOrder = 1,
+            fetchFolders = true,
+            fetchItems = false,
+        )
+
+        val payload = DeclaredMessageSlices.writeFetchInventoryDescendents(message)
+        val parsed = DeclaredMessageSlices.parseFetchInventoryDescendents(payload)
+        assertEquals(message, parsed)
+
+        val rawPacket = wrapRawPacket(MessageIds.FETCH_INVENTORY_DESCENDENTS, payload)
+        var handledSummary = ""
+        val handled = DeclaredMessageSlices.handle(MessageIds.FETCH_INVENTORY_DESCENDENTS, rawPacket) {
+            handledSummary = it
+        }
+        assertTrue(handled)
+        assertTrue(handledSummary.contains("FetchInventoryDescendents"))
+        assertTrue(MessageParserRegistry.hasHandler(MessageIds.FETCH_INVENTORY_DESCENDENTS))
+        assertTrue(MessageTemplateCatalog.supportedParserOrWriterMessages.contains("FetchInventoryDescendents"))
+    }
+
+    @Test
+    fun `medium-utility slice supports parser writer handler`() {
+        val message = DeclaredMessageSlices.MapNameRequestMessage(
+            agentId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            sessionId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            flags = 2,
+            estateId = 8,
+            godlike = false,
+            name = "Sandbox",
+        )
+
+        val payload = DeclaredMessageSlices.writeMapNameRequest(message)
+        val parsed = DeclaredMessageSlices.parseMapNameRequest(payload)
+        assertEquals(message, parsed)
+
+        val rawPacket = wrapRawPacket(MessageIds.MAP_NAME_REQUEST, payload)
+        var handledSummary = ""
+        val handled = DeclaredMessageSlices.handle(MessageIds.MAP_NAME_REQUEST, rawPacket) {
+            handledSummary = it
+        }
+        assertTrue(handled)
+        assertTrue(handledSummary.contains("MapNameRequest"))
+        assertTrue(MessageParserRegistry.hasHandler(MessageIds.MAP_NAME_REQUEST))
+        assertTrue(MessageTemplateCatalog.supportedParserOrWriterMessages.contains("MapNameRequest"))
+    }
+
+    @Test
+    fun `low-priority-admin slice supports parser writer handler`() {
+        val message = DeclaredMessageSlices.AgentPauseMessage(
+            agentId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            sessionId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+            serialNum = 42,
+        )
+
+        val payload = DeclaredMessageSlices.writeAgentPause(message)
+        val parsed = DeclaredMessageSlices.parseAgentPause(payload)
+        assertEquals(message, parsed)
+
+        val rawPacket = wrapRawPacket(MessageIds.AGENT_PAUSE, payload)
+        var handledSummary = ""
+        val handled = DeclaredMessageSlices.handle(MessageIds.AGENT_PAUSE, rawPacket) {
+            handledSummary = it
+        }
+        assertTrue(handled)
+        assertTrue(handledSummary.contains("AgentPause"))
+        assertTrue(MessageParserRegistry.hasHandler(MessageIds.AGENT_PAUSE))
+        assertTrue(MessageTemplateCatalog.supportedParserOrWriterMessages.contains("AgentPause"))
+    }
+
+    @Test
+    fun `declared-only catalog is split into three slices`() {
+        assertTrue(MessageTemplateCatalog.declaredOnlyUserCriticalMessagesWithRationale.isNotEmpty())
+        assertTrue(MessageTemplateCatalog.declaredOnlyMediumUtilityMessagesWithRationale.isNotEmpty())
+        assertTrue(MessageTemplateCatalog.declaredOnlyLowPriorityAdminMessagesWithRationale.isNotEmpty())
+        assertTrue(MessageTemplateCatalog.declaredOnlyMessagesWithRationale.keys.none { it == "MapNameRequest" })
+    }
+
+    private fun wrapRawPacket(messageId: Int, payload: ByteArray): ByteArray {
+        val idBytes = encodeMessageId(messageId)
+        val packet = ByteArray(6 + idBytes.size + payload.size)
+        idBytes.copyInto(packet, destinationOffset = 6)
+        payload.copyInto(packet, destinationOffset = 6 + idBytes.size)
+        return packet
+    }
+
+    private fun encodeMessageId(messageId: Int): ByteArray {
+        return when {
+            messageId > 0 && messageId < 256 -> byteArrayOf(messageId.toByte())
+            messageId < 0 -> {
+                ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN)
+                    .put(0xFF.toByte())
+                    .put(0xFF.toByte())
+                    .putShort((messageId and 0xFFFF).toShort())
+                    .array()
+            }
+            else -> byteArrayOf(0xFF.toByte(), (messageId and 0xFF).toByte())
+        }
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageTemplateProtocolConformanceTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageTemplateProtocolConformanceTest.kt
@@ -13,6 +13,9 @@ class MessageTemplateProtocolConformanceTest {
         val supported = MessageIds.supportedTemplateMessages
         val declaredOnly = MessageIds.declaredOnlyTemplateMessages
         val deprecated = MessageIds.deprecatedTemplateMessages
+        val declaredUserCritical = MessageTemplateCatalog.declaredOnlyUserCriticalMessagesWithRationale
+        val declaredMediumUtility = MessageTemplateCatalog.declaredOnlyMediumUtilityMessagesWithRationale
+        val declaredLowPriorityAdmin = MessageTemplateCatalog.declaredOnlyLowPriorityAdminMessagesWithRationale
 
         val duplicateClassifications = templateMessages.filter { message ->
             listOf(
@@ -44,6 +47,9 @@ class MessageTemplateProtocolConformanceTest {
                 appendLine("template_count=${templateMessages.size}")
                 appendLine("supported_count=${templateMessages.count { it.name in supported }}")
                 appendLine("declared_only_count=${templateMessages.count { it.name in declaredOnly }}")
+                appendLine("declared_user_critical_count=${templateMessages.count { it.name in declaredUserCritical }}")
+                appendLine("declared_medium_utility_count=${templateMessages.count { it.name in declaredMediumUtility }}")
+                appendLine("declared_low_priority_admin_count=${templateMessages.count { it.name in declaredLowPriorityAdmin }}")
                 appendLine("deprecated_count=${templateMessages.count { it.name in deprecated }}")
                 appendLine("missing_classification_count=${missingClassification.size}")
                 appendLine("duplicate_classification_count=${duplicateClassifications.size}")
@@ -66,6 +72,24 @@ class MessageTemplateProtocolConformanceTest {
 
                 appendLine("[DECLARED_ONLY_MESSAGES]")
                 declaredOnly.toSortedMap().forEach { (name, rationale) ->
+                    appendLine("- $name :: $rationale")
+                }
+                appendLine()
+
+                appendLine("[DECLARED_ONLY_USER_CRITICAL]")
+                declaredUserCritical.toSortedMap().forEach { (name, rationale) ->
+                    appendLine("- $name :: $rationale")
+                }
+                appendLine()
+
+                appendLine("[DECLARED_ONLY_MEDIUM_UTILITY]")
+                declaredMediumUtility.toSortedMap().forEach { (name, rationale) ->
+                    appendLine("- $name :: $rationale")
+                }
+                appendLine()
+
+                appendLine("[DECLARED_ONLY_LOW_PRIORITY_ADMIN]")
+                declaredLowPriorityAdmin.toSortedMap().forEach { (name, rationale) ->
                     appendLine("- $name :: $rationale")
                 }
                 appendLine()


### PR DESCRIPTION
### Motivation

- Reduce the large declared-only parity bucket into prioritized slices so parser/writer/handler work can be implemented incrementally and parity drift is visible by slice. 
- Promote a small set of previously declared-only messages to first-class parser/writer/handler coverage to enable immediate user-visible behavior and testing.

### Description

- Added a new `DeclaredMessageSlices` module that provides parsers, writers, and a unified `handle` function for messages in three slices (user-critical, medium-utility, low-priority/admin) including `FetchInventoryDescendents`, `FetchInventory`, `RequestPayPrice`, `DirFindQuery`, `GroupTitlesRequest`, `MapNameRequest`, `AgentPause`, and `AgentResume` (`src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt`).
- Wired the new parsers into `MessageParserRegistry` by registering handlers for the promoted message IDs and updated `LinkpointApp` message registrations to call `DeclaredMessageSlices.handle(...)` so runtime handlers produce structured summaries and parity diagnostics (`MessageParserRegistry.kt`, `LinkpointApp.kt`).
- Reworked the declared-only parity bookkeeping in `MessageTemplateCatalog` to remove implemented messages from the deferred backlog and expose three explicit maps: `declaredOnlyUserCriticalMessagesWithRationale`, `declaredOnlyMediumUtilityMessagesWithRationale`, and `declaredOnlyLowPriorityAdminMessagesWithRationale`, with dated, issue-linked rationale for truly deferred items (since=2026-04-24). 
- Added unit tests and parity-report enhancements: `DeclaredMessageSlicesTest` contains round-trip parser/writer/handler checks for one message per slice, and `MessageTemplateProtocolConformanceTest` was extended to include per-slice counts and report sections for the new backlog split (`src/test/kotlin/com/linkpoint/protocol/messages/`).

### Testing

- Attempted to run targeted unit tests with `./gradlew test --tests 'com.linkpoint.protocol.messages.DeclaredMessageSlicesTest.user-critical slice supports parser writer handler' --tests 'com.linkpoint.protocol.messages.MessageTemplateProtocolConformanceTest'`, but the build failed in this environment due to missing Android SDK configuration (error: `SDK location not found; set ANDROID_HOME or local.properties sdk.dir`).
- The change includes unit test files for CI to exercise parser/writer round-trips and parity-report generation once the project is built in a correctly configured environment, and the tests are expected to pass under CI with a configured Android SDK.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf5c9fa8832390ed55ef9385dd54)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR promotes eight previously declared-only protocol messages (`FetchInventoryDescendents`, `FetchInventory`, `RequestPayPrice`, `DirFindQuery`, `GroupTitlesRequest`, `MapNameRequest`, `AgentPause`, `AgentResume`) to full parser/writer/handler coverage through a new `DeclaredMessageSlices` module. It also restructures the declared-only parity backlog from a single large bucket into three prioritized slices (user-critical, medium-utility, low-priority/admin) with explicit deferred rationale including issue linkage and dates, making technical debt visible and incrementally addressable.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParserRegistry.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageTemplateCatalog.kt` |
| 4 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/DeclaredMessageSlicesTest.kt` |
| 5 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageTemplateProtocolConformanceTest.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->