### PR TITLE
Repair decompilation stubs in Group invite, SyncManager, and WorldViewActivity

### DIFF
--- a/docs/broken_code_inventory_2026-04-24.csv
+++ b/docs/broken_code_inventory_2026-04-24.csv
@@ -459,16 +459,16 @@ app/src/main/kotlin/com/lumiyaviewer/lumiya/slproto/messages/ObjectLinkKt.kt,kt,
 cleanup-branches.sh,sh,OK,,ok,SecondLifeViewer|FirestormViewer
 file_bundle/ActiveChattersManager.java,java,BROKEN,decompilation-stub|unsupported-operation,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/CardboardActivity.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
-file_bundle/GroupMainProfileTab.java,java,BROKEN,decompilation-stub|unsupported-operation,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
+file_bundle/GroupMainProfileTab.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/InventoryFragment.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/InventoryFragmentHelper.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/ObjectDetailsFragment.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/SLChatEvent.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/SLInventory.java,java,OK,,not-checked,LLSD|LibreMetaverse|SecondLifeViewer|FirestormViewer
-file_bundle/SyncManager.java,java,BROKEN,decompilation-stub|unsupported-operation,not-checked,SecondLifeViewer|FirestormViewer
+file_bundle/SyncManager.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 file_bundle/UserFunctionsFragment.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 file_bundle/VoiceStatusView.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
-file_bundle/WorldViewActivity.java,java,BROKEN,decompilation-stub|unsupported-operation,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
+file_bundle/WorldViewActivity.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/android/arch/core/internal/FastSafeIterableMap.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/android/arch/core/internal/SafeIterableMap.java,java,BROKEN,unsupported-operation,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/android/arch/lifecycle/BuildConfig.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
@@ -3035,7 +3035,7 @@ lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/OnListUpd
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SearchManager.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SortedChatterList.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SubscribableList.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
-lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SyncManager.java,java,BROKEN,decompilation-stub|unsupported-operation,not-checked,SecondLifeViewer|FirestormViewer
+lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SyncManager.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/UnreadMessageInfo.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/UnreadNotificationInfo.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/UnreadNotificationManager.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
@@ -3222,7 +3222,7 @@ lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/MoveControl.java,java
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/OnHoverListenerCompat.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/RenderSettings.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldSurfaceView.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
-lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldViewActivity.java,java,BROKEN,decompilation-stub|unsupported-operation,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
+lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldViewActivity.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldViewActivity_ViewBinding.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/search/ParcelInfoFragment.java,java,OK,,not-checked,LibreMetaverse|SecondLifeViewer|FirestormViewer
 lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/search/ParcelInfoFragment_ViewBinding.java,java,OK,,not-checked,SecondLifeViewer|FirestormViewer

--- a/file_bundle/GroupMainProfileTab.java
+++ b/file_bundle/GroupMainProfileTab.java
@@ -479,63 +479,18 @@ Method generation error in method: com.lumiyaviewer.lumiya.ui.chat.profiles.-$La
     }
 
     /* access modifiers changed from: private */
-    /* JADX WARNING: Code restructure failed: missing block: B:5:0x000c, code lost:
-        r1 = r8.groupProfile.get().GroupData_Field.GroupID;
-     */
     /* renamed from: onInviteClicked */
-    /* Code decompiled incorrectly, please refer to instructions dump. */
-    public void m446com_lumiyaviewer_lumiya_ui_chat_profiles_GroupMainProfileTabmthref9(android.view.View r9) {
-        /*
-            r8 = this;
-            com.lumiyaviewer.lumiya.slproto.users.ChatterID r0 = r8.chatterID     // Catch:{ DataNotReadyException -> 0x0067 }
-            if (r0 == 0) goto L_0x0066
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.SLAgentCircuit> r0 = r8.agentCircuit     // Catch:{ DataNotReadyException -> 0x0067 }
-            boolean r0 = r0.hasData()     // Catch:{ DataNotReadyException -> 0x0067 }
-            if (r0 == 0) goto L_0x0066
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply> r0 = r8.groupProfile     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r0 = r0.get()     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply r0 = (com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply) r0     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply$GroupData r0 = r0.GroupData_Field     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.util.UUID r1 = r0.GroupID     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList> r0 = r8.myGroupList     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r0 = r0.get()     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList r0 = (com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList) r0     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.google.common.collect.ImmutableMap<java.util.UUID, com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList$AvatarGroupEntry> r0 = r0.Groups     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r0 = r0.get(r1)     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList$AvatarGroupEntry r0 = (com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList.AvatarGroupEntry) r0     // Catch:{ DataNotReadyException -> 0x0067 }
-            if (r0 == 0) goto L_0x0066
-            long r2 = r0.GroupPowers     // Catch:{ DataNotReadyException -> 0x0067 }
-            r4 = 2
-            long r2 = r2 & r4
-            r4 = 0
-            int r0 = (r2 > r4 ? 1 : (r2 == r4 ? 0 : -1))
-            if (r0 == 0) goto L_0x0066
-            android.support.v4.app.FragmentActivity r6 = r8.getActivity()     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Class<com.lumiyaviewer.lumiya.ui.chat.AvatarPickerForInvite> r7 = com.lumiyaviewer.lumiya.ui.chat.AvatarPickerForInvite.class
-            com.lumiyaviewer.lumiya.slproto.users.ChatterID r0 = r8.chatterID     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.util.UUID r0 = r0.agentUUID     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply> r2 = r8.groupProfile     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r2 = r2.get()     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply r2 = (com.lumiyaviewer.lumiya.slproto.messages.GroupProfileReply) r2     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList> r3 = r8.myGroupList     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r3 = r3.get()     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList r3 = (com.lumiyaviewer.lumiya.slproto.modules.groups.AvatarGroupList) r3     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.messages.GroupTitlesReply> r4 = r8.groupTitles     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r4 = r4.get()     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.messages.GroupTitlesReply r4 = (com.lumiyaviewer.lumiya.slproto.messages.GroupTitlesReply) r4     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.messages.GroupRoleDataReply> r5 = r8.groupRoles     // Catch:{ DataNotReadyException -> 0x0067 }
-            java.lang.Object r5 = r5.get()     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.slproto.messages.GroupRoleDataReply r5 = (com.lumiyaviewer.lumiya.slproto.messages.GroupRoleDataReply) r5     // Catch:{ DataNotReadyException -> 0x0067 }
-            android.os.Bundle r0 = com.lumiyaviewer.lumiya.ui.chat.AvatarPickerForInvite.makeArguments(r0, r1, r2, r3, r4, r5)     // Catch:{ DataNotReadyException -> 0x0067 }
-            com.lumiyaviewer.lumiya.ui.common.DetailsActivity.showEmbeddedDetails(r6, r7, r0)     // Catch:{ DataNotReadyException -> 0x0067 }
-        L_0x0066:
-            return
-        L_0x0067:
-            r0 = move-exception
-            com.lumiyaviewer.lumiya.Debug.Warning(r0)
-            goto L_0x0066
-        */
-        throw new UnsupportedOperationException("Method not decompiled: com.lumiyaviewer.lumiya.ui.chat.profiles.GroupMainProfileTab.m446com_lumiyaviewer_lumiya_ui_chat_profiles_GroupMainProfileTabmthref9(android.view.View):void");
+    public void m446com_lumiyaviewer_lumiya_ui_chat_profiles_GroupMainProfileTabmthref9(View view) {
+        try {
+            UUID uuid;
+            AvatarGroupList.AvatarGroupEntry avatarGroupEntry;
+            if (this.chatterID == null || !this.agentCircuit.hasData() || (avatarGroupEntry = this.myGroupList.get().Groups.get((uuid = this.groupProfile.get().GroupData_Field.GroupID))) == null || (avatarGroupEntry.GroupPowers & 2) == 0) {
+                return;
+            }
+            DetailsActivity.showEmbeddedDetails(getActivity(), AvatarPickerForInvite.class, AvatarPickerForInvite.makeArguments(this.chatterID.agentUUID, uuid, this.groupProfile.get(), this.myGroupList.get(), this.groupTitles.get(), this.groupRoles.get()));
+        } catch (SubscriptionData.DataNotReadyException e) {
+            Debug.Warning(e);
+        }
     }
 
     /* access modifiers changed from: private */

--- a/file_bundle/SyncManager.java
+++ b/file_bundle/SyncManager.java
@@ -362,202 +362,76 @@ Method generation error in method: com.lumiyaviewer.lumiya.slproto.users.manager
     /* renamed from: syncMoreMessages */
     /* Code decompiled incorrectly, please refer to instructions dump. */
     public void m360com_lumiyaviewer_lumiya_slproto_users_manager_SyncManagermthref4() {
-        /*
-            r18 = this;
-            r0 = r18
-            java.util.concurrent.atomic.AtomicBoolean r2 = r0.syncMessageSent
-            r3 = 1
-            boolean r2 = r2.getAndSet(r3)
-            if (r2 != 0) goto L_0x0171
-            r11 = 0
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.ChatterNameRetriever r2 = r0.myNameRetriever
-            if (r2 != 0) goto L_0x003b
-            com.lumiyaviewer.lumiya.slproto.users.ChatterNameRetriever r2 = new com.lumiyaviewer.lumiya.slproto.users.ChatterNameRetriever
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r3 = r0.userManager
-            java.util.UUID r3 = r3.getUserID()
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r4 = r0.userManager
-            java.util.UUID r4 = r4.getUserID()
-            com.lumiyaviewer.lumiya.slproto.users.ChatterID$ChatterIDUser r3 = com.lumiyaviewer.lumiya.slproto.users.ChatterID.getUserChatterID(r3, r4)
-            com.lumiyaviewer.lumiya.slproto.users.manager.-$Lambda$AZwop9CtlZWAAgrWZJSwnA0FdZ8$2 r4 = new com.lumiyaviewer.lumiya.slproto.users.manager.-$Lambda$AZwop9CtlZWAAgrWZJSwnA0FdZ8$2
-            r0 = r18
-            r4.<init>(r0)
-            r0 = r18
-            java.util.concurrent.Executor r5 = r0.dbExecutor
-            r6 = 1
-            r2.<init>(r3, r4, r5, r6)
-            r0 = r18
-            r0.myNameRetriever = r2
-        L_0x003b:
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.ChatterNameRetriever r2 = r0.myNameRetriever
-            java.lang.String r12 = r2.getResolvedName()
-            if (r12 == 0) goto L_0x01ba
-            r0 = r18
-            de.greenrobot.dao.query.Query<com.lumiyaviewer.lumiya.dao.ChatMessage> r2 = r0.messagesQuery
-            de.greenrobot.dao.query.Query r2 = r2.forCurrentThread()
-            r0 = r18
-            long r4 = r0.lastConfirmedMessageID
-            java.lang.Long r3 = java.lang.Long.valueOf(r4)
-            r4 = 0
-            r2.setParameter(r4, r3)
-            de.greenrobot.dao.query.LazyList r13 = r2.listLazy()
-            com.google.common.collect.ImmutableList$Builder r14 = com.google.common.collect.ImmutableList.builder()
-            r4 = 0
-            r2 = 0
-            java.util.Iterator r15 = r13.iterator()
-            r6 = r2
-            r10 = r4
-        L_0x006a:
-            boolean r2 = r15.hasNext()
-            if (r2 == 0) goto L_0x0101
-            java.lang.Object r2 = r15.next()
-            com.lumiyaviewer.lumiya.dao.ChatMessage r2 = (com.lumiyaviewer.lumiya.dao.ChatMessage) r2
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r3 = r0.userManager
-            java.util.UUID r3 = r3.getUserID()
-            com.lumiyaviewer.lumiya.slproto.chat.generic.SLChatEvent r4 = com.lumiyaviewer.lumiya.slproto.chat.generic.SLChatEvent.loadFromDatabaseObject(r2, r3)
-            if (r4 == 0) goto L_0x01b1
-            r0 = r18
-            com.lumiyaviewer.lumiya.dao.ChatterDao r3 = r0.chatterDao
-            long r8 = r2.getChatterID()
-            java.lang.Long r5 = java.lang.Long.valueOf(r8)
-            java.lang.Object r3 = r3.load(r5)
-            r5 = r3
-            com.lumiyaviewer.lumiya.dao.Chatter r5 = (com.lumiyaviewer.lumiya.dao.Chatter) r5
-            if (r5 == 0) goto L_0x01b1
-            r0 = r18
-            java.lang.String r8 = r0.resolveChatterName(r5)
-            if (r8 == 0) goto L_0x0101
-            r0 = r18
-            android.content.Context r3 = r0.context
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r6 = r0.userManager
-            r7 = 0
-            java.lang.CharSequence r9 = r4.getPlainTextMessage(r3, r6, r7)
-            com.lumiyaviewer.lumiya.cloud.common.LogChatMessage r3 = new com.lumiyaviewer.lumiya.cloud.common.LogChatMessage
-            int r4 = r5.getType()
-            java.util.UUID r5 = r5.getUuid()
-            java.lang.Long r6 = r2.getId()
-            long r6 = r6.longValue()
-            java.lang.StringBuilder r16 = new java.lang.StringBuilder
-            r16.<init>()
-            java.lang.String r17 = "["
-            java.lang.StringBuilder r16 = r16.append(r17)
-            r0 = r18
-            java.text.DateFormat r0 = r0.dateFormat
-            r17 = r0
-            java.util.Date r2 = r2.getTimestamp()
-            r0 = r17
-            java.lang.String r2 = r0.format(r2)
-            r0 = r16
-            java.lang.StringBuilder r2 = r0.append(r2)
-            java.lang.String r16 = "] "
-            r0 = r16
-            java.lang.StringBuilder r2 = r2.append(r0)
-            java.lang.StringBuilder r2 = r2.append(r9)
-            java.lang.String r9 = r2.toString()
-            r3.<init>(r4, r5, r6, r8, r9)
-            r14.add((java.lang.Object) r3)
-            long r6 = r3.messageID
-            int r10 = r10 + 1
-            r2 = 100
-            if (r10 < r2) goto L_0x01b1
-        L_0x0101:
-            r13.close()
-            if (r10 == 0) goto L_0x01b7
-            com.lumiyaviewer.lumiya.cloud.common.LogMessageBatch r2 = new com.lumiyaviewer.lumiya.cloud.common.LogMessageBatch
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r3 = r0.userManager
-            java.util.UUID r3 = r3.getUserID()
-            com.google.common.collect.ImmutableList r5 = r14.build()
-            r4 = r12
-            r2.<init>(r3, r4, r5, r6)
-            r0 = r18
-            java.util.concurrent.atomic.AtomicReference<com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection> r3 = r0.syncServiceConnection
-            java.lang.Object r3 = r3.get()
-            com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection r3 = (com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection) r3
-            if (r3 == 0) goto L_0x01b7
-            com.lumiyaviewer.lumiya.cloud.common.MessageType r4 = com.lumiyaviewer.lumiya.cloud.common.MessageType.LogMessageBatch
-            boolean r2 = r3.sendMessage(r4, r2)
-            r4 = r2
-        L_0x012b:
-            r0 = r18
-            java.util.Set<java.lang.String> r2 = r0.flushChatterNames
-            boolean r2 = r2.isEmpty()
-            if (r2 != 0) goto L_0x016a
-            r0 = r18
-            java.util.concurrent.atomic.AtomicReference<com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection> r2 = r0.syncServiceConnection
-            java.lang.Object r2 = r2.get()
-            com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection r2 = (com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection) r2
-            if (r2 == 0) goto L_0x016a
-            r0 = r18
-            java.util.Set<java.lang.String> r3 = r0.flushChatterNames
-            java.util.Iterator r5 = r3.iterator()
-            boolean r3 = r5.hasNext()
-            if (r3 == 0) goto L_0x016a
-            java.lang.Object r3 = r5.next()
-            java.lang.String r3 = (java.lang.String) r3
-            r5.remove()
-            com.lumiyaviewer.lumiya.cloud.common.MessageType r5 = com.lumiyaviewer.lumiya.cloud.common.MessageType.LogFlushMessages
-            com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages r6 = new com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r7 = r0.userManager
-            java.util.UUID r7 = r7.getUserID()
-            r6.<init>(r7, r12, r3)
-            r2.sendMessage(r5, r6)
-        L_0x016a:
-            r0 = r18
-            java.util.concurrent.atomic.AtomicBoolean r2 = r0.syncMessageSent
-            r2.set(r4)
-        L_0x0171:
-            r0 = r18
-            java.util.concurrent.atomic.AtomicBoolean r2 = r0.needsStopSyncing
-            r3 = 0
-            boolean r2 = r2.getAndSet(r3)
-            if (r2 == 0) goto L_0x01b0
-            r0 = r18
-            java.util.concurrent.atomic.AtomicBoolean r2 = r0.syncingEnabled
-            r3 = 0
-            r2.set(r3)
-            r0 = r18
-            java.util.concurrent.atomic.AtomicReference<com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection> r2 = r0.syncServiceConnection
-            r3 = 0
-            java.lang.Object r2 = r2.getAndSet(r3)
-            com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection r2 = (com.lumiyaviewer.lumiya.sync.CloudSyncServiceConnection) r2
-            r0 = r18
-            java.util.concurrent.atomic.AtomicBoolean r3 = r0.syncMessageSent
-            r4 = 0
-            r3.set(r4)
-            if (r2 == 0) goto L_0x01b0
-            com.lumiyaviewer.lumiya.cloud.common.MessageType r3 = com.lumiyaviewer.lumiya.cloud.common.MessageType.LogFlushMessages
-            com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages r4 = new com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages
-            r0 = r18
-            com.lumiyaviewer.lumiya.slproto.users.manager.UserManager r5 = r0.userManager
-            java.util.UUID r5 = r5.getUserID()
-            r6 = 0
-            r7 = 0
-            r4.<init>(r5, r6, r7)
-            r2.sendMessage(r3, r4)
-            r2.disconnect()
-        L_0x01b0:
-            return
-        L_0x01b1:
-            r2 = r6
-            r4 = r10
-            r6 = r2
-            r10 = r4
-            goto L_0x006a
-        L_0x01b7:
-            r4 = r11
-            goto L_0x012b
-        L_0x01ba:
-            r4 = r11
-            goto L_0x016a
-        */
-        throw new UnsupportedOperationException("Method not decompiled: com.lumiyaviewer.lumiya.slproto.users.manager.SyncManager.m360com_lumiyaviewer_lumiya_slproto_users_manager_SyncManagermthref4():void");
+        if (!this.syncMessageSent.getAndSet(true)) {
+            boolean keepSyncMessageSent = false;
+            String myName = null;
+            if (this.myNameRetriever == null) {
+                this.myNameRetriever = new ChatterNameRetriever(ChatterID.getUserChatterID(this.userManager.getUserID(), this.userManager.getUserID()), new ChatterNameRetriever.OnChatterNameUpdated() {
+                    @Override
+                    public void onChatterNameUpdated(ChatterNameRetriever chatterNameRetriever) {
+                        SyncManager.this.m368x9b8293a7(chatterNameRetriever);
+                    }
+                }, this.dbExecutor, true);
+            }
+            myName = this.myNameRetriever.getResolvedName();
+            if (myName != null) {
+                Query<ChatMessage> query = this.messagesQuery.forCurrentThread();
+                query.setParameter(0, Long.valueOf(this.lastConfirmedMessageID));
+                de.greenrobot.dao.query.LazyList<ChatMessage> messages = query.listLazy();
+                ImmutableList.Builder<com.lumiyaviewer.lumiya.cloud.common.LogChatMessage> builder = ImmutableList.builder();
+                int count = 0;
+                long lastMessageId = 0;
+                for (ChatMessage chatMessage : messages) {
+                    com.lumiyaviewer.lumiya.slproto.chat.generic.SLChatEvent chatEvent = com.lumiyaviewer.lumiya.slproto.chat.generic.SLChatEvent.loadFromDatabaseObject(chatMessage, this.userManager.getUserID());
+                    if (chatEvent != null) {
+                        Chatter chatter = this.chatterDao.load(Long.valueOf(chatMessage.getChatterID()));
+                        if (chatter != null) {
+                            String chatterName = resolveChatterName(chatter);
+                            if (chatterName == null) {
+                                break;
+                            }
+                            CharSequence text = chatEvent.getPlainTextMessage(this.context, this.userManager, false);
+                            com.lumiyaviewer.lumiya.cloud.common.LogChatMessage logChatMessage = new com.lumiyaviewer.lumiya.cloud.common.LogChatMessage(chatter.getType(), chatter.getUuid(), chatMessage.getId().longValue(), chatterName, "[" + this.dateFormat.format(chatMessage.getTimestamp()) + "] " + text);
+                            builder.add(logChatMessage);
+                            lastMessageId = logChatMessage.messageID;
+                            count++;
+                            if (count >= 100) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                messages.close();
+                if (count > 0) {
+                    com.lumiyaviewer.lumiya.cloud.common.LogMessageBatch batch = new com.lumiyaviewer.lumiya.cloud.common.LogMessageBatch(this.userManager.getUserID(), myName, builder.build(), lastMessageId);
+                    CloudSyncServiceConnection connection = this.syncServiceConnection.get();
+                    if (connection != null) {
+                        keepSyncMessageSent = connection.sendMessage(com.lumiyaviewer.lumiya.cloud.common.MessageType.LogMessageBatch, batch);
+                    }
+                }
+                if (!this.flushChatterNames.isEmpty()) {
+                    CloudSyncServiceConnection connection2 = this.syncServiceConnection.get();
+                    if (connection2 != null) {
+                        java.util.Iterator<String> iterator = this.flushChatterNames.iterator();
+                        if (iterator.hasNext()) {
+                            String chatterName2 = iterator.next();
+                            iterator.remove();
+                            connection2.sendMessage(com.lumiyaviewer.lumiya.cloud.common.MessageType.LogFlushMessages, new com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages(this.userManager.getUserID(), myName, chatterName2));
+                        }
+                    }
+                }
+            }
+            this.syncMessageSent.set(keepSyncMessageSent);
+        }
+        if (this.needsStopSyncing.getAndSet(false)) {
+            this.syncingEnabled.set(false);
+            CloudSyncServiceConnection connection3 = this.syncServiceConnection.getAndSet(null);
+            this.syncMessageSent.set(false);
+            if (connection3 != null) {
+                connection3.sendMessage(com.lumiyaviewer.lumiya.cloud.common.MessageType.LogFlushMessages, new com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages(this.userManager.getUserID(), null, null));
+                connection3.disconnect();
+            }
+        }
     }
 
     /* access modifiers changed from: package-private */

--- a/file_bundle/WorldViewActivity.java
+++ b/file_bundle/WorldViewActivity.java
@@ -17,6 +17,7 @@ import android.os.SystemClock;
 import androidx.preference.PreferenceManager;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.core.view.GestureDetectorCompat;
@@ -884,27 +885,13 @@ Method generation error in method: com.lumiyaviewer.lumiya.ui.render.-$Lambda$Yn
     }
 
     /* access modifiers changed from: private */
-    /* JADX WARNING: Code restructure failed: missing block: B:2:0x0006, code lost:
-        r0 = r0.findFragmentById(com.lumiyaviewer.lumiya.R.id.details);
-     */
-    /* Code decompiled incorrectly, please refer to instructions dump. */
     public boolean detailsVisible() {
-        /*
-            r2 = this;
-            android.support.v4.app.FragmentManager r0 = r2.getSupportFragmentManager()
-            if (r0 == 0) goto L_0x0017
-            r1 = 2131755284(0x7f100114, float:1.9141443E38)
-            android.support.v4.app.Fragment r0 = r0.findFragmentById(r1)
-            if (r0 == 0) goto L_0x0017
-            boolean r0 = r0.isVisible()
-            if (r0 == 0) goto L_0x0017
-            r0 = 1
-            return r0
-        L_0x0017:
-            r0 = 0
-            return r0
-        */
-        throw new UnsupportedOperationException("Method not decompiled: com.lumiyaviewer.lumiya.ui.render.WorldViewActivity.detailsVisible():boolean");
+        FragmentManager supportFragmentManager = getSupportFragmentManager();
+        if (supportFragmentManager == null) {
+            return false;
+        }
+        Fragment findFragmentById = supportFragmentManager.findFragmentById(R.id.details);
+        return findFragmentById != null && findFragmentById.isVisible();
     }
 
     private void displayHUD(int i) {
@@ -1278,390 +1265,72 @@ Method generation error in method: com.lumiyaviewer.lumiya.ui.render.-$Lambda$Yn
     /* JADX WARNING: Removed duplicated region for block: B:99:0x013b  */
     /* Code decompiled incorrectly, please refer to instructions dump. */
     private void updateObjectPanel() {
-        /*
-            r12 = this;
-            com.lumiyaviewer.lumiya.react.SubscriptionData<com.lumiyaviewer.lumiya.react.SubscriptionSingleKey, com.lumiyaviewer.lumiya.slproto.users.manager.MyAvatarState> r0 = r12.myAvatarState
-            java.lang.Object r0 = r0.getData()
-            com.lumiyaviewer.lumiya.slproto.users.manager.MyAvatarState r0 = (com.lumiyaviewer.lumiya.slproto.users.manager.MyAvatarState) r0
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.util.UUID, com.lumiyaviewer.lumiya.slproto.SLAgentCircuit> r1 = r12.agentCircuit
-            java.lang.Object r1 = r1.getData()
-            com.lumiyaviewer.lumiya.slproto.SLAgentCircuit r1 = (com.lumiyaviewer.lumiya.slproto.SLAgentCircuit) r1
-            if (r1 == 0) goto L_0x0143
-            r2 = 1
-            r8 = r2
-        L_0x0014:
-            if (r0 == 0) goto L_0x0147
-            boolean r2 = r0.isSitting()
-            r7 = r2
-        L_0x001b:
-            if (r0 == 0) goto L_0x014b
-            boolean r2 = r0.hasHUDs()
-            r6 = r2
-        L_0x0022:
-            if (r0 == 0) goto L_0x014f
-            boolean r2 = r0.isFlying()
-            r5 = r2
-        L_0x0029:
-            if (r1 == 0) goto L_0x0153
-            com.lumiyaviewer.lumiya.slproto.modules.SLModules r2 = r1.getModules()
-            com.lumiyaviewer.lumiya.slproto.modules.rlv.RLVController r2 = r2.rlvController
-            boolean r2 = r2.canStandUp()
-            r4 = r2
-        L_0x0036:
-            if (r1 == 0) goto L_0x0157
-            com.lumiyaviewer.lumiya.slproto.modules.SLModules r1 = r1.getModules()
-            com.lumiyaviewer.lumiya.slproto.modules.rlv.RLVController r1 = r1.rlvController
-            boolean r1 = r1.canSit()
-        L_0x0042:
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r2 = r12.pickedObject
-            if (r2 == 0) goto L_0x015a
-            r2 = 1
-        L_0x0047:
-            java.lang.String r3 = "isSitting %b, isFlying %b, hasHUDs %b, isDragging %b"
-            r9 = 4
-            java.lang.Object[] r9 = new java.lang.Object[r9]
-            java.lang.Boolean r10 = java.lang.Boolean.valueOf(r7)
-            r11 = 0
-            r9[r11] = r10
-            java.lang.Boolean r10 = java.lang.Boolean.valueOf(r5)
-            r11 = 1
-            r9[r11] = r10
-            java.lang.Boolean r10 = java.lang.Boolean.valueOf(r6)
-            r11 = 2
-            r9[r11] = r10
-            boolean r10 = r12.isDragging
-            java.lang.Boolean r10 = java.lang.Boolean.valueOf(r10)
-            r11 = 3
-            r9[r11] = r10
-            com.lumiyaviewer.lumiya.Debug.Printf(r3, r9)
-            android.view.ViewGroup r9 = r12.dragPointerLayout
-            boolean r3 = r12.isDragging
-            if (r3 == 0) goto L_0x015d
-            r3 = 0
-        L_0x0075:
-            r9.setVisibility(r3)
-            android.view.View r9 = r12.dragPointer
-            boolean r3 = r12.isDragging
-            if (r3 == 0) goto L_0x0160
-            r3 = 0
-        L_0x007f:
-            r9.setVisibility(r3)
-            android.widget.LinearLayout r9 = r12.flyButtonsLayout
-            if (r7 != 0) goto L_0x008a
-            r3 = r8 ^ 1
-            if (r3 == 0) goto L_0x0094
-        L_0x008a:
-            boolean r3 = r12.camButtonEnabled
-            if (r3 == 0) goto L_0x0163
-            boolean r3 = r12.manualCamMode
-        L_0x0090:
-            r3 = r3 ^ 1
-            if (r3 != 0) goto L_0x009a
-        L_0x0094:
-            boolean r3 = r12.isDragging
-            if (r3 != 0) goto L_0x009a
-            if (r2 == 0) goto L_0x0166
-        L_0x009a:
-            r3 = 8
-        L_0x009c:
-            r9.setVisibility(r3)
-            android.view.View r9 = r12.moveButtonsLayout
-            if (r7 != 0) goto L_0x00a7
-            r3 = r8 ^ 1
-            if (r3 == 0) goto L_0x00b1
-        L_0x00a7:
-            boolean r3 = r12.camButtonEnabled
-            if (r3 == 0) goto L_0x0169
-            boolean r3 = r12.manualCamMode
-        L_0x00ad:
-            r3 = r3 ^ 1
-            if (r3 != 0) goto L_0x00b7
-        L_0x00b1:
-            boolean r3 = r12.isDragging
-            if (r3 != 0) goto L_0x00b7
-            if (r2 == 0) goto L_0x016c
-        L_0x00b7:
-            r3 = 4
-        L_0x00b8:
-            r9.setVisibility(r3)
-            android.widget.ImageButton r9 = r12.buttonStandUp
-            if (r4 == 0) goto L_0x016f
-            if (r7 == 0) goto L_0x016f
-            boolean r3 = r12.isDragging
-            r3 = r3 ^ 1
-            if (r3 == 0) goto L_0x016f
-            r3 = 0
-        L_0x00c8:
-            r9.setVisibility(r3)
-            android.widget.Button r9 = r12.buttonHUD
-            if (r6 == 0) goto L_0x0173
-            boolean r3 = r12.isDragging
-            r3 = r3 ^ 1
-            if (r3 == 0) goto L_0x0173
-            if (r8 == 0) goto L_0x0173
-            r3 = 0
-        L_0x00d8:
-            r9.setVisibility(r3)
-            android.widget.ImageButton r6 = r12.buttonFlyDownward
-            if (r5 == 0) goto L_0x00e1
-            if (r8 != 0) goto L_0x00e9
-        L_0x00e1:
-            boolean r3 = r12.camButtonEnabled
-            if (r3 == 0) goto L_0x0177
-            boolean r3 = r12.manualCamMode
-            if (r3 == 0) goto L_0x0177
-        L_0x00e9:
-            r3 = 0
-        L_0x00ea:
-            r6.setVisibility(r3)
-            android.widget.ImageButton r6 = r12.buttonStopFlying
-            if (r5 == 0) goto L_0x017e
-            if (r8 == 0) goto L_0x017e
-            boolean r3 = r12.camButtonEnabled
-            if (r3 == 0) goto L_0x017b
-            boolean r3 = r12.manualCamMode
-        L_0x00f9:
-            r3 = r3 ^ 1
-            if (r3 == 0) goto L_0x017e
-            r3 = 0
-        L_0x00fe:
-            r6.setVisibility(r3)
-            android.widget.ImageButton r5 = r12.buttonCamOn
-            boolean r3 = r12.camButtonEnabled
-            if (r3 == 0) goto L_0x0182
-            boolean r3 = r12.manualCamMode
-            r3 = r3 ^ 1
-            if (r3 == 0) goto L_0x0182
-            boolean r3 = r12.isDragging
-            r3 = r3 ^ 1
-            if (r3 == 0) goto L_0x0182
-            r3 = r2 ^ 1
-            if (r3 == 0) goto L_0x0182
-            r3 = 0
-        L_0x0118:
-            r5.setVisibility(r3)
-            android.widget.ImageButton r3 = r12.buttonCamOff
-            boolean r5 = r12.camButtonEnabled
-            if (r5 == 0) goto L_0x0185
-            boolean r5 = r12.manualCamMode
-            if (r5 == 0) goto L_0x0185
-            boolean r5 = r12.isDragging
-            r5 = r5 ^ 1
-            if (r5 == 0) goto L_0x0185
-            r2 = r2 ^ 1
-            if (r2 == 0) goto L_0x0185
-            r2 = 0
-        L_0x0130:
-            r3.setVisibility(r2)
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r2 = r12.pickedObject
-            if (r2 == 0) goto L_0x013b
-            r2 = r8 ^ 1
-            if (r2 == 0) goto L_0x0188
-        L_0x013b:
-            android.view.View r0 = r12.objectControlsPanel
-            r1 = 8
-            r0.setVisibility(r1)
-        L_0x0142:
-            return
-        L_0x0143:
-            r2 = 0
-            r8 = r2
-            goto L_0x0014
-        L_0x0147:
-            r2 = 0
-            r7 = r2
-            goto L_0x001b
-        L_0x014b:
-            r2 = 0
-            r6 = r2
-            goto L_0x0022
-        L_0x014f:
-            r2 = 0
-            r5 = r2
-            goto L_0x0029
-        L_0x0153:
-            r2 = 0
-            r4 = r2
-            goto L_0x0036
-        L_0x0157:
-            r1 = 0
-            goto L_0x0042
-        L_0x015a:
-            r2 = 0
-            goto L_0x0047
-        L_0x015d:
-            r3 = 4
-            goto L_0x0075
-        L_0x0160:
-            r3 = 4
-            goto L_0x007f
-        L_0x0163:
-            r3 = 0
-            goto L_0x0090
-        L_0x0166:
-            r3 = 0
-            goto L_0x009c
-        L_0x0169:
-            r3 = 0
-            goto L_0x00ad
-        L_0x016c:
-            r3 = 0
-            goto L_0x00b8
-        L_0x016f:
-            r3 = 8
-            goto L_0x00c8
-        L_0x0173:
-            r3 = 8
-            goto L_0x00d8
-        L_0x0177:
-            r3 = 8
-            goto L_0x00ea
-        L_0x017b:
-            r3 = 0
-            goto L_0x00f9
-        L_0x017e:
-            r3 = 8
-            goto L_0x00fe
-        L_0x0182:
-            r3 = 8
-            goto L_0x0118
-        L_0x0185:
-            r2 = 8
-            goto L_0x0130
-        L_0x0188:
-            android.view.View r2 = r12.objectControlsPanel
-            r3 = 0
-            r2.setVisibility(r3)
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r2 = r12.pickedObject
-            boolean r2 = r2.isTouchable()
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r3 = r12.pickedObject
-            boolean r3 = r3.isAvatar()
-            if (r3 == 0) goto L_0x01a3
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r3 = r12.pickedObject
-            boolean r3 = r3.hasTouchableChildren()
-            r2 = r2 | r3
-        L_0x01a3:
-            android.widget.ImageButton r3 = r12.objectTouchButton
-            if (r2 == 0) goto L_0x021f
-            r2 = 0
-        L_0x01a8:
-            r3.setVisibility(r2)
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r2 = r12.pickedObject
-            boolean r3 = r2.isAvatar()
-            if (r7 == 0) goto L_0x0222
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r2 = r12.pickedObject
-            int r2 = r2.localID
-            int r0 = r0.sittingOn()
-            if (r2 != r0) goto L_0x0222
-            r0 = 1
-        L_0x01be:
-            if (r3 != 0) goto L_0x0224
-            r2 = r0 ^ 1
-        L_0x01c2:
-            if (r3 != 0) goto L_0x0226
-        L_0x01c4:
-            android.widget.ImageButton r5 = r12.objectSitButton
-            if (r2 == 0) goto L_0x0228
-            if (r1 == 0) goto L_0x0228
-            r1 = 0
-        L_0x01cb:
-            r5.setVisibility(r1)
-            android.widget.ImageButton r1 = r12.objectStandButton
-            if (r0 == 0) goto L_0x022b
-            if (r4 == 0) goto L_0x022b
-            r0 = 0
-        L_0x01d5:
-            r1.setVisibility(r0)
-            android.widget.ImageButton r1 = r12.objectChatButton
-            if (r3 == 0) goto L_0x022e
-            r0 = 0
-        L_0x01dd:
-            r1.setVisibility(r0)
-            android.widget.ImageView r1 = r12.avatarIconView
-            if (r3 == 0) goto L_0x0231
-            r0 = 0
-        L_0x01e5:
-            r1.setVisibility(r0)
-            android.widget.ImageButton r1 = r12.objectPayButton
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r0 = r12.pickedObject
-            boolean r0 = r0.isPayable()
-            if (r0 != 0) goto L_0x01f8
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r0 = r12.pickedObject
-            byte r0 = r0.saleType
-            if (r0 == 0) goto L_0x0234
-        L_0x01f8:
-            r0 = 0
-        L_0x01f9:
-            r1.setVisibility(r0)
-            r1 = 0
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r0 = r12.pickedObject
-            boolean r0 = r0.isAvatar()
-            if (r0 == 0) goto L_0x0237
-            com.lumiyaviewer.lumiya.slproto.users.ChatterNameRetriever r0 = r12.pickedAvatarNameRetriever
-            if (r0 == 0) goto L_0x0264
-            com.lumiyaviewer.lumiya.slproto.users.ChatterNameRetriever r0 = r12.pickedAvatarNameRetriever
-            java.lang.String r0 = r0.getResolvedName()
-        L_0x020f:
-            if (r0 != 0) goto L_0x0218
-            r0 = 2131296825(0x7f090239, float:1.8211578E38)
-            java.lang.String r0 = r12.getString(r0)
-        L_0x0218:
-            android.widget.TextView r1 = r12.objectNameTextView
-            r1.setText(r0)
-            goto L_0x0142
-        L_0x021f:
-            r2 = 8
-            goto L_0x01a8
-        L_0x0222:
-            r0 = 0
-            goto L_0x01be
-        L_0x0224:
-            r2 = 0
-            goto L_0x01c2
-        L_0x0226:
-            r0 = 0
-            goto L_0x01c4
-        L_0x0228:
-            r1 = 8
-            goto L_0x01cb
-        L_0x022b:
-            r0 = 8
-            goto L_0x01d5
-        L_0x022e:
-            r0 = 8
-            goto L_0x01dd
-        L_0x0231:
-            r0 = 8
-            goto L_0x01e5
-        L_0x0234:
-            r0 = 8
-            goto L_0x01f9
-        L_0x0237:
-            com.lumiyaviewer.lumiya.react.SubscriptionData<java.lang.Integer, com.lumiyaviewer.lumiya.slproto.objects.SLObjectProfileData> r0 = r12.selectedObjectProfile
-            java.lang.Object r0 = r0.getData()
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectProfileData r0 = (com.lumiyaviewer.lumiya.slproto.objects.SLObjectProfileData) r0
-            if (r0 == 0) goto L_0x0262
-            java.util.UUID r2 = r0.objectUUID()
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r3 = r12.pickedObject
-            java.util.UUID r3 = r3.getId()
-            boolean r2 = com.google.common.base.Objects.equal(r2, r3)
-            if (r2 == 0) goto L_0x0262
-            com.google.common.base.Optional r0 = r0.name()
-            java.lang.Object r0 = r0.orNull()
-            java.lang.String r0 = (java.lang.String) r0
-        L_0x025b:
-            if (r0 != 0) goto L_0x020f
-            com.lumiyaviewer.lumiya.slproto.objects.SLObjectInfo r0 = r12.pickedObject
-            java.lang.String r0 = r0.name
-            goto L_0x020f
-        L_0x0262:
-            r0 = r1
-            goto L_0x025b
-        L_0x0264:
-            r0 = r1
-            goto L_0x020f
-        */
-        throw new UnsupportedOperationException("Method not decompiled: com.lumiyaviewer.lumiya.ui.render.WorldViewActivity.updateObjectPanel():void");
+        MyAvatarState myAvatarState2 = this.myAvatarState.getData();
+        SLAgentCircuit circuit = this.agentCircuit.getData();
+        boolean isConnected = circuit != null;
+        boolean isSitting = myAvatarState2 != null && myAvatarState2.isSitting();
+        boolean hasHUDs = myAvatarState2 != null && myAvatarState2.hasHUDs();
+        boolean isFlying = myAvatarState2 != null && myAvatarState2.isFlying();
+        boolean canStandUp = circuit != null && circuit.getModules().rlvController.canStandUp();
+        boolean canSit = circuit != null && circuit.getModules().rlvController.canSit();
+        boolean hasPickedObject = this.pickedObject != null;
+        boolean cameraLocked = this.camButtonEnabled ? this.manualCamMode : false;
+
+        this.dragPointerLayout.setVisibility(this.isDragging ? 0 : 4);
+        this.dragPointer.setVisibility(this.isDragging ? 0 : 4);
+
+        boolean hideMovement = isSitting || !isConnected || cameraLocked || this.isDragging || hasPickedObject;
+        this.flyButtonsLayout.setVisibility(hideMovement ? 8 : 0);
+        this.moveButtonsLayout.setVisibility(hideMovement ? 4 : 0);
+
+        this.buttonStandUp.setVisibility((canStandUp && isSitting && !this.isDragging) ? 0 : 8);
+        this.buttonHUD.setVisibility((hasHUDs && !this.isDragging && isConnected) ? 0 : 8);
+        this.buttonFlyDownward.setVisibility((isFlying || !isConnected || cameraLocked) ? 0 : 8);
+        this.buttonStopFlying.setVisibility((isFlying && isConnected && !cameraLocked) ? 0 : 8);
+
+        this.buttonCamOn.setVisibility((this.camButtonEnabled && !this.manualCamMode && !this.isDragging && !hasPickedObject) ? 0 : 8);
+        this.buttonCamOff.setVisibility((this.camButtonEnabled && this.manualCamMode && !this.isDragging && !hasPickedObject) ? 0 : 8);
+
+        if (this.pickedObject == null || !isConnected) {
+            this.objectControlsPanel.setVisibility(8);
+            return;
+        }
+
+        this.objectControlsPanel.setVisibility(0);
+        boolean canTouch = this.pickedObject.isTouchable();
+        boolean isAvatar = this.pickedObject.isAvatar();
+        if (isAvatar) {
+            canTouch |= this.pickedObject.hasTouchableChildren();
+        }
+        this.objectTouchButton.setVisibility(canTouch ? 0 : 8);
+
+        boolean sittingOnPicked = isSitting && myAvatarState2 != null && this.pickedObject.localID == myAvatarState2.sittingOn();
+        boolean canSitOnPicked = !isAvatar && !sittingOnPicked;
+        this.objectSitButton.setVisibility((canSitOnPicked && canSit) ? 0 : 8);
+        this.objectStandButton.setVisibility((sittingOnPicked && canStandUp) ? 0 : 8);
+        this.objectChatButton.setVisibility(isAvatar ? 0 : 8);
+        this.avatarIconView.setVisibility(isAvatar ? 0 : 8);
+
+        this.objectPayButton.setVisibility((this.pickedObject.isPayable() || this.pickedObject.saleType != 0) ? 0 : 8);
+
+        String name = null;
+        if (isAvatar) {
+            if (this.pickedAvatarNameRetriever != null) {
+                name = this.pickedAvatarNameRetriever.getResolvedName();
+            }
+            if (name == null) {
+                name = getString(R.string.unknown_avatar);
+            }
+        } else {
+            SLObjectProfileData profileData = this.selectedObjectProfile.getData();
+            if (profileData != null && Objects.equal(profileData.objectUUID(), this.pickedObject.getId())) {
+                name = profileData.name().orNull();
+            }
+            if (name == null) {
+                name = this.pickedObject.name;
+            }
+        }
+        this.objectNameTextView.setText(name);
     }
 
     private void updateSimTimeOverride() {

--- a/lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SyncManager.java
+++ b/lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SyncManager.java
@@ -179,11 +179,76 @@ public class SyncManager {
         To view partially-correct add '--show-bad-code' argument
     */
     public void m371x9b8293aa() {
-        /*
-            Method dump skipped, instructions count: 444
-            To view this dump add '--comments-level debug' option
-        */
-        throw new UnsupportedOperationException("Method not decompiled: com.lumiyaviewer.lumiya.slproto.users.manager.SyncManager.m371x9b8293aa():void");
+        if (!this.syncMessageSent.getAndSet(true)) {
+            boolean keepSyncMessageSent = false;
+            String myName = null;
+            if (this.myNameRetriever == null) {
+                this.myNameRetriever = new ChatterNameRetriever(ChatterID.getUserChatterID(this.userManager.getUserID(), this.userManager.getUserID()), new ChatterNameRetriever.OnChatterNameUpdated() {
+                    @Override
+                    public void onChatterNameUpdated(ChatterNameRetriever chatterNameRetriever) {
+                        SyncManager.this.m368x9b8293a7(chatterNameRetriever);
+                    }
+                }, this.dbExecutor, true);
+            }
+            myName = this.myNameRetriever.getResolvedName();
+            if (myName != null) {
+                Query<ChatMessage> query = this.messagesQuery.forCurrentThread();
+                query.setParameter(0, Long.valueOf(this.lastConfirmedMessageID));
+                de.greenrobot.dao.query.LazyList<ChatMessage> messages = query.listLazy();
+                ImmutableList.Builder<com.lumiyaviewer.lumiya.cloud.common.LogChatMessage> builder = ImmutableList.builder();
+                int count = 0;
+                long lastMessageId = 0;
+                for (ChatMessage chatMessage : messages) {
+                    com.lumiyaviewer.lumiya.slproto.chat.generic.SLChatEvent chatEvent = com.lumiyaviewer.lumiya.slproto.chat.generic.SLChatEvent.loadFromDatabaseObject(chatMessage, this.userManager.getUserID());
+                    if (chatEvent != null) {
+                        Chatter chatter = this.chatterDao.load(Long.valueOf(chatMessage.getChatterID()));
+                        if (chatter != null) {
+                            String chatterName = resolveChatterName(chatter);
+                            if (chatterName == null) {
+                                break;
+                            }
+                            CharSequence text = chatEvent.getPlainTextMessage(this.context, this.userManager, false);
+                            com.lumiyaviewer.lumiya.cloud.common.LogChatMessage logChatMessage = new com.lumiyaviewer.lumiya.cloud.common.LogChatMessage(chatter.getType(), chatter.getUuid(), chatMessage.getId().longValue(), chatterName, "[" + this.dateFormat.format(chatMessage.getTimestamp()) + "] " + text);
+                            builder.add(logChatMessage);
+                            lastMessageId = logChatMessage.messageID;
+                            count++;
+                            if (count >= 100) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                messages.close();
+                if (count > 0) {
+                    com.lumiyaviewer.lumiya.cloud.common.LogMessageBatch batch = new com.lumiyaviewer.lumiya.cloud.common.LogMessageBatch(this.userManager.getUserID(), myName, builder.build(), lastMessageId);
+                    CloudSyncServiceConnection connection = this.syncServiceConnection.get();
+                    if (connection != null) {
+                        keepSyncMessageSent = connection.sendMessage(com.lumiyaviewer.lumiya.cloud.common.MessageType.LogMessageBatch, batch);
+                    }
+                }
+                if (!this.flushChatterNames.isEmpty()) {
+                    CloudSyncServiceConnection connection2 = this.syncServiceConnection.get();
+                    if (connection2 != null) {
+                        java.util.Iterator<String> iterator = this.flushChatterNames.iterator();
+                        if (iterator.hasNext()) {
+                            String chatterName2 = iterator.next();
+                            iterator.remove();
+                            connection2.sendMessage(com.lumiyaviewer.lumiya.cloud.common.MessageType.LogFlushMessages, new com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages(this.userManager.getUserID(), myName, chatterName2));
+                        }
+                    }
+                }
+            }
+            this.syncMessageSent.set(keepSyncMessageSent);
+        }
+        if (this.needsStopSyncing.getAndSet(false)) {
+            this.syncingEnabled.set(false);
+            CloudSyncServiceConnection connection3 = this.syncServiceConnection.getAndSet(null);
+            this.syncMessageSent.set(false);
+            if (connection3 != null) {
+                connection3.sendMessage(com.lumiyaviewer.lumiya.cloud.common.MessageType.LogFlushMessages, new com.lumiyaviewer.lumiya.cloud.common.LogFlushMessages(this.userManager.getUserID(), null, null));
+                connection3.disconnect();
+            }
+        }
     }
 
     /* JADX INFO: Access modifiers changed from: package-private */

--- a/lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldViewActivity.java
+++ b/lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldViewActivity.java
@@ -846,11 +846,72 @@ public class WorldViewActivity extends DetailsActivity implements View.OnTouchLi
         To view partially-correct add '--show-bad-code' argument
     */
     private void updateObjectPanel() {
-        /*
-            Method dump skipped, instructions count: 614
-            To view this dump add '--comments-level debug' option
-        */
-        throw new UnsupportedOperationException("Method not decompiled: com.lumiyaviewer.lumiya.ui.render.WorldViewActivity.updateObjectPanel():void");
+        MyAvatarState myAvatarState2 = this.myAvatarState.getData();
+        SLAgentCircuit circuit = this.agentCircuit.getData();
+        boolean isConnected = circuit != null;
+        boolean isSitting = myAvatarState2 != null && myAvatarState2.isSitting();
+        boolean hasHUDs = myAvatarState2 != null && myAvatarState2.hasHUDs();
+        boolean isFlying = myAvatarState2 != null && myAvatarState2.isFlying();
+        boolean canStandUp = circuit != null && circuit.getModules().rlvController.canStandUp();
+        boolean canSit = circuit != null && circuit.getModules().rlvController.canSit();
+        boolean hasPickedObject = this.pickedObject != null;
+        boolean cameraLocked = this.camButtonEnabled ? this.manualCamMode : false;
+
+        this.dragPointerLayout.setVisibility(this.isDragging ? 0 : 4);
+        this.dragPointer.setVisibility(this.isDragging ? 0 : 4);
+
+        boolean hideMovement = isSitting || !isConnected || cameraLocked || this.isDragging || hasPickedObject;
+        this.flyButtonsLayout.setVisibility(hideMovement ? 8 : 0);
+        this.moveButtonsLayout.setVisibility(hideMovement ? 4 : 0);
+
+        this.buttonStandUp.setVisibility((canStandUp && isSitting && !this.isDragging) ? 0 : 8);
+        this.buttonHUD.setVisibility((hasHUDs && !this.isDragging && isConnected) ? 0 : 8);
+        this.buttonFlyDownward.setVisibility((isFlying || !isConnected || cameraLocked) ? 0 : 8);
+        this.buttonStopFlying.setVisibility((isFlying && isConnected && !cameraLocked) ? 0 : 8);
+
+        this.buttonCamOn.setVisibility((this.camButtonEnabled && !this.manualCamMode && !this.isDragging && !hasPickedObject) ? 0 : 8);
+        this.buttonCamOff.setVisibility((this.camButtonEnabled && this.manualCamMode && !this.isDragging && !hasPickedObject) ? 0 : 8);
+
+        if (this.pickedObject == null || !isConnected) {
+            this.objectControlsPanel.setVisibility(8);
+            return;
+        }
+
+        this.objectControlsPanel.setVisibility(0);
+        boolean canTouch = this.pickedObject.isTouchable();
+        boolean isAvatar = this.pickedObject.isAvatar();
+        if (isAvatar) {
+            canTouch |= this.pickedObject.hasTouchableChildren();
+        }
+        this.objectTouchButton.setVisibility(canTouch ? 0 : 8);
+
+        boolean sittingOnPicked = isSitting && myAvatarState2 != null && this.pickedObject.localID == myAvatarState2.sittingOn();
+        boolean canSitOnPicked = !isAvatar && !sittingOnPicked;
+        this.objectSitButton.setVisibility((canSitOnPicked && canSit) ? 0 : 8);
+        this.objectStandButton.setVisibility((sittingOnPicked && canStandUp) ? 0 : 8);
+        this.objectChatButton.setVisibility(isAvatar ? 0 : 8);
+        this.avatarIconView.setVisibility(isAvatar ? 0 : 8);
+
+        this.objectPayButton.setVisibility((this.pickedObject.isPayable() || this.pickedObject.saleType != 0) ? 0 : 8);
+
+        String name = null;
+        if (isAvatar) {
+            if (this.pickedAvatarNameRetriever != null) {
+                name = this.pickedAvatarNameRetriever.getResolvedName();
+            }
+            if (name == null) {
+                name = getString(R.string.unknown_avatar);
+            }
+        } else {
+            SLObjectProfileData profileData = this.selectedObjectProfile.getData();
+            if (profileData != null && Objects.equal(profileData.objectUUID(), this.pickedObject.getId())) {
+                name = profileData.name().orNull();
+            }
+            if (name == null) {
+                name = this.pickedObject.name;
+            }
+        }
+        this.objectNameTextView.setText(name);
     }
 
     private void updateSimTimeOverride() {


### PR DESCRIPTION
### Motivation
- Remove decompiler-generated stubs that threw `UnsupportedOperationException` and restore behavior for group-invite, sync batching, and the world object panel so runtime paths no longer crash and UI flows behave deterministically.

### Description
- Implemented a concrete `onInviteClicked` flow in `file_bundle/GroupMainProfileTab.java` that validates agent/data presence, checks group powers, and launches `AvatarPickerForInvite` when permitted.
- Reconstructed the message-batching/sync flow in `SyncManager` (both `file_bundle/SyncManager.java` and `lumiya_decompiled_source/.../SyncManager.java`) to collect unsynced chat messages, build `LogMessageBatch` payloads, dispatch flush messages, and perform clean teardown when syncing stops.
- Replaced `detailsVisible()` and `updateObjectPanel()` stubs in `file_bundle/WorldViewActivity.java` (and `updateObjectPanel()` in the decompiled `lumiya_decompiled_source` copy) with real UI-state logic that computes visibility and control enablement from avatar state, agent circuit, and picked-object data.
- Updated the CSV tracker `docs/broken_code_inventory_2026-04-24.csv` to mark the repaired files as `OK` and cleared their `broken_signals` entries.

### Testing
- Verified no remaining decompilation stubs by running `rg -n "UnsupportedOperationException(\"Method not decompiled"` against the modified files and confirmed zero matches (success).
- Validated tracker updates by reading `docs/broken_code_inventory_2026-04-24.csv` and confirming the targeted rows now show `status=OK` and empty `broken_signals` (success).
- Performed repository hygiene checks using `rg` and `git status` to confirm the expected files were modified and no other stub instances remain (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb63a2ef748323a6c2d21a1b990835)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes decompiler-generated stubs that threw `UnsupportedOperationException` and replaces them with functional implementations across three main areas: group invite functionality in `GroupMainProfileTab`, message batching and sync logic in `SyncManager`, and UI state management for the world object panel in `WorldViewActivity`. The implementations validate agent and data presence, check permissions, handle message collection and dispatching, and compute UI visibility and control states based on avatar state and picked objects. The CSV inventory tracker is updated to mark all repaired files as `OK` with cleared broken signals.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/broken_code_inventory_2026-04-24.csv` |
| 2 | `file_bundle/GroupMainProfileTab.java` |
| 3 | `file_bundle/SyncManager.java` |
| 4 | `lumiya_decompiled_source/com/lumiyaviewer/lumiya/slproto/users/manager/SyncManager.java` |
| 5 | `file_bundle/WorldViewActivity.java` |
| 6 | `lumiya_decompiled_source/com/lumiyaviewer/lumiya/ui/render/WorldViewActivity.java` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->