### PR TITLE
Fix Kotlin compilation blockers in protocol and profile managers

### DIFF
--- a/Linkpoint/build.gradle.kts
+++ b/Linkpoint/build.gradle.kts
@@ -348,6 +348,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("com.squareup.okhttp3:okhttp:4.12.0")  // For integration tests
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.json:json:20240303")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -646,7 +646,7 @@ class LinkpointApp : Application() {
                     ?: transferManager.fetchAsset(item.assetId, item.assetType)?.also { fetched ->
                         assetCache.put(item.assetId, cacheType, fetched)
                     }
-            )
+            }
             avatarManager.setOutfitManager(outfitManager)
         }
         

--- a/Linkpoint/src/main/java/com/linkpoint/inventory/notecard/NotecardManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/inventory/notecard/NotecardManager.kt
@@ -38,8 +38,8 @@ import java.util.concurrent.ConcurrentHashMap
  * }
  */
 class NotecardManager(
-    private val transferManager: TransferManager,
-    private val capabilityManager: CapabilityManager,
+    private val transferManager: TransferManager?,
+    private val capabilityManager: CapabilityRequester,
     private val httpClient: OkHttpClient = OkHttpClient(),
     private val capabilityRequest: suspend (String, LLSDMap) -> com.linkpoint.protocol.llsd.LLSDValue? = { capName, body ->
         capabilityManager.request(capName, body)

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt
@@ -625,7 +625,7 @@ class CapabilityManager : CapabilityRequester {
      */
     override suspend fun request(
         capName: String,
-        body: LLSDValue? = null
+        body: LLSDValue?
     ): LLSDValue? = withContext(Dispatchers.IO) {
         val url = getCapability(capName) ?: return@withContext null
         val options = getOptionsForCapability(capName)

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt
@@ -65,7 +65,11 @@ object DeclaredMessageSlices {
         val serialNum: Long,
     )
 
-    typealias AgentResumeMessage = AgentPauseMessage
+    data class AgentResumeMessage(
+        val agentId: UUID,
+        val sessionId: UUID,
+        val serialNum: Long,
+    )
 
     fun writeFetchInventoryDescendents(message: FetchInventoryDescendentsMessage): ByteArray =
         ByteBuffer.allocate(70).order(ByteOrder.LITTLE_ENDIAN).apply {
@@ -210,9 +214,13 @@ object DeclaredMessageSlices {
         )
     }
 
-    fun writeAgentResume(message: AgentResumeMessage): ByteArray = writeAgentPause(message)
+    fun writeAgentResume(message: AgentResumeMessage): ByteArray =
+        writeAgentPause(AgentPauseMessage(message.agentId, message.sessionId, message.serialNum))
 
-    fun parseAgentResume(payload: ByteArray): AgentResumeMessage = parseAgentPause(payload)
+    fun parseAgentResume(payload: ByteArray): AgentResumeMessage {
+        val pause = parseAgentPause(payload)
+        return AgentResumeMessage(pause.agentId, pause.sessionId, pause.serialNum)
+    }
 
     fun handle(messageId: Int, rawPacket: ByteArray, onHandled: (String) -> Unit): Boolean {
         val payload = MessageParser.extractPayload(rawPacket) ?: return false

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIds.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIds.kt
@@ -428,18 +428,6 @@ object MessageIds {
     
     /** AvatarInterestsReply - Avatar interests/picks */
     const val AVATAR_INTERESTS_REPLY = (0xFFFF00AC).toInt()  // Wire: FF FF 00 AC = -65364 (Lumiya: AvatarInterestsReply)
-
-    /** AvatarInterestsRequest - Request avatar interests */
-    const val AVATAR_INTERESTS_REQUEST = (0xFFFF00AE).toInt()  // Legacy manager compatibility ID
-
-    /** AvatarNotesRequest - Request avatar notes */
-    const val AVATAR_NOTES_REQUEST = (0xFFFF00B2).toInt()      // Legacy manager compatibility ID
-
-    /** AvatarPicksRequest - Request avatar picks */
-    const val AVATAR_PICKS_REQUEST = (0xFFFF00B4).toInt()      // Legacy manager compatibility ID
-
-    /** AvatarClassifiedsRequest - Request avatar classifieds */
-    const val AVATAR_CLASSIFIEDS_REQUEST = (0xFFFF00B5).toInt() // Legacy manager compatibility ID
     
     /** AvatarGroupsReply - Avatar group memberships */
     const val AVATAR_GROUPS_REPLY = (0xFFFF00AD).toInt()  // Wire: FF FF 00 AD = -65363 (Lumiya: AvatarGroupsReply)

--- a/Linkpoint/src/main/java/com/linkpoint/users/UserProfileManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/users/UserProfileManager.kt
@@ -32,9 +32,7 @@ class UserProfileManager(
     private val agentId: UUID,
     private val capabilityRequest: suspend (String, LLSDValue?) -> LLSDValue? =
         { capabilityName, body -> capabilityManager.request(capabilityName, body) },
-    private val udpFallbackRequest: suspend (UUID) -> Unit = { fallbackAvatarId ->
-        sendPropertiesRequestInternal(fallbackAvatarId)
-    }
+    private val udpFallbackRequest: (suspend (UUID) -> Unit)? = null
 ) {
     companion object {
         private const val TAG = "UserProfileManager"
@@ -93,13 +91,14 @@ class UserProfileManager(
             val request = LLSDMap().apply {
                 this["agent_id"] = LLSDString(avatarId.toString())
             }
-            val response = capabilityManager.request(CapabilityManager.CAP_AGENT_PROFILE, request)
+            val response = capabilityRequest(CapabilityManager.CAP_AGENT_PROFILE, request)
 
             if (response is LLSDMap) {
                 val profile = parseProfileFromLLSD(avatarId, response)
                 cacheProfile(avatarId, profile)
                 notifyCallbacks(avatarId, profile)
-                Log.d(TAG, "Loaded profile for $avatarId via AgentProfile capability ($capUrl)")
+                val capUrl = capabilityManager.getCapability(CapabilityManager.CAP_AGENT_PROFILE)
+                Log.d(TAG, "Loaded profile for $avatarId via AgentProfile capability (${capUrl ?: "unknown"})")
                 return
             }
 
@@ -116,7 +115,7 @@ class UserProfileManager(
      * Send AvatarPropertiesRequest via UDP.
      */
     private suspend fun sendPropertiesRequest(avatarId: UUID) {
-        udpFallbackRequest(avatarId)
+        udpFallbackRequest?.invoke(avatarId) ?: sendPropertiesRequestInternal(avatarId)
     }
 
     private suspend fun sendPropertiesRequestInternal(avatarId: UUID) {

--- a/Linkpoint/src/test/kotlin/com/linkpoint/inventory/notecard/NotecardManagerSaveTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/inventory/notecard/NotecardManagerSaveTest.kt
@@ -7,14 +7,14 @@ import com.linkpoint.protocol.llsd.LLSDUUID
 import com.linkpoint.protocol.llsd.LLSDXmlUtils
 import com.linkpoint.protocol.messages.UDPConnectionFixed
 import com.linkpoint.protocol.transfer.TransferManager
-import com.sun.net.httpserver.HttpServer
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.net.InetSocketAddress
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
@@ -122,19 +122,19 @@ class NotecardManagerSaveTest {
         return LLSDXmlUtils.wrap(LLSDMap(mutableMapOf("state" to LLSDString(state))))
     }
 
-    private fun withTestServer(responseXml: String, block: (String) -> Unit) {
-        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
-        server.createContext("/") { exchange ->
-            val bytes = responseXml.toByteArray(Charsets.UTF_8)
-            exchange.responseHeaders.add("Content-Type", "application/llsd+xml")
-            exchange.sendResponseHeaders(200, bytes.size.toLong())
-            exchange.responseBody.use { it.write(bytes) }
-        }
+    private suspend fun withTestServer(responseXml: String, block: suspend (String) -> Unit) {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/llsd+xml")
+                .setBody(responseXml)
+        )
         server.start()
         try {
-            block("http://127.0.0.1:${server.address.port}/")
+            block(server.url("/").toString())
         } finally {
-            server.stop(0)
+            server.shutdown()
         }
     }
 }

--- a/Linkpoint/src/test/kotlin/com/linkpoint/users/CapabilityManagersRequestShapeTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/users/CapabilityManagersRequestShapeTest.kt
@@ -4,6 +4,7 @@ import com.linkpoint.protocol.capabilities.CapabilityManager
 import com.linkpoint.protocol.capabilities.FakeCapabilityRequester
 import com.linkpoint.protocol.llsd.LLSDArray
 import com.linkpoint.protocol.llsd.LLSDMap
+import com.linkpoint.protocol.llsd.LLSDString
 import com.linkpoint.render.RenderMaterialsManager
 import com.linkpoint.world.SimulatorFeaturesManager
 import kotlinx.coroutines.runBlocking
@@ -87,6 +88,6 @@ class CapabilityManagersRequestShapeTest {
         assertEquals(CapabilityManager.CAP_RENDER_MATERIALS, call.capName)
         val body = call.body as LLSDMap
         val ids = body.getArray("object_ids") as LLSDArray
-        assertEquals(objectId.toString(), ids.getString(0))
+        assertEquals(objectId.toString(), (ids[0] as LLSDString).value)
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve multiple Kotlin compilation failures caused by syntax issues and API mismatches in core protocol and profile code paths. 
- Ensure message parsing helpers, capability requests, and profile fallback flows compile cleanly so downstream builds can proceed. 

### Description
- Corrected a mismatched lambda/brace in `LinkpointApp.kt` to close the `OutfitManager` asset-fetch lambda and restore proper function scope. 
- Adjusted `CapabilityManager.request` override signature to remove a default parameter value so it conforms to Kotlin override rules. 
- Replaced an experimental nested `typealias` with a concrete `AgentResumeMessage` `data class` in `DeclaredMessageSlices.kt` and added explicit adapter implementations for resume write/parse. 
- Removed duplicated avatar request constants from `MessageIds.kt` to eliminate conflicting declarations and fixed `UserProfileManager` to use an injectable capability request lambda and safe UDP fallback invocation while improving capability URL logging. 

### Testing
- Ran `./gradlew :Linkpoint:compileStableDebugKotlin --continue` and the Kotlin compilation completed successfully (warnings only). 
- Ran `./gradlew :Linkpoint:compileStableReleaseKotlin :Linkpoint:compileXrExperimentalDebugKotlin :Linkpoint:compileXrExperimentalReleaseKotlin --continue` and all specified Kotlin compile tasks completed successfully (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb176f114883238b4daab891acc635)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes multiple Kotlin compilation blockers across protocol and profile management code. It corrects a lambda brace mismatch in `LinkpointApp`, adjusts the `CapabilityManager.request` override signature to comply with Kotlin override rules, replaces an experimental nested `typealias` with a concrete `AgentResumeMessage` data class and explicit adapter implementations, removes duplicate avatar request constants from `MessageIds`, and refactors `UserProfileManager` to use injectable capability requests with safe UDP fallback invocation and improved logging.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIds.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/capabilities/CapabilityManager.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/DeclaredMessageSlices.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/users/UserProfileManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed outfit manager callback so item asset caching/fetching callbacks run correctly.

* **Refactor**
  * Made agent resume messages distinct for clearer handling.
  * Adjusted capability request parameter handling and streamlined legacy message IDs.
  * Made profile and notecard flows more flexible with optional transfer/capability hooks.

* **Tests**
  * Switched unit tests to use an HTTP mock server and updated related test assertions.

* **Chores**
  * Added MockWebServer to test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->