### PR TITLE
Fix JPEG2000 decoding and improve chat/render initialization

### DIFF
--- a/Linkpoint/src/main/cpp/j2k_decoder.cpp
+++ b/Linkpoint/src/main/cpp/j2k_decoder.cpp
@@ -192,19 +192,60 @@ Java_com_linkpoint_assets_JPEG2000Decoder_nativeDecode(
     }
     
     opj_end_decompress(codec, stream);
-    
-    // Get image info
-    int width = image->x1 - image->x0;
-    int height = image->y1 - image->y0;
+
     int numComponents = image->numcomps;
-    
-    LOGI("Decoded image: %dx%d, %d components", width, height, numComponents);
-    
+    if (numComponents <= 0 || image->comps == nullptr) {
+        LOGE("Decoded image has no components");
+        opj_image_destroy(image);
+        opj_stream_destroy(stream);
+        opj_destroy_codec(codec);
+        env->ReleaseByteArrayElements(jdata, dataPtr, JNI_ABORT);
+        return nullptr;
+    }
+
+    // With cp_reduce > 0 OpenJPEG decodes a sub-resolution image; the canvas
+    // (x0/x1/y0/y1) stays at full size, but the actual pixel buffer is
+    // comps[i].w x comps[i].h. Driving the copy loop from the canvas size
+    // walks past the end of the component buffers and corrupts memory.
+    // Use the smallest component extent so we never read past any plane.
+    int width = image->comps[0].w;
+    int height = image->comps[0].h;
+    for (int c = 1; c < numComponents; ++c) {
+        if (image->comps[c].w < (OPJ_UINT32)width) width = image->comps[c].w;
+        if (image->comps[c].h < (OPJ_UINT32)height) height = image->comps[c].h;
+    }
+
+    if (width <= 0 || height <= 0) {
+        LOGE("Decoded image has invalid dimensions: %dx%d", width, height);
+        opj_image_destroy(image);
+        opj_stream_destroy(stream);
+        opj_destroy_codec(codec);
+        env->ReleaseByteArrayElements(jdata, dataPtr, JNI_ABORT);
+        return nullptr;
+    }
+
+    LOGI("Decoded image: %dx%d, %d components (canvas %dx%d, reduce=%d)",
+         width, height, numComponents,
+         image->x1 - image->x0, image->y1 - image->y0, discardLevel);
+
+    // Some component data pointers can be null if decoding failed silently
+    // for that plane; bail out before dereferencing them.
+    for (int c = 0; c < numComponents; ++c) {
+        if (image->comps[c].data == nullptr) {
+            LOGE("Component %d has null data buffer", c);
+            opj_image_destroy(image);
+            opj_stream_destroy(stream);
+            opj_destroy_codec(codec);
+            env->ReleaseByteArrayElements(jdata, dataPtr, JNI_ABORT);
+            return nullptr;
+        }
+    }
+
     // Convert to RGBA
-    size_t pixelCount = width * height;
+    size_t pixelCount = (size_t)width * (size_t)height;
     size_t rgbaSize = pixelCount * 4;
     uint8_t* rgbaData = (uint8_t*)malloc(rgbaSize);
