### PR TITLE
Replace TODO-based parser scaffolding with domain-aware delegating generator

### DIFF
--- a/Linkpoint/tools/generate_parser_scaffolding.py
+++ b/Linkpoint/tools/generate_parser_scaffolding.py
@@ -1,25 +1,120 @@
 #!/usr/bin/env python3
+"""Generate Kotlin parser scaffolding from template metadata.
+
+This script turns entries from ``tools/parser-templates/message-parser-templates.json``
+into concrete parser forwarding methods in
+``src/main/java/com/linkpoint/protocol/messages/generated/GeneratedParserScaffolding.kt``.
+
+The generated methods intentionally delegate to existing domain parser objects (for
+example ``ObjectMessageParsers`` and ``TeleportMessageParsers``) so that scaffolding
+is immediately usable and does not emit TODO placeholders.
+"""
+
+from __future__ import annotations
+
+import argparse
 import json
 from pathlib import Path
+from typing import Any
 
-root = Path(__file__).resolve().parents[1]
-tpl = json.loads((root / "tools/parser-templates/message-parser-templates.json").read_text())
-out = root / "src/main/java/com/linkpoint/protocol/messages/generated/GeneratedParserScaffolding.kt"
-out.parent.mkdir(parents=True, exist_ok=True)
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TEMPLATE = ROOT / "tools/parser-templates/message-parser-templates.json"
+DEFAULT_OUTPUT = ROOT / "src/main/java/com/linkpoint/protocol/messages/generated/GeneratedParserScaffolding.kt"
 
-lines = [
-    "package com.linkpoint.protocol.messages.generated",
-    "",
-    "import com.linkpoint.protocol.messages.*",
-    "",
-    "/** Auto-generated parser scaffolding from message templates. */",
-    "object GeneratedParserScaffolding {",
-]
-for msg in tpl["messages"]:
-    lines.append(f"    const val {msg['name'].upper()}_ID: Int = {msg['id']}")
-    lines.append(f"    // domain={msg['domain']} returnType={msg['returnType']}")
-    lines.append(f"    fun parse{msg['name']}(payload: ByteArray): {msg['returnType']} = TODO(\"Implement {msg['name']} parser\")")
-    lines.append("")
-lines.append("}")
-out.write_text("\n".join(lines))
-print(f"Wrote {out}")
+# Domain-to-parser mapping follows conventions in src/main/java/com/linkpoint/protocol/messages/*Parsers.kt
+PARSER_OBJECT_BY_DOMAIN: dict[str, str] = {
+    "object": "MessageParser",  # parseObjectUpdate currently lives in MessageParser
+    "avatar": "AvatarMessageParsers",
+    "teleport": "TeleportMessageParsers",
+    "inventory": "AdditionalMessageParsers",
+    "chat": "ChatMessageParsers",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate GeneratedParserScaffolding.kt by wiring template messages to "
+            "existing parser objects (no TODO stubs)."
+        )
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE,
+        help="Path to message-parser-templates.json (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Path to write GeneratedParserScaffolding.kt (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def load_template(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text())
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        raise ValueError(f"Expected top-level 'messages' array in {path}")
+    return messages
+
+
+def parser_object_for(message: dict[str, Any]) -> str:
+    explicit_parser = message.get("parserObject")
+    if isinstance(explicit_parser, str) and explicit_parser:
+        return explicit_parser
+
+    domain = message.get("domain")
+    if not isinstance(domain, str) or domain not in PARSER_OBJECT_BY_DOMAIN:
+        known = ", ".join(sorted(PARSER_OBJECT_BY_DOMAIN))
+        raise ValueError(
+            f"Message '{message.get('name')}' has unknown domain '{domain}'. "
+            f"Add parserObject in template or extend domain map ({known})."
+        )
+    return PARSER_OBJECT_BY_DOMAIN[domain]
+
+
+def generate(messages: list[dict[str, Any]]) -> str:
+    lines = [
+        "package com.linkpoint.protocol.messages.generated",
+        "",
+        "import com.linkpoint.protocol.messages.*",
+        "",
+        "/** Auto-generated parser scaffolding from message templates. */",
+        "object GeneratedParserScaffolding {",
+    ]
+
+    for message in messages:
+        name = message["name"]
+        msg_id = message["id"]
+        domain = message["domain"]
+        return_type = message["returnType"]
+        parser_object = parser_object_for(message)
+
+        lines.append(f"    const val {name.upper()}_ID: Int = {msg_id}")
+        lines.append(f"    // domain={domain} returnType={return_type}")
+        lines.append(
+            f"    fun parse{name}(payload: ByteArray): {return_type} = "
+            f"{parser_object}.parse{name}(payload)"
+        )
+        lines.append("")
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    template_path = args.template if args.template.is_absolute() else ROOT / args.template
+    output_path = args.output if args.output.is_absolute() else ROOT / args.output
+
+    messages = load_template(template_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(generate(messages) + "\n")
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- The previous generator emitted `TODO("Implement ... parser")` placeholders which marked the tool as BROKEN in the audit and produced unusable scaffolding.
- The goal is to produce immediately usable parser scaffolding that matches existing parser conventions under `com.linkpoint.protocol.messages` and to make the generator self-documenting to avoid regressions.

### Description
- Rewrote `Linkpoint/tools/generate_parser_scaffolding.py` into a proper CLI generator with a module docstring and `--template`/`--output` argument help. 
- Implemented a domain-to-parser mapping and `parserObject` override so generated methods delegate to existing parser objects (e.g. `MessageParser`, `AvatarMessageParsers`, `TeleportMessageParsers`) instead of emitting `TODO` stubs. 
- Added validation that raises a clear error for unknown `domain` values in the template and ensured the generator always writes a trailing newline to the output file. 
- Regenerated `src/main/java/com/linkpoint/protocol/messages/generated/GeneratedParserScaffolding.kt` to use concrete delegating `parseX` methods that align with the repository's parser implementations. 

### Testing
- Ran `python3 Linkpoint/tools/generate_parser_scaffolding.py` to generate `GeneratedParserScaffolding.kt`, which completed successfully and produced the expected delegating methods. 
- Performed a static signal check for `TODO(` / `todo-call` / merge-conflict markers against the generator and confirmed `signals=none`. 
- Inspected the generated `GeneratedParserScaffolding.kt` to verify method signatures, domain comments, and delegation target objects match existing parser code and found no TODO placeholders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb63b2d948832382c72aec95507a9c)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR replaces the parser scaffolding generator that previously emitted unusable `TODO` stubs with a domain-aware implementation that delegates to existing parser objects (`MessageParser`, `AvatarMessageParsers`, `TeleportMessageParsers`, etc.). The generator has been refactored into a proper CLI tool with argument parsing, module-level documentation, domain-to-parser mapping, validation for unknown domains, and support for `parserObject` overrides in templates. The output now produces immediately usable parser methods that align with existing repository conventions.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/tools/generate_parser_scaffolding.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->