### PR TITLE
Fix Int overflow in AssetCache memory cache size

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/assets/AssetCache.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/assets/AssetCache.kt
@@ -27,9 +27,23 @@ class AssetCache(private val context: Context) {
     
     // Memory cache (LRU) - uses configured size from CacheManager
     private val memoryCache: LruCache<String, ByteArray> by lazy {
-        val maxMemoryMB = cacheManager.getMemoryCacheSizeMB()
-        Log.i(TAG, "Initializing memory cache: ${maxMemoryMB}MB")
-        object : LruCache<String, ByteArray>(maxMemoryMB * 1024 * 1024) {
+        val configuredMB = cacheManager.getMemoryCacheSizeMB()
+        // Clamp the MB value in case a persisted preference is outside the supported range,
+        // then compute bytes in Long to avoid Int overflow. LruCache's maxSize is an Int,
+        // so at >= 2048 MB the naive Int multiplication wraps to <= 0 and crashes the
+        // constructor with "maxSize <= 0".
+        val clampedMB = configuredMB.coerceIn(
+            CacheManager.MIN_MEMORY_CACHE_MB,
+            CacheManager.MAX_MEMORY_CACHE_MB
+        )
+        val maxBytes = (clampedMB.toLong() * 1024L * 1024L)
+            .coerceAtMost(Int.MAX_VALUE.toLong())
+            .toInt()
+        if (clampedMB != configuredMB) {
+            Log.w(TAG, "Memory cache size ${configuredMB}MB out of range; clamped to ${clampedMB}MB")
+        }
+        Log.i(TAG, "Initializing memory cache: ${maxBytes / 1024 / 1024}MB")
+        object : LruCache<String, ByteArray>(maxBytes) {
             override fun sizeOf(key: String, value: ByteArray): Int = value.size
         }
     }


### PR DESCRIPTION
The LruCache constructor was called with `maxMemoryMB * 1024 * 1024` in Int
arithmetic. With the settings UI allowing values up to MAX_MEMORY_CACHE_MB
(4096), the multiplication overflows Int (4096 MB wraps to 0, 2048 MB wraps
to Int.MIN_VALUE), causing `IllegalArgumentException: maxSize <= 0` on the
first asset fetch. Compute bytes in Long and clamp to Int.MAX_VALUE, and
clamp the configured MB value to the supported range as a defense against
corrupted preferences.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes an integer overflow bug in the `AssetCache` memory cache initialization that occurred when calculating the cache size in bytes. When the configured memory cache size was set to high values (e.g., 4096 MB or 2048 MB), the naive `Int` arithmetic (`maxMemoryMB * 1024 * 1024`) would overflow, resulting in zero or negative values and causing an `IllegalArgumentException` when creating the `LruCache`. The fix performs the byte calculation using `Long` arithmetic, clamps the result to `Int.MAX_VALUE`, and also defensively clamps the configured MB value to the supported range with appropriate logging.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/assets/AssetCache.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->