### PR TITLE
Fix Android SDK setup in CI workflows and ByteBuffer API compatibility

### DIFF
--- a/.github/workflows/build-linkpoint.yml
+++ b/.github/workflows/build-linkpoint.yml
@@ -36,13 +36,28 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'gradle'
       
+      # setup-android@v3 dropped the api-level/build-tools/cmake/ndk inputs;
+      # they are silently ignored, which previously left the runner without
+      # the NDK / CMake the build needs. Pass everything via `packages` so
+      # the SDK is fully provisioned in one step.
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: ${{ env.ANDROID_SDK_VERSION }}
-          build-tools: 35.0.0
-          cmake: 3.22.1
-          ndk: ${{ env.NDK_VERSION }}
+          packages: >-
+            platform-tools
+            platforms;android-${{ env.ANDROID_SDK_VERSION }}
+            build-tools;35.0.0
+            cmake;3.22.1
+            ndk;${{ env.NDK_VERSION }}
+
+      - name: Verify Android SDK install
+        run: |
+          set -euo pipefail
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+          test -d "$ANDROID_SDK_ROOT/platforms/android-${{ env.ANDROID_SDK_VERSION }}"
+          test -d "$ANDROID_SDK_ROOT/build-tools/35.0.0"
+          test -d "$ANDROID_SDK_ROOT/cmake/3.22.1"
+          test -d "$ANDROID_SDK_ROOT/ndk/${{ env.NDK_VERSION }}"
       
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,22 +29,30 @@ jobs:
       - name: Cache Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # setup-android@v3 dropped the api-level/build-tools/cmake/ndk inputs;
+      # only `packages`, `cmdline-tools-version`, and the license toggles are
+      # accepted now. Pass the full package list here so we get one source of
+      # truth for what the build needs (compile SDK 35 + build-tools 35.0.0,
+      # NDK r26 to match Linkpoint/build.gradle.kts ndkVersion, and CMake
+      # 3.22.1 for src/main/cpp).
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 35
-          build-tools: 35.0.0
-          cmake: 3.22.1
-          ndk: 26.3.11579264
+          packages: >-
+            platform-tools
+            platforms;android-35
+            build-tools;35.0.0
+            cmake;3.22.1
+            ndk;26.3.11579264
 
-      - name: Install SDK components
+      - name: Verify Android SDK install
         run: |
-          sdkmanager --install \
-            "platform-tools" \
-            "platforms;android-35" \
-            "build-tools;35.0.0" \
-            "cmake;3.22.1" \
-            "ndk;26.3.11579264"
+          set -euo pipefail
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+          test -d "$ANDROID_SDK_ROOT/platforms/android-35"
+          test -d "$ANDROID_SDK_ROOT/build-tools/35.0.0"
+          test -d "$ANDROID_SDK_ROOT/cmake/3.22.1"
+          test -d "$ANDROID_SDK_ROOT/ndk/26.3.11579264"
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,13 +44,27 @@ jobs:
         java-version: ${{ env.JAVA_VERSION }}
         cache: 'gradle'
     
+    # setup-android@v3 only accepts `packages` / `cmdline-tools-version` /
+    # license toggles. The legacy api-level/build-tools/cmake/ndk inputs are
+    # silently dropped, which previously meant deploys ran without an NDK.
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
       with:
-        api-level: ${{ env.ANDROID_SDK_VERSION }}
-        build-tools: 35.0.0
-        cmake: 3.22.1
-        ndk: ${{ env.NDK_VERSION }}
+        packages: >-
+          platform-tools
+          platforms;android-${{ env.ANDROID_SDK_VERSION }}
+          build-tools;35.0.0
+          cmake;3.22.1
+          ndk;${{ env.NDK_VERSION }}
+
+    - name: Verify Android SDK install
+      run: |
+        set -euo pipefail
+        echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+        test -d "$ANDROID_SDK_ROOT/platforms/android-${{ env.ANDROID_SDK_VERSION }}"
+        test -d "$ANDROID_SDK_ROOT/build-tools/35.0.0"
+        test -d "$ANDROID_SDK_ROOT/cmake/3.22.1"
+        test -d "$ANDROID_SDK_ROOT/ndk/${{ env.NDK_VERSION }}"
     
     - name: Cache Gradle packages
       uses: actions/cache@v4

--- a/Linkpoint/src/main/java/com/linkpoint/assets/Etc2Compressor.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/assets/Etc2Compressor.kt
@@ -98,7 +98,11 @@ internal object Etc1Fallback : Etc2Compressor {
         val dst = ByteBuffer.allocateDirect(compressedSize).order(ByteOrder.nativeOrder())
         ETC1.encodeImage(src, width, height, 3, width * 3, dst)
         val out = ByteArray(compressedSize)
-        dst.position(0).get(out)
+        // Android's java.nio.Buffer.position(int) returns Buffer (not the
+        // covariant ByteBuffer the JDK 9+ desktop API returns), so chaining
+        // .get(ByteArray) off it fails to resolve. Split the calls.
+        dst.position(0)
+        dst.get(out)
         return Etc2Compressor.Result(
             data = out,
             format = Etc2Compressor.GpuFormat.ETC1_RGB,


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to properly configure the Android SDK with the latest `setup-android@v3` action, which changed its input API. Additionally, it fixes a Java/Kotlin compatibility issue with ByteBuffer method chaining.

## Key Changes

**CI Workflow Updates (build-release.yml, build-linkpoint.yml, deploy.yml):**
- Migrated from deprecated individual inputs (`api-level`, `build-tools`, `cmake`, `ndk`) to the new `packages` input format for `android-actions/setup-android@v3`
- The action now silently ignores the old inputs, which was causing builds to run without required NDK and CMake components
- Added verification steps to confirm all required Android SDK components are properly installed
- Consolidated SDK configuration into a single source of truth via the `packages` parameter

**Kotlin Source Code Fix (Etc2Compressor.kt):**
- Fixed ByteBuffer method chaining issue in `Etc1Fallback.compress()`
- Android's `java.nio.Buffer.position(int)` returns `Buffer` (not the covariant `ByteBuffer` that JDK 9+ returns), preventing direct chaining with `.get(ByteArray)`
- Split the chained call into separate statements for compatibility with Android's Java runtime

## Implementation Details
- The new `packages` format requires explicit package specifications (e.g., `platforms;android-35`, `build-tools;35.0.0`)
- Verification steps use directory existence checks to ensure SDK components are available before the build proceeds
- The ByteBuffer fix maintains the same functionality while working around the Android runtime's type signature differences

https://claude.ai/code/session_01NrQCUhEpZ8ExozyfPctvz1

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two related issues: updates three GitHub Actions workflows to use the new `packages` input format for `setup-android@v3` (which silently dropped support for legacy inputs like `api-level`, `build-tools`, `cmake`, and `ndk`), and resolves a ByteBuffer method chaining compatibility issue in Kotlin code caused by Android's Java runtime returning `Buffer` instead of the covariant `ByteBuffer` type available in JDK 9+.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/assets/Etc2Compressor.kt` |
| 2 | `.github/workflows/build-release.yml` |
| 3 | `.github/workflows/build-linkpoint.yml` |
| 4 | `.github/workflows/deploy.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed texture decompression logic in fallback processing to ensure output buffers are correctly populated during rendering operations.

* **Chores**
  * Modernized build pipeline configurations with updated SDK provisioning methods and added verification steps to ensure all required build components are properly installed before compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->