### PR TITLE
Fix misleading phases and false 'no packets received' in debug report

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -752,7 +752,7 @@ class LinkpointApp : Application() {
                             com.linkpoint.utils.InitializationTracker.Phase.REGION_HANDSHAKE_RECEIVED,
                             "Reply sent to ${regionData.simName}"
                         )
-                        com.linkpoint.utils.InitializationTracker.startPhase(
+                        com.linkpoint.utils.InitializationTracker.reachPhase(
                             com.linkpoint.utils.InitializationTracker.Phase.REGION_HANDSHAKE_REPLIED,
                             "Waiting for world data"
                         )
@@ -823,7 +823,7 @@ class LinkpointApp : Application() {
                         com.linkpoint.utils.InitializationTracker.Phase.AGENT_MOVEMENT_COMPLETE,
                         "Agent at ${moveData.position}"
                     )
-                    com.linkpoint.utils.InitializationTracker.startPhase(
+                    com.linkpoint.utils.InitializationTracker.reachPhase(
                         com.linkpoint.utils.InitializationTracker.Phase.FULLY_CONNECTED,
                         "Agent is now in world"
                     )

--- a/Linkpoint/src/main/java/com/linkpoint/network/SecondLifeProtocol.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/SecondLifeProtocol.kt
@@ -168,7 +168,7 @@ class SecondLifeProtocol(private val context: Context) {
         
         // Start initialization tracking
         com.linkpoint.utils.InitializationTracker.startSession()
-        com.linkpoint.utils.InitializationTracker.startPhase(
+        com.linkpoint.utils.InitializationTracker.reachPhase(
             com.linkpoint.utils.InitializationTracker.Phase.LOGIN_STARTING,
             "Login for $firstName $lastName"
         )
@@ -366,7 +366,7 @@ class SecondLifeProtocol(private val context: Context) {
                         com.linkpoint.utils.InitializationTracker.Phase.UDP_CONNECTING,
                         "UDP connected"
                     )
-                    com.linkpoint.utils.InitializationTracker.startPhase(
+                    com.linkpoint.utils.InitializationTracker.reachPhase(
                         com.linkpoint.utils.InitializationTracker.Phase.UDP_CONNECTED,
                         "Waiting for simulator messages"
                     )
@@ -409,7 +409,7 @@ class SecondLifeProtocol(private val context: Context) {
                                 com.linkpoint.utils.InitializationTracker.Phase.CAPABILITIES_FETCHING,
                                 "${app.capabilityManager.getCapabilityCount()} capabilities loaded"
                             )
-                            com.linkpoint.utils.InitializationTracker.startPhase(
+                            com.linkpoint.utils.InitializationTracker.reachPhase(
                                 com.linkpoint.utils.InitializationTracker.Phase.CAPABILITIES_READY,
                                 "Capabilities available for use"
                             )

--- a/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
@@ -429,20 +429,35 @@ class DebugReportService private constructor(private val context: Context) {
                             appendLine("     Full packet: ${entry.fullHexDump}")
                         }
                         
-                        // Summary statistics
+                        // Summary statistics (counted within the bounded history window)
                         val sendSuccessCount = packetHistory.count { it.type == UDPConnectionFixed.PacketHistoryEntry.PacketEventType.SEND_SUCCESS }
                         val sendFailedCount = packetHistory.count { it.type == UDPConnectionFixed.PacketHistoryEntry.PacketEventType.SEND_FAILED }
                         val receiveCount = packetHistory.count { it.type == UDPConnectionFixed.PacketHistoryEntry.PacketEventType.RECEIVE }
                         val resendCount = packetHistory.count { it.type == UDPConnectionFixed.PacketHistoryEntry.PacketEventType.RESEND }
-                        
+
                         appendLine()
-                        appendLine("History Summary:")
+                        appendLine("History Summary (recent ${packetHistory.size}-packet window):")
                         appendLine("  Sent Successfully: $sendSuccessCount")
                         appendLine("  Send Failures: $sendFailedCount")
                         appendLine("  Received: $receiveCount")
                         appendLine("  Resends: $resendCount")
-                        
-                        if (receiveCount == 0 && sendSuccessCount > 0) {
+
+                        // Determine whether any packets have EVER been received using the
+                        // absolute counter, not the bounded history window. AgentUpdate
+                        // sends ~10/sec quickly evict receive entries from a 50-entry
+                        // buffer, which previously produced a false "none received"
+                        // warning even after a successful handshake.
+                        val totalReceivedEver = try {
+                            app.udpConnection.getMessageStatistics().totalPacketsReceived
+                        } catch (e: Exception) {
+                            receiveCount
+                        }
+                        val totalSentEver = try {
+                            app.udpConnection.getDiagnostics().sequenceNumber
+                        } catch (e: Exception) {
+                            sendSuccessCount
+                        }
+                        if (totalReceivedEver == 0 && totalSentEver > 0) {
                             appendLine()
                             appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED!")
                             appendLine("   Possible causes:")

--- a/Linkpoint/src/main/java/com/linkpoint/utils/InitializationTracker.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/InitializationTracker.kt
@@ -106,8 +106,30 @@ object InitializationTracker {
     fun completePhase(phase: Phase, message: String = "") {
         phaseCompletions[phase] = true
         val duration = phaseTimings[phase]?.let { System.currentTimeMillis() - it } ?: 0
-        
+
         val msg = if (message.isNotEmpty()) "$phase: $message (${duration}ms)" else "$phase completed (${duration}ms)"
+        logEvent(EventType.PHASE_COMPLETE, phase, msg)
+        Log.i(TAG, "[${getRelativeTimeString()}] ✓ $msg")
+    }
+
+    /**
+     * Record a milestone/state-marker phase as reached.
+     *
+     * Some phases (LOGIN_STARTING, UDP_CONNECTED, CAPABILITIES_READY,
+     * REGION_HANDSHAKE_REPLIED, FULLY_CONNECTED) represent "we arrived at this
+     * state" rather than "we are now doing work". They have no distinct
+     * completion event, so callers should use this method instead of
+     * [startPhase]. Otherwise they would show up as "pending" forever in the
+     * debug report even after the milestone was reached.
+     */
+    fun reachPhase(phase: Phase, message: String = "") {
+        currentPhase = phase
+        val now = System.currentTimeMillis()
+        phaseTimings[phase] = now
+        phasesFailed.remove(phase)
+        phaseCompletions[phase] = true
+
+        val msg = if (message.isNotEmpty()) "$phase: $message" else "$phase reached"
         logEvent(EventType.PHASE_COMPLETE, phase, msg)
         Log.i(TAG, "[${getRelativeTimeString()}] ✓ $msg")
     }

--- a/Linkpoint/src/test/kotlin/com/linkpoint/utils/InitializationTrackerTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/utils/InitializationTrackerTest.kt
@@ -70,4 +70,30 @@ class InitializationTrackerTest {
             diagnostics.failedPhases.contains(InitializationTracker.Phase.LOGIN_RESPONSE_PARSING)
         )
     }
+
+    @Test
+    fun `reachPhase marks milestone phase complete without a separate completePhase`() {
+        InitializationTracker.startSession()
+        InitializationTracker.reachPhase(InitializationTracker.Phase.CAPABILITIES_READY, "caps ready")
+
+        val diagnostics = InitializationTracker.getDiagnostics()
+
+        assertEquals(
+            "Current phase should track the reached milestone",
+            InitializationTracker.Phase.CAPABILITIES_READY,
+            diagnostics.currentPhase
+        )
+        assertTrue(
+            "Reached phase should show as completed",
+            diagnostics.completedPhases.contains(InitializationTracker.Phase.CAPABILITIES_READY)
+        )
+        assertFalse(
+            "Reached phase should not show as pending",
+            diagnostics.pendingPhases.contains(InitializationTracker.Phase.CAPABILITIES_READY)
+        )
+        assertFalse(
+            "Reached phase should not show as failed",
+            diagnostics.failedPhases.contains(InitializationTracker.Phase.CAPABILITIES_READY)
+        )
+    }
 }


### PR DESCRIPTION
Two reporting bugs were visible in the latest manual debug capture:

1. InitializationTracker listed milestone phases (LOGIN_STARTING, UDP_CONNECTED, CAPABILITIES_READY, REGION_HANDSHAKE_REPLIED, FULLY_CONNECTED) as "Pending" forever because callers only invoked startPhase() on them and never completePhase(). These phases are state markers, not long-running tasks. Added reachPhase() which records the phase as started and completed in one call, and updated the five marker callers to use it.

2. DebugReportService emitted "PACKETS SENT BUT NONE RECEIVED" whenever the 50-entry packet history window contained no RECEIVE entries. AgentUpdate sends ~10 packets/sec, so the ring buffer fills with sends within ~5 seconds and the warning fires even when the absolute receive counter is non-zero. The check now consults the cumulative totalPacketsReceived / sequenceNumber counters instead, and the summary label makes it clear the per-type counts are windowed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two debug reporting bugs. First, it adds a `reachPhase()` method to `InitializationTracker` for milestone phases that represent state markers rather than long-running tasks, preventing them from showing as "Pending" forever. Second, it corrects the "no packets received" false positive in `DebugReportService` by checking cumulative packet counters instead of the limited 50-entry ring buffer that was being overwhelmed by frequent AgentUpdate sends.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/utils/InitializationTracker.kt` |
| 2 | `Linkpoint/src/test/kotlin/com/linkpoint/utils/InitializationTrackerTest.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/network/SecondLifeProtocol.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->