-    
+
     if (!rgbaData) {
         LOGE("Failed to allocate output buffer");
         opj_image_destroy(image);
@@ -213,34 +254,55 @@ Java_com_linkpoint_assets_JPEG2000Decoder_nativeDecode(
         env->ReleaseByteArrayElements(jdata, dataPtr, JNI_ABORT);
         return nullptr;
     }
-    
-    // Handle different component counts
+
+    // Normalise sample values to 8-bit. SL textures usually arrive as 8-bit
+    // unsigned, but signed/high-precision streams must be shifted/saturated
+    // before truncation, otherwise & 0xFF produces wrap-around garbage.
+    auto sampleToByte = [](OPJ_INT32 v, int prec, OPJ_BOOL signedSample) -> uint8_t {
+        if (signedSample) {
+            v += 1 << (prec - 1);
+        }
+        if (prec > 8) {
+            v >>= (prec - 8);
+        } else if (prec < 8 && prec > 0) {
+            v <<= (8 - prec);
+        }
+        if (v < 0) v = 0;
+        if (v > 255) v = 255;
+        return (uint8_t)v;
+    };
+
     if (numComponents >= 3) {
-        // RGB or RGBA
+        const auto& cR = image->comps[0];
+        const auto& cG = image->comps[1];
+        const auto& cB = image->comps[2];
+        const opj_image_comp_t* cA = (numComponents >= 4) ? &image->comps[3] : nullptr;
         for (size_t i = 0; i < pixelCount; i++) {
-            rgbaData[i * 4 + 0] = (uint8_t)(image->comps[0].data[i] & 0xFF); // R
-            rgbaData[i * 4 + 1] = (uint8_t)(image->comps[1].data[i] & 0xFF); // G
-            rgbaData[i * 4 + 2] = (uint8_t)(image->comps[2].data[i] & 0xFF); // B
-            rgbaData[i * 4 + 3] = (numComponents >= 4) ? 
-                (uint8_t)(image->comps[3].data[i] & 0xFF) : 255; // A
+            rgbaData[i * 4 + 0] = sampleToByte(cR.data[i], cR.prec, cR.sgnd);
+            rgbaData[i * 4 + 1] = sampleToByte(cG.data[i], cG.prec, cG.sgnd);
+            rgbaData[i * 4 + 2] = sampleToByte(cB.data[i], cB.prec, cB.sgnd);
+            rgbaData[i * 4 + 3] = (cA != nullptr)
+                ? sampleToByte(cA->data[i], cA->prec, cA->sgnd)
+                : (uint8_t)255;
         }
     } else if (numComponents == 1) {
-        // Grayscale
+        const auto& c0 = image->comps[0];
         for (size_t i = 0; i < pixelCount; i++) {
-            uint8_t gray = (uint8_t)(image->comps[0].data[i] & 0xFF);
+            uint8_t gray = sampleToByte(c0.data[i], c0.prec, c0.sgnd);
             rgbaData[i * 4 + 0] = gray;
             rgbaData[i * 4 + 1] = gray;
             rgbaData[i * 4 + 2] = gray;
             rgbaData[i * 4 + 3] = 255;
         }
-    } else if (numComponents == 2) {
-        // Grayscale + Alpha
+    } else { // numComponents == 2 (grayscale + alpha)
+        const auto& c0 = image->comps[0];
+        const auto& c1 = image->comps[1];
         for (size_t i = 0; i < pixelCount; i++) {
-            uint8_t gray = (uint8_t)(image->comps[0].data[i] & 0xFF);
+            uint8_t gray = sampleToByte(c0.data[i], c0.prec, c0.sgnd);
             rgbaData[i * 4 + 0] = gray;
             rgbaData[i * 4 + 1] = gray;
             rgbaData[i * 4 + 2] = gray;
-            rgbaData[i * 4 + 3] = (uint8_t)(image->comps[1].data[i] & 0xFF);
+            rgbaData[i * 4 + 3] = sampleToByte(c1.data[i], c1.prec, c1.sgnd);
         }
     }
     

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -81,7 +81,20 @@ class RenderManager(private val context: Context) {
      */
     fun initialize(surfaceView: SurfaceView): Boolean {
         requireRenderThread("initialize")
-        if (isInitialized) return true
+        if (isInitialized) {
+            // Activity may have created a fresh SurfaceView (e.g. after a renderer
+            // toggle or configuration change) while we're already initialized.
+            // Adopt the new SurfaceView and rebuild the SwapChain against it,
+            // otherwise we keep rendering against a stale (or destroyed) surface.
+            if (this.surfaceView !== surfaceView) {
+                Log.i(TAG, "RenderManager.initialize: adopting new SurfaceView, rebuilding SwapChain")
+                this.surfaceView = surfaceView
+                uiHelper?.detach()
+                uiHelper?.attachTo(surfaceView)
+                rebuildSwapChainForCurrentSurface()
+            }
+            return true
+        }
         this.surfaceView = surfaceView
         
         try {
@@ -168,9 +181,18 @@ class RenderManager(private val context: Context) {
                 attachTo(surfaceView)
                 Log.d(TAG, "UiHelper attached to SurfaceView")
             }
-            
-            // Setup display helper
+
+            // Setup display helper BEFORE the eager swapchain rebuild so the
+            // attachDisplayHelper() call inside it can succeed on first try.
             displayHelper = DisplayHelper(context)
+
+            // UiHelper.attachTo does not always re-fire onNativeWindowChanged for
+            // surfaces that were already created before we attached - which is the
+            // common case here, because the SurfaceHolder.Callback in the activity
+            // dispatches us onto the render thread while the surface is already valid.
+            // Without this eager creation the SwapChain stays null forever and frames
+            // never composite, producing the "world refuses to load" symptom.
+            rebuildSwapChainForCurrentSurface()
             
             // Configure renderer with SL default clear color (sky blue)
             renderer?.clearOptions?.apply {
@@ -322,6 +344,38 @@ class RenderManager(private val context: Context) {
             1000.0,         // far plane
             Camera.Fov.VERTICAL
         )
+    }
+
+    private fun rebuildSwapChainForCurrentSurface() {
+        val eng = engine ?: return
+        val sv = surfaceView ?: return
+        val surface = sv.holder?.surface
+        if (surface == null || !surface.isValid) {
+            return
+        }
+        synchronized(swapChainLock) {
+            swapChain?.let {
+                try { eng.destroySwapChain(it) } catch (_: Exception) {}
+            }
+            swapChain = try {
+                eng.createSwapChain(surface)
+            } catch (e: Exception) {
+                Log.e(TAG, "rebuildSwapChainForCurrentSurface: createSwapChain threw", e)
+                null
+            }
+            if (swapChain != null) {
+                Log.i(TAG, "✓ SwapChain created eagerly during initialize")
+                attachDisplayHelper()
+                val width = sv.width
+                val height = sv.height
+                if (width > 0 && height > 0) {
+                    view?.viewport = Viewport(0, 0, width, height)
+                    viewportWidth = width
+                    viewportHeight = height
+                    updateProjection(width, height)
+                }
+            }
+        }
     }
 
     private fun ensureSwapChain(engine: Engine): SwapChain? {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt
@@ -48,18 +48,19 @@ class ChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_chat)
-        
+
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             title = "Chat"
         }
-        
+
         initViews()
         setupTabs()
         setupChat()
         handleIntent()
         observeImMessages()
         observeSessionUpdates()
+        observeLocalChat()
     }
     
     private fun initViews() {
@@ -105,9 +106,12 @@ class ChatActivity : AppCompatActivity() {
                 messageInput.text.clear()
             }
         }
-        
-        // Add welcome message
-        addSystemMessage("Connected to local chat")
+
+        // Seed the LOCAL tab with whatever nearby-chat history we already have
+        // so the screen doesn't look empty / "stuck loading" when it's opened
+        // mid-session. loadMessages will fall back to a system banner if there
+        // is no history yet.
+        loadMessages()
     }
 
     private fun handleIntent() {
@@ -160,12 +164,28 @@ class ChatActivity : AppCompatActivity() {
             }
         }
     }
+
+    private fun observeLocalChat() {
+        if (!app.isChatManagerInitialized()) return
+        lifecycleScope.launch {
+            app.chatManager.chatFlow.collect { chat ->
+                // Local + Nearby tabs both show simulator-driven nearby chat.
+                if (currentChannel != ActivityChatChannel.LOCAL && currentChannel != ActivityChatChannel.NEARBY) {
+                    return@collect
+                }
+                val activityMessage = chat.toActivityMessage(currentChannel)
+                messages.add(activityMessage)
+                adapter.notifyItemInserted(messages.size - 1)
+                recyclerView.scrollToPosition(messages.size - 1)
+            }
+        }
+    }
     
     private fun loadMessages() {
         // Load messages for current channel
         messages.clear()
         adapter.notifyDataSetChanged()
-        
+
         if (currentChannel == ActivityChatChannel.IM || currentChannel == ActivityChatChannel.GROUP) {
             val sessionId = resolveSessionIdForChannel(currentChannel)
             if (sessionId == null) {
@@ -187,8 +207,21 @@ class ChatActivity : AppCompatActivity() {
                 recyclerView.scrollToPosition(messages.size - 1)
             }
         } else {
-            // Add channel info
-            addSystemMessage("Switched to ${currentChannel.name.lowercase()} chat")
+            // LOCAL / NEARBY: replay nearby-chat history so the screen doesn't
+            // appear empty when it's opened mid-session. Without this the only
+            // thing the user ever saw was the synthetic welcome line.
+            if (app.isChatManagerInitialized()) {
+                val history = app.chatManager.getHistory()
+                messages.addAll(history.map { it.toActivityMessage(currentChannel) })
+                adapter.notifyDataSetChanged()
+                if (messages.isNotEmpty()) {
+                    recyclerView.scrollToPosition(messages.size - 1)
+                } else {
+                    addSystemMessage("Switched to ${currentChannel.name.lowercase()} chat")
+                }
+            } else {
+                addSystemMessage("Switched to ${currentChannel.name.lowercase()} chat")
+            }
         }
     }
     
@@ -210,25 +243,10 @@ class ChatActivity : AppCompatActivity() {
             text.startsWith("/me ") -> ChatType.NORMAL to text // Emotes
             else -> ChatType.NORMAL to text
         }
-        
-        val message = ActivityChatMessage(
-            id = UUID.randomUUID().toString(),
-            sender = app.sessionManager.getAvatarName().ifEmpty { "You" },
-            content = displayText,
-            timestamp = System.currentTimeMillis(),
-            type = when (chatType) {
-                ChatType.SHOUT -> ActivityMessageType.SHOUT
-                ChatType.WHISPER -> ActivityMessageType.WHISPER
-                else -> if (text.startsWith("/me ")) ActivityMessageType.EMOTE else ActivityMessageType.NORMAL
-            },
-            channel = currentChannel
-        )
-        
-        messages.add(message)
-        adapter.notifyItemInserted(messages.size - 1)
-        recyclerView.scrollToPosition(messages.size - 1)
-        
-        // Send to server
+
+        // ChatManager echoes outgoing messages back through chatFlow, so just
+        // send and let observeLocalChat() append the row. Adding it here too
+        // produced duplicate "You: ..." entries on every send.
         lifecycleScope.launch {
             app.protocol.sendChat(displayText, 0, chatType)
         }
@@ -255,6 +273,24 @@ class ChatActivity : AppCompatActivity() {
             content = message,
             timestamp = timestamp,
             type = ActivityMessageType.NORMAL,
+            channel = channel
+        )
+    }
+
+    private fun com.linkpoint.chat.ChatMessage.toActivityMessage(channel: ActivityChatChannel): ActivityChatMessage {
+        val activityType = when {
+            chatType == com.linkpoint.protocol.messages.ChatType.SHOUT -> ActivityMessageType.SHOUT
+            chatType == com.linkpoint.protocol.messages.ChatType.WHISPER -> ActivityMessageType.WHISPER
+            sourceType == com.linkpoint.protocol.messages.ChatSourceType.OBJECT -> ActivityMessageType.OBJECT
+            message.startsWith("/me ") -> ActivityMessageType.EMOTE
+            else -> ActivityMessageType.NORMAL
+        }
+        return ActivityChatMessage(
+            id = id.toString(),
+            sender = fromName,
+            content = message,
+            timestamp = timestamp,
+            type = activityType,
             channel = channel
         )
     }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsListFragment.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsListFragment.kt
@@ -56,6 +56,14 @@ class FriendsListFragment : Fragment() {
         observeFriendEvents()
     }
 
+    override fun onResume() {
+        super.onResume()
+        // The buddy-list parser populates FriendsManager asynchronously after login,
+        // so refresh whenever the user comes back to this screen rather than relying
+        // solely on the initial onViewCreated load.
+        loadFriends()
+    }
+
     private fun setupViews(view: View) {
         recyclerView = view.findViewById(R.id.friends_recyclerview)
         progressBar = view.findViewById(R.id.progress_bar)

--- a/Linkpoint/src/main/java/com/linkpoint/world/FriendsManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/world/FriendsManager.kt
@@ -725,12 +725,20 @@ class FriendsManager(
     fun addFriendFromLogin(agentId: UUID, name: String, rightsGiven: Int, rightsHas: Int) {
         val resolvedName = name.ifBlank { "Resident (${agentId.toString().take(8)})" }
         Log.d(TAG, "Adding friend from login: $resolvedName ($agentId)")
-        friends[agentId] = Friend(
+        val friend = Friend(
             agentId = agentId,
             name = resolvedName,
             rightsGiven = rightsGiven,
             rightsHas = rightsHas
         )
+        val isNew = friends.put(agentId, friend) == null
+        // Emit so any UI that's already observing the flow refreshes once buddy-list
+        // parsing completes after the user has opened the Friends screen.
+        if (isNew) {
+            scope.launch {
+                _friendsFlow.emit(FriendEvent.Added(friend))
+            }
+        }
     }
     
     /**


### PR DESCRIPTION
## Summary
This PR addresses critical bugs in JPEG2000 image decoding, improves chat message handling, and fixes rendering initialization issues when surfaces are recreated.

## Key Changes

### JPEG2000 Decoder (j2k_decoder.cpp)
- **Fixed memory corruption**: When `cp_reduce > 0` is used, OpenJPEG decodes sub-resolution images but keeps the canvas at full size. The code now uses actual component dimensions (`comps[i].w/h`) instead of canvas dimensions to prevent buffer overruns.
- **Added validation**: Check for null component data pointers and invalid dimensions before processing to prevent crashes from silent decode failures.
- **Improved sample normalization**: Replaced simple `& 0xFF` truncation with proper `sampleToByte()` function that handles signed samples and high-precision streams by shifting/saturating before conversion to 8-bit.
- **Enhanced logging**: Added canvas size and reduce level to debug output for better diagnostics.

### Chat Activity (ChatActivity.kt)
- **Fixed duplicate messages**: Removed manual message insertion on send since `ChatManager` echoes messages back through `chatFlow`. Now only `observeLocalChat()` adds messages to prevent duplicates.
- **Improved history display**: Added `observeLocalChat()` to observe the chat flow and `loadMessages()` now replays nearby-chat history so the LOCAL/NEARBY tabs don't appear empty when opened mid-session.
- **Added message conversion**: New `toActivityMessage()` extension function to convert `ChatMessage` to `ActivityChatMessage` with proper type mapping.
- **Better initialization**: Seed LOCAL tab with existing history instead of just a welcome message.

### Render Manager (RenderManager.kt)
- **Fixed surface recreation**: When activity creates a new `SurfaceView` (after renderer toggle or config change), the manager now detaches/reattaches the `UiHelper` and rebuilds the `SwapChain` instead of ignoring the new surface.
- **Eager SwapChain creation**: Added `rebuildSwapChainForCurrentSurface()` to eagerly create the SwapChain during initialization. This fixes the "world refuses to load" symptom where `UiHelper.attachTo()` doesn't always re-fire `onNativeWindowChanged` for already-valid surfaces.
- **Proper initialization order**: Moved `DisplayHelper` setup before eager SwapChain rebuild so `attachDisplayHelper()` succeeds on first try.

### Friends Manager (FriendsManager.kt)
- **Emit friend events**: When friends are added from login, now emit `FriendEvent.Added` so UI observing the flow refreshes after buddy-list parsing completes.

### Friends List Fragment (FriendsListFragment.kt)
- **Refresh on resume**: Added `onResume()` to reload friends when returning to the screen, since buddy-list parsing happens asynchronously after login.

## Notable Implementation Details
- The JPEG2000 fix uses component-level dimensions rather than canvas dimensions to handle sub-resolution decoding correctly.
- Chat message flow now uses a single source of truth (the `chatFlow`) to avoid duplication.
- SwapChain recreation is now synchronized and handles both initial creation and surface changes.

https://claude.ai/code/session_01WRV7aCvkP2Qye5Fk7zZMgi

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes three critical bugs: a memory corruption issue in JPEG2000 decoding when using sub-resolution images, duplicate message display in the chat interface, and rendering failures when surfaces are recreated. The JPEG2000 decoder now correctly uses component dimensions instead of canvas dimensions to prevent buffer overruns and properly normalizes pixel samples. The chat system eliminates duplicate messages by relying on a single source of truth (`chatFlow`) and now displays chat history when tabs are opened mid-session. The render manager now properly handles surface recreation scenarios by rebuilding the `SwapChain` when a new `SurfaceView` is provided. Minor improvements include emitting friend events when the buddy list is parsed and refreshing the friends list on resume.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/cpp/j2k_decoder.cpp` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/world/FriendsManager.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsListFragment.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->