### PR TITLE
Add monotonic statistics counters to NetworkLogger

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
@@ -12,6 +12,7 @@ import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.*
 
 /**
@@ -65,6 +66,19 @@ object NetworkLogger {
     
     // In-memory log buffer for export/debugging
     private val logBuffer = ConcurrentLinkedQueue<LogEntry>()
+
+    // Monotonic counters for the lifetime of the process. The buffer above is
+    // bounded at MAX_LOG_ENTRIES, so deriving statistics from it under-reports
+    // (e.g. UDP debug spam evicts older HTTP_REQUEST entries and the count
+    // collapses to 0). These atomics keep accurate totals regardless of buffer
+    // turnover.
+    private val httpRequestCount = AtomicLong(0)
+    private val httpResponseCount = AtomicLong(0)
+    private val errorCount = AtomicLong(0)
+    private val warningCount = AtomicLong(0)
+    private val retryCount = AtomicLong(0)
+    private val timeoutCount = AtomicLong(0)
+    private val redirectCount = AtomicLong(0)
     
     // Date formatter for timestamps
     private val timestampFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
@@ -939,6 +953,22 @@ object NetworkLogger {
         while (logBuffer.size > MAX_LOG_ENTRIES) {
             logBuffer.poll()
         }
+
+        // Bump monotonic statistics counters - kept independent of the bounded
+        // buffer so they don't silently regress when old entries are evicted.
+        when (level) {
+            Level.ERROR -> errorCount.incrementAndGet()
+            Level.WARN -> warningCount.incrementAndGet()
+            else -> {}
+        }
+        when (category) {
+            Category.HTTP_REQUEST -> httpRequestCount.incrementAndGet()
+            Category.HTTP_RESPONSE -> httpResponseCount.incrementAndGet()
+            Category.RETRY -> retryCount.incrementAndGet()
+            Category.TIMEOUT -> timeoutCount.incrementAndGet()
+            Category.REDIRECT -> redirectCount.incrementAndGet()
+            else -> {}
+        }
         
         // Format for logcat
         val timestamp = timestampFormat.format(Date(entry.timestamp))
@@ -989,46 +1019,45 @@ object NetworkLogger {
      */
     fun clearLogs() {
         logBuffer.clear()
+        httpRequestCount.set(0)
+        httpResponseCount.set(0)
+        errorCount.set(0)
+        warningCount.set(0)
+        retryCount.set(0)
+        timeoutCount.set(0)
+        redirectCount.set(0)
         Log.i(TAG, "Network logs cleared")
     }
-    
+
     /**
-     * Get statistics about logged network activity
+     * Get statistics about logged network activity. Counts are monotonic for the
+     * lifetime of the process (or until [clearLogs] is called) and are NOT
+     * derived from the bounded log buffer, so they remain accurate even after
+     * thousands of UDP debug entries have rolled the buffer.
      */
     fun getStatistics(): NetworkStatistics {
-        val stats = NetworkStatistics()
-        
-        logBuffer.forEach { entry ->
-            when (entry.level) {
-                Level.ERROR -> stats.errorCount++
-                Level.WARN -> stats.warningCount++
-                else -> {}
-            }
-            
-            when (entry.category) {
-                Category.HTTP_REQUEST -> stats.requestCount++
-                Category.HTTP_RESPONSE -> stats.responseCount++
-                Category.RETRY -> stats.retryCount++
-                Category.TIMEOUT -> stats.timeoutCount++
-                Category.REDIRECT -> stats.redirectCount++
-                else -> {}
-            }
-        }
-        
-        return stats
+        return NetworkStatistics(
+            requestCount = httpRequestCount.get(),
+            responseCount = httpResponseCount.get(),
+            errorCount = errorCount.get(),
+            warningCount = warningCount.get(),
+            retryCount = retryCount.get(),
+            timeoutCount = timeoutCount.get(),
+            redirectCount = redirectCount.get()
+        )
     }
     
     /**
      * Statistics about network activity
      */
     data class NetworkStatistics(
-        var requestCount: Int = 0,
-        var responseCount: Int = 0,
-        var errorCount: Int = 0,
-        var warningCount: Int = 0,
-        var retryCount: Int = 0,
-        var timeoutCount: Int = 0,
-        var redirectCount: Int = 0
+        var requestCount: Long = 0,
+        var responseCount: Long = 0,
+        var errorCount: Long = 0,
+        var warningCount: Long = 0,
+        var retryCount: Long = 0,
+        var timeoutCount: Long = 0,
+        var redirectCount: Long = 0
     ) {
         override fun toString(): String {
             return buildString {

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -668,6 +668,12 @@ class RenderManager(private val context: Context) {
     fun getDiagnostics(): RenderManagerDiagnostics {
         // Use synchronized to get consistent swapchain status
         val hasSwapChainNow = synchronized(swapChainLock) { swapChain != null }
+        // A SwapChain only makes sense when the SurfaceView is actually attached
+        // and the underlying Surface is valid. When the user is on Settings (or any
+        // non-WorldView screen), the SurfaceView is detached and `surface` is null
+        // or invalid - that is normal, not an error.
+        val surface = surfaceView?.holder?.surface
+        val surfaceReady = surface != null && surface.isValid
         return RenderManagerDiagnostics(
             isInitialized = isInitialized,
             isXRMode = isXRMode,
@@ -677,6 +683,7 @@ class RenderManager(private val context: Context) {
             hasView = view != null,
             hasCamera = camera != null,
             hasSwapChain = hasSwapChainNow,
+            isSurfaceReady = surfaceReady,
             viewportWidth = viewportWidth,
             viewportHeight = viewportHeight,
             frameCount = frameCount.get(),
@@ -686,7 +693,7 @@ class RenderManager(private val context: Context) {
             scenePopulationSnapshot = ScenePopulationDiagnostics.snapshot()
         )
     }
-    
+
     /**
      * Diagnostic data class for render manager state
      */
@@ -699,6 +706,7 @@ class RenderManager(private val context: Context) {
         val hasView: Boolean,
         val hasCamera: Boolean,
         val hasSwapChain: Boolean,
+        val isSurfaceReady: Boolean,
         val viewportWidth: Int,
         val viewportHeight: Int,
         val frameCount: Long,

--- a/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
@@ -824,6 +824,19 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine("  Error States: ${texDiag.textureErrorStateCount}")
                         val decoderStatus = com.linkpoint.assets.JPEG2000Decoder.getStartupStatus()
                         appendLine("  Backend: ${decoderStatus.activeBackend}")
+                        appendLine("  Native Loaded: ${if (decoderStatus.nativeLoaded) "✓" else "✗"}")
+                        appendLine("  Native Healthy: ${if (decoderStatus.nativeHealthy) "✓" else "✗"}")
+                        appendLine("  JP2ForAndroid Fallback: ${if (decoderStatus.jp2ForAndroidAvailable) "✓" else "✗"}")
+                        // Surface the underlying load/health failure when the backend
+                        // ended up as "none" - this is the difference between "we don't
+                        // know why" and "UnsatisfiedLinkError: dlopen failed: cannot
+                        // locate symbol opj_create_decompress" (NDK / OpenJPEG mismatch).
+                        decoderStatus.nativeError?.let {
+                            appendLine("  Native Load Error: $it")
+                        }
+                        decoderStatus.nativeHealthError?.let {
+                            appendLine("  Native Health Error: $it")
+                        }
                         if (decoderStatus.warningMessage != null) {
                             appendLine("  Warning: ${decoderStatus.warningMessage}")
                         }
@@ -879,22 +892,28 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine("  View: ${if (renderDiag.hasView) "✓" else "✗"}")
                         appendLine("  Camera: ${if (renderDiag.hasCamera) "✓" else "✗"}")
                         appendLine("  SwapChain: ${if (renderDiag.hasSwapChain) "✓" else "✗"}")
-                        
+                        appendLine("  Surface Ready: ${if (renderDiag.isSurfaceReady) "✓" else "✗ (e.g. on Settings, app backgrounded)"}")
+
                         if (renderDiag.initializationTime > 0) {
                             appendLine()
                             appendLine("Initialization Time: ${formatTimestamp(renderDiag.initializationTime)}")
                         }
-                        
+
                         if (renderDiag.lastInitializationError != null) {
                             appendLine()
                             appendLine("⚠️ INITIALIZATION ERROR: ${renderDiag.lastInitializationError}")
                         }
-                        
+
                         if (!renderDiag.isInitialized) {
                             appendLine()
                             appendLine("⚠️ RENDERER NOT INITIALIZED - No 3D rendering!")
                         }
-                        if (renderDiag.isInitialized && !renderDiag.hasSwapChain) {
+                        // Only flag a missing SwapChain as a problem when the Surface is
+                        // actually attached and ready - otherwise it just means the world
+                        // view isn't on screen right now (Settings, backgrounded, etc.),
+                        // which is the normal state when capturing a debug report from
+                        // any non-WorldView screen.
+                        if (renderDiag.isInitialized && !renderDiag.hasSwapChain && renderDiag.isSurfaceReady) {
                             appendLine()
                             appendLine("⚠️ NO SWAP CHAIN - Rendering not visible!")
                         }


### PR DESCRIPTION
## Summary
This PR improves the accuracy of network activity statistics by introducing monotonic counters that track events for the lifetime of the process, independent of the bounded log buffer. It also enhances debug diagnostics reporting for render and decoder status.

## Key Changes

**NetworkLogger.kt:**
- Added `AtomicLong` counters for HTTP requests, responses, errors, warnings, retries, timeouts, and redirects
- These counters are incremented whenever events are logged, providing accurate statistics even when old entries are evicted from the bounded log buffer
- Updated `getStatistics()` to return values from the monotonic counters instead of iterating through the buffer
- Changed `NetworkStatistics` data class fields from `Int` to `Long` to accommodate larger counts
- Updated `clearLogs()` to reset all monotonic counters when logs are cleared
- Added detailed comments explaining why monotonic counters are necessary (buffer turnover can cause statistics to regress)

**DebugReportService.kt:**
- Enhanced JPEG2000 decoder diagnostics to surface native library load/health errors
- Added `isSurfaceReady` field to render diagnostics output
- Improved SwapChain warning logic to only flag missing SwapChain as an error when the Surface is actually ready (not when the app is backgrounded or on non-WorldView screens)
- Added clarifying comments about when SwapChain absence is expected vs. problematic

**RenderManager.kt:**
- Added `isSurfaceReady` property to `RenderManagerDiagnostics` to track whether the underlying Surface is valid and attached
- Implemented Surface validity check in `getDiagnostics()` method
- Added explanatory comments about when SwapChain and Surface readiness are expected to be null/invalid

## Implementation Details
- Monotonic counters use `AtomicLong` for thread-safe increments without locking
- Statistics are now accurate regardless of how many entries have been evicted from the bounded buffer
- Debug reporting now provides better context for diagnosing initialization and rendering issues by distinguishing between "not ready" (normal) and "error" states

https://claude.ai/code/session_01HyTRaEWvMyA3ac4q1jvtg6

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces monotonic statistics counters to `NetworkLogger` to prevent counter regression when the bounded log buffer evicts old entries, and enhances debug diagnostics by adding surface readiness checks and JPEG2000 decoder health information. The network statistics counters are changed from `Int` to `Long` and backed by `AtomicLong` to provide thread-safe, accurate lifetime counts independent of buffer turnover. The debug reporting improvements help distinguish between normal "not ready" states (like when the app is backgrounded) versus actual error conditions in the renderer and decoder.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Network statistics tracking now provides persistent, accurate metrics throughout the app's lifetime instead of relying on buffer contents.
  * Added rendering surface readiness diagnostics to better identify and troubleshoot rendering issues.
  * Enhanced diagnostic reports with additional native backend health status information and refined warning logic for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->