### PR TITLE
Track UseCircuitCode sequence number for proper ACK matching

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -379,10 +379,10 @@ class LinkpointApp : Application() {
     var agentId: UUID? = null
         private set
     
-    // Flag to track if CompleteAgentMovement has been sent
-    // Per SL protocol: This must be sent immediately when UseCircuitCode (seq 0) is ACKed
-    // The server won't send RegionHandshake until we send this
-    // Using AtomicBoolean to prevent race conditions with concurrent PacketAck messages
+    // Flag to track if CompleteAgentMovement has been sent.
+    // Per SL protocol: This must be sent immediately once UseCircuitCode is ACKed;
+    // the server won't send RegionHandshake until it receives CompleteAgentMovement.
+    // Using AtomicBoolean to prevent race conditions with concurrent PacketAck messages.
     private val completeAgentMovementSent = AtomicBoolean(false)
     
     override fun onCreate() {
@@ -1171,11 +1171,10 @@ class LinkpointApp : Application() {
             }
         }
         
-        // PacketAck - Acknowledgment messages for reliable packets
+        // PacketAck - Acknowledgment messages for reliable packets.
         // These are sent by the simulator to confirm receipt of our reliable packets.
-        // CRITICAL: When UseCircuitCode (seq 0) is acknowledged, we MUST immediately send
-        // CompleteAgentMovement. This follows the SL protocol behavior - the server
-        // won't send RegionHandshake until it receives CompleteAgentMovement.
+        // CRITICAL: When UseCircuitCode is acknowledged, we MUST immediately send
+        // CompleteAgentMovement - the simulator won't send RegionHandshake until then.
         udpConnection.registerHandler(com.linkpoint.protocol.messages.MessageIds.PACKET_ACK) { _, rawPacket ->
             // PacketAck format: Count (1 byte), then list of acknowledged sequence numbers (4 bytes each)
             try {
@@ -1183,27 +1182,27 @@ class LinkpointApp : Application() {
                 if (payload == null) return@registerHandler
                 val buffer = java.nio.ByteBuffer.wrap(payload).order(java.nio.ByteOrder.LITTLE_ENDIAN)
                 val count = buffer.get().toInt() and 0xFF
-                
-                // Parse the acknowledged sequence numbers and check for seq 0 during parsing
-                // (optimization: avoid extra contains() call on the list)
+
+                // Match the ACK list against the exact sequence number we used for
+                // UseCircuitCode, not a hardcoded value. Lumiya sends UseCircuitCode
+                // with the counter's first increment (seq=1), and any reconnect uses
+                // a larger number — so we must match on what the sender recorded.
+                val useCircuitCodeSeq = udpConnection.useCircuitCodeSequence
                 val ackedSequences = mutableListOf<Int>()
-                var containsSeq0 = false
+                var containsUseCircuitCodeAck = false
                 for (i in 0 until count) {
                     if (buffer.remaining() >= 4) {
                         val seq = buffer.int
                         ackedSequences.add(seq)
-                        if (seq == 0) containsSeq0 = true
+                        if (useCircuitCodeSeq >= 0 && seq == useCircuitCodeSeq) {
+                            containsUseCircuitCodeAck = true
+                        }
                     }
                 }
-                
+
                 Log.d(TAG, "PacketAck received: $count packets acknowledged - sequences: $ackedSequences")
-                
-                // Check if UseCircuitCode (sequence 0) was acknowledged
-                // This is CRITICAL - per SL protocol, we must send CompleteAgentMovement
-                // immediately when UseCircuitCode is ACKed. The server waits for this before
-                // sending RegionHandshake and other world data.
-                // Using compareAndSet for thread-safe, atomic check-and-set operation
-                if (containsSeq0 && completeAgentMovementSent.compareAndSet(false, true)) {
+
+                if (containsUseCircuitCodeAck && completeAgentMovementSent.compareAndSet(false, true)) {
                     Log.i(TAG, "╔══════════════════════════════════════════════════════════════════")
                     Log.i(TAG, "║ ⭐ UseCircuitCode ACKNOWLEDGED - Sending CompleteAgentMovement")
                     Log.i(TAG, "╚══════════════════════════════════════════════════════════════════")

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -322,6 +322,15 @@ class UDPConnectionFixed {
      * Critical for implementing circuit establishment state machine.
      */
     private val pendingCallbacks = java.util.concurrent.ConcurrentHashMap<Int, MessageCallbackInfo>()
+
+    /**
+     * Sequence number used for the most recent UseCircuitCode send, or -1 if not sent yet.
+     * The login handshake's PacketAck handler uses this to know which ACK signals that
+     * the circuit is established so CompleteAgentMovement can be sent.
+     */
+    @Volatile
+    var useCircuitCodeSequence: Int = -1
+        private set
     
     /**
      * Internal callback info with timeout handling.
@@ -1767,7 +1776,7 @@ class UDPConnectionFixed {
     private fun sendUseCircuitCode() {
         val identity = outboundIdentity("UDPConnectionFixed.sendUseCircuitCode")
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "→ Sending UseCircuitCode")
-        
+
         // UseCircuitCode message format:
         // - CircuitCode (4 bytes, little-endian)
         // - SessionID (16 bytes, UUID)
@@ -1776,72 +1785,10 @@ class UDPConnectionFixed {
         payload.putInt(identity.circuitCode ?: 0)
         payload.put(identity.sessionId.asBytes())
         payload.put(identity.agentId.asBytes())
-        
-        // Message ID for UseCircuitCode (low frequency: -65533)
-        val messageId = MessageIds.USE_CIRCUIT_CODE
 
-        // CRITICAL: UseCircuitCode MUST be sent with sequence number 0.
-        // The login handshake in LinkpointApp waits for PacketAck(seq=0) before
-        // sending CompleteAgentMovement. If this packet is sent as seq=1, the
-        // client never advances to world bootstrap and only ping traffic flows.
-        //
-        // Do not route through sendPacket() here because sendPacket() increments
-        // the sequence counter before assignment.
-        try {
-            val flags = 0x40 // reliable
-            val header = ByteBuffer.allocate(PACKET_HEADER_SIZE).order(ByteOrder.BIG_ENDIAN)
-            header.put(flags.toByte())
-            header.putInt(0) // REQUIRED by SL protocol for UseCircuitCode
-            header.put(0.toByte())
-
-            val messageIdBytes = encodeMessageId(messageId)
-            val packet = header.array() + messageIdBytes + payload.array()
-
-            val buffer = ByteBuffer.wrap(packet)
-            val bytesWritten = datagramChannel?.write(buffer) ?: 0
-            if (bytesWritten > 0) {
-                packetsSent.incrementAndGet()
-                bytesSent.addAndGet(bytesWritten.toLong())
-                lastSendTime = System.currentTimeMillis()
-
-                NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-                    "→ Sent UseCircuitCode with fixed seq=0 (${packet.size} bytes)")
-
-                recordPacketEvent(
-                    type = PacketHistoryEntry.PacketEventType.SEND_SUCCESS,
-                    messageId = messageId,
-                    data = packet,
-                    sequenceNumber = 0,
-                    success = true
-                )
-
-                EnhancedPacketLogger.logPacketSent(
-                    messageId = messageId,
-                    messageName = getMessageName(messageId),
-                    sequenceNumber = 0,
-                    data = packet,
-                    flags = EnhancedPacketLogger.PacketFlags(
-                        reliable = true,
-                        resent = false,
-                        zerocoded = false,
-                        hasAcks = false
-                    )
-                )
-
-                SessionLogRecorder.logPacketSent(
-                    messageId = messageId,
-                    messageName = getMessageName(messageId),
-                    sequenceNumber = 0,
-                    data = packet,
-                    reliable = true
-                )
-            } else {
-                NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
-                    "UseCircuitCode write returned 0 bytes")
-            }
-        } catch (e: Exception) {
-            NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
-                "Failed to send UseCircuitCode seq=0: ${e.message}")
+        val seq = sendPacket(MessageIds.USE_CIRCUIT_CODE, payload.array(), reliable = true)
+        if (seq >= 0) {
+            useCircuitCodeSequence = seq
         }
     }
     
@@ -2079,19 +2026,20 @@ class UDPConnectionFixed {
         reliable: Boolean = false,
         zerocoded: Boolean = false,
         listener: MessageEventListener? = null
-    ) {
+    ): Int {
         if (!_isConnected.value) {
             NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP, "Cannot send: not connected")
-            return
+            return -1
         }
-        
+
+        // Lumiya uses incrementAndGet() — first packet gets seq=1, not 0.
+        // This matches all other send paths (sendPendingAcks, sendPendingAcksFromIOThread).
+        val seqNum = sequenceNumber.incrementAndGet()
+
         try {
             // Build packet header (big-endian per SL protocol)
             val flags = (if (reliable) 0x40 else 0) or (if (zerocoded) 0x80 else 0)
-            // Lumiya uses incrementAndGet() — first packet gets seq=1, not 0.
-            // This matches all other send paths (sendPendingAcks, sendPendingAcksFromIOThread).
-            val seqNum = sequenceNumber.incrementAndGet()
-            
+
             // Track callback if this is a reliable message with listener
             if (reliable && listener != null) {
                 val callbackInfo = MessageCallbackInfo(
@@ -2192,7 +2140,7 @@ class UDPConnectionFixed {
                 type = PacketHistoryEntry.PacketEventType.SEND_FAILED,
                 messageId = messageId,
                 data = payload,
-                sequenceNumber = sequenceNumber.get(),
+                sequenceNumber = seqNum,
                 success = false,
                 errorMessage = e.message
             )
@@ -2228,9 +2176,11 @@ class UDPConnectionFixed {
                     }
                 }
             }
+            return -1
         }
+        return seqNum
     }
-    
+
     /**
      * Encode message ID for transmission (Linkpoint)
      */


### PR DESCRIPTION
## Summary
Refactored the UseCircuitCode sending mechanism to track the actual sequence number used, enabling proper matching of PacketAck responses instead of relying on a hardcoded sequence 0 assumption.

## Key Changes

- **Added `useCircuitCodeSequence` property** to `UDPConnectionFixed`: A volatile field that stores the sequence number of the most recent UseCircuitCode packet, initialized to -1 if not yet sent.

- **Simplified `sendUseCircuitCode()` method**: Removed the custom packet construction logic that forced sequence 0 and now delegates to the standard `sendPacket()` method, which properly increments the sequence counter. The returned sequence number is stored in `useCircuitCodeSequence`.

- **Modified `sendPacket()` return type**: Changed from `Unit` to `Int` to return the sequence number used for the packet, enabling callers to track which sequence was assigned. Returns -1 on failure.

- **Updated PacketAck handler in `LinkpointApp`**: Changed from checking for a hardcoded sequence 0 to dynamically matching against `udpConnection.useCircuitCodeSequence`. This ensures CompleteAgentMovement is sent when the actual UseCircuitCode packet is acknowledged, regardless of its sequence number.

## Implementation Details

- The sequence number is now properly tracked through the standard packet sending pipeline, matching Lumiya's behavior where the first packet gets sequence 1 (via `incrementAndGet()`).
- The PacketAck handler uses atomic compare-and-set (`compareAndSet`) to ensure thread-safe, one-time sending of CompleteAgentMovement.
- This change maintains protocol compliance while being more robust to reconnection scenarios where the sequence number may differ from the initial connection.

https://claude.ai/code/session_018BAkH55srKuHQvLQ8hDBnT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handshake reliability by fixing packet acknowledgment tracking during circuit code initialization, ensuring proper correlation between sent packets and received acknowledgments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->