### PR TITLE
Add login/world-data validation script with APK build and device-smoke flow

### DIFF
--- a/scripts/validate_login_world_data.sh
+++ b/scripts/validate_login_world_data.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="$ROOT_DIR/Linkpoint"
+APK_PATH="$APP_DIR/build/outputs/apk/stable/debug/Linkpoint-stable-debug.apk"
+ADB="/usr/lib/android-sdk/platform-tools/adb"
+
+USERNAME_DEFAULT="Firstname Lastname"
+PASSWORD_DEFAULT="Password"
+LINKPOINT_USERNAME="${LINKPOINT_USERNAME:-$USERNAME_DEFAULT}"
+LINKPOINT_PASSWORD="${LINKPOINT_PASSWORD:-$PASSWORD_DEFAULT}"
+
+run_unit_checks() {
+  echo "[1/3] Running login + world-data unit tests"
+  (cd "$APP_DIR" && ./gradlew testStableDebugUnitTest \
+    --tests "com.linkpoint.connection.ConnectionIntegrationTest" \
+    --tests "com.linkpoint.protocol.messages.RegionHandshakeParserTest" \
+    --tests "com.linkpoint.protocol.messages.MessageRouterTest")
+}
+
+build_apk() {
+  echo "[2/3] Building stable debug APK"
+  (cd "$APP_DIR" && ./gradlew assembleStableDebug)
+  echo "APK: $APK_PATH"
+}
+
+device_smoke() {
+  echo "[3/3] Device smoke preflight"
+  if ! command -v "$ADB" >/dev/null 2>&1; then
+    echo "WARN: adb not found at $ADB. Skipping device smoke."
+    return 0
+  fi
+
+  local connected
+  connected="$($ADB devices | awk 'NR>1 && $2=="device" {print $1}' | head -n1)"
+  if [[ -z "$connected" ]]; then
+    echo "WARN: no running emulator/device detected."
+    echo "      To run device smoke: boot an emulator, then rerun this script."
+    return 0
+  fi
+
+  echo "Installing APK on $connected"
+  "$ADB" -s "$connected" install -r "$APK_PATH"
+
+  cat <<MSG
+Device smoke prep complete.
+Credentials available for manual login entry:
+  username: $LINKPOINT_USERNAME
+  password: $LINKPOINT_PASSWORD
+
+After opening Linkpoint, verify these in logcat:
+  - successful login response
+  - UDP circuit established
+  - RegionHandshake received
+  - object/avatar updates flowing
+MSG
+}
+
+run_unit_checks
+build_apk
+device_smoke
+
+echo "Validation script completed."


### PR DESCRIPTION
### Motivation
- Provide a repeatable, single-command validation flow for the login/world-data code paths to reduce manual steps during local QA and CI.
- Make it easy to build the APK, run focused unit tests for connection/handshake/message parsing, and optionally install to a connected device for runtime verification.
- Allow injection of test credentials via environment variables while keeping a safe default for quick local runs.

### Description
- Add an executable script `scripts/validate_login_world_data.sh` that runs targeted unit tests, builds the stable debug APK, and performs an ADB device-smoke preflight/install when a device is available.
- The script runs `./gradlew testStableDebugUnitTest` for the focused tests `com.linkpoint.connection.ConnectionIntegrationTest`, `com.linkpoint.protocol.messages.RegionHandshakeParserTest`, and `com.linkpoint.protocol.messages.MessageRouterTest` and then runs `./gradlew assembleStableDebug` to produce the APK at `Linkpoint/build/outputs/apk/stable/debug/Linkpoint-stable-debug.apk`.
- Supports credential overrides via `LINKPOINT_USERNAME` and `LINKPOINT_PASSWORD` with defaults `Firstname Lastname` and `Password`, and prints a concise post-install checklist of runtime signals to verify (login success, UDP circuit, RegionHandshake, object/avatar updates).

### Testing
- Ran the focused unit tests via `./gradlew testStableDebugUnitTest` for the three tests listed above, and they completed successfully.
- Executed `./gradlew assembleStableDebug` which completed successfully and produced `Linkpoint/build/outputs/apk/stable/debug/Linkpoint-stable-debug.apk`.
- The script's ADB-based device-smoke install step is conditional and will run when a device/emulator is connected; in this environment the step was skipped because no device was detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9ea22ee8832395eda1106f24883b)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a validation script that automates testing and building the Android app for login and world-data code paths. The script `validate_login_world_data.sh` orchestrates three steps: running focused unit tests for connection, handshake parsing, and message routing; building the stable debug APK; and conditionally installing the APK to a connected device with instructions for manual runtime verification. It supports credential injection via environment variables (`LINKPOINT_USERNAME` and `LINKPOINT_PASSWORD`) and provides sensible defaults for quick local execution.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/validate_login_world_data.sh` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added automated validation workflow for login and world-data functionality
* Validation includes unit testing, APK build verification, and optional device smoke testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->