### PR TITLE
Add Ktheme theme selection menu to Settings

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt
@@ -26,6 +26,7 @@ import com.linkpoint.BuildConfig
 import com.linkpoint.R
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.service.BackgroundResumeScheduler
+import com.linkpoint.ui.theme.ThemeManager
 import com.linkpoint.ui.tos.TosActivity
 import com.linkpoint.ui.world.WorldViewActivity
 import com.linkpoint.utils.CodexUploadService
@@ -109,6 +110,7 @@ class SettingsActivity : AppCompatActivity() {
 
             // Interface settings
             setupInterfaceSettings()
+            setupKthemeThemeMenu()
             
             // Graphics settings
             findPreference<ListPreference>("graphics_quality")?.setOnPreferenceChangeListener { _, newValue ->
@@ -200,6 +202,53 @@ class SettingsActivity : AppCompatActivity() {
                 BackgroundResumeScheduler.schedule(requireContext(), immediate = false)
                 true
             }
+        }
+
+        private fun setupKthemeThemeMenu() {
+            val themePreference = findPreference<Preference>("open_ktheme_theme_menu") ?: return
+
+            val themeManager = ThemeManager.getInstance(requireContext())
+            updateKthemeThemeSummary(themePreference, themeManager)
+
+            themePreference.setOnPreferenceClickListener {
+                val availableThemes = themeManager.availableThemes.value
+                if (availableThemes.isEmpty()) {
+                    Toast.makeText(requireContext(), "No Ktheme themes are available yet", Toast.LENGTH_SHORT).show()
+                    return@setOnPreferenceClickListener true
+                }
+
+                val themeNames = availableThemes.map { it.name }.toTypedArray()
+                val activeThemeId = themeManager.activeTheme.value.id
+                val activeThemeIndex = availableThemes.indexOfFirst { it.id == activeThemeId }.coerceAtLeast(0)
+                var selectedIndex = activeThemeIndex
+
+                AlertDialog.Builder(requireContext())
+                    .setTitle("Select Ktheme Theme")
+                    .setSingleChoiceItems(themeNames, activeThemeIndex) { _, which ->
+                        selectedIndex = which
+                    }
+                    .setPositiveButton("Apply") { _, _ ->
+                        availableThemes.getOrNull(selectedIndex)?.let { selectedTheme ->
+                            themeManager.setActiveTheme(selectedTheme)
+                            updateKthemeThemeSummary(themePreference, themeManager)
+                            Toast.makeText(
+                                requireContext(),
+                                "Theme applied: ${selectedTheme.name}",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                    .setNegativeButton("Cancel", null)
+                    .show()
+
+                true
+            }
+        }
+
+        private fun updateKthemeThemeSummary(themePreference: Preference, themeManager: ThemeManager) {
+            val activeThemeName = themeManager.activeTheme.value.name
+            val themeCount = themeManager.availableThemes.value.size
+            themePreference.summary = "Current: $activeThemeName ($themeCount available)"
         }
 
         /**

--- a/Linkpoint/src/main/res/xml/preferences.xml
+++ b/Linkpoint/src/main/res/xml/preferences.xml
@@ -47,6 +47,11 @@
             android:title="Customize Layout"
             android:summary="Reposition on-screen controls" />
 
+        <Preference
+            android:key="open_ktheme_theme_menu"
+            android:title="Ktheme Themes"
+            android:summary="Choose from built-in and shared Ktheme themes" />
+
     </PreferenceCategory>
 
     <!-- Graphics Settings -->


### PR DESCRIPTION
### Motivation
- Provide a direct Settings menu entry so users can browse and apply Ktheme (built-in and shared) themes from the app settings.
- Surface the currently active theme and number of available themes in the settings UI for discoverability.

### Description
- Added a new `Preference` entry `open_ktheme_theme_menu` to `res/xml/preferences.xml` under the Interface category to expose Ktheme themes in Settings.
- Wired `SettingsActivity.SettingsFragment` to initialize the menu via a new `setupKthemeThemeMenu()` method and imported `ThemeManager`.
- Implemented a single-choice dialog that lists `ThemeManager.availableThemes`, preselects the active theme, applies the selected theme via `ThemeManager.setActiveTheme(...)`, and shows a confirmation `Toast`.
- Added `updateKthemeThemeSummary()` to keep the preference summary in-sync with the active theme name and available theme count.

### Testing
- Ran `ANDROID_HOME=/workspace/Linkpoint/android-sdk ./gradlew -p Linkpoint :compileStableDebugKotlin` and the build completed successfully (warnings unrelated to this change remain).
- Attempting `./gradlew -p Linkpoint :compileDebugKotlin` failed due to an ambiguous task name in the multi-variant project, not because of the changes made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebea22c678832389cd9231a1f248de)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new settings menu entry that allows users to browse and select Ktheme themes directly from the app settings. The implementation includes a preference item in the Interface category that displays the currently active theme and the total number of available themes. When clicked, it opens a single-choice dialog where users can select and apply a theme, with the changes reflected immediately via `ThemeManager`. The preference summary dynamically updates to show the active theme name and theme count.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/res/xml/preferences.xml` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme customization to Settings under the Interface section
  * Users can now browse and select from available Ktheme themes via a dialog menu
  * Theme changes apply immediately with confirmation feedback
  * Graceful handling when themes are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->