### PR TITLE
Fix UDP receive loop startup ordering

### DIFF
--- a/src/main/java/com/linkpoint/protocol/messages/RobustUDPConnection.kt
+++ b/src/main/java/com/linkpoint/protocol/messages/RobustUDPConnection.kt
@@ -102,14 +102,12 @@ class RobustUDPConnection(
             datagramChannel?.configureBlocking(true)
             datagramChannel?.connect(address)
             
-            // Start receive loop
-            startReceiveLoop()
-            
-            // Start heartbeat
-            startHeartbeat()
-            
             _connectionState.value = ConnectionState.CONNECTED
             reconnectAttempts.set(0)
+
+            // Start loops after state is CONNECTED so their guards are true
+            startReceiveLoop()
+            startHeartbeat()
             
             Log.i(TAG, "✓ Connected to $simIP:$simPort")
             true


### PR DESCRIPTION
### Motivation
- Prevent a race where the receive and heartbeat coroutines start while `_connectionState` is still `CONNECTING`, causing their `while (... && _connectionState.value == ConnectionState.CONNECTED)` guards to evaluate false and the coroutines to exit immediately.

### Description
- Set `_connectionState.value = ConnectionState.CONNECTED` before launching `startReceiveLoop()` and `startHeartbeat()` in `RobustUDPConnection.connect()` so the coroutine loop guards are true when they start.
- Added an inline comment explaining that the loops are started after the state transition so their guards are true.

### Testing
- Attempted to run `./gradlew :app:compileDebugKotlin`, but the build could not run in this environment because the Android SDK location is not configured (`ANDROID_HOME` / `sdk.dir` missing), so no automated build/test completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb13052d48323a40b6a7e5ffc46fe)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a race condition in the UDP connection startup sequence by ensuring that `_connectionState` is set to `CONNECTED` **before** launching the receive loop and heartbeat coroutines. Previously, these coroutines could start while the connection state was still `CONNECTING`, causing their loop guards to evaluate false and exit immediately. The fix reorders the operations so that the state transition happens first, ensuring the coroutine loop guards are true when they begin execution.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/main/java/com/linkpoint/protocol/messages/RobustUDPConnection.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UDP connection reliability by improving the timing of connection state initialization, ensuring background processes function correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->