### PR TITLE
Add inbound-flow watchdog and UDP UUIDNameRequest fallback

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -1017,6 +1017,21 @@ class LinkpointApp : Application() {
                         inventoryManager.warmFetch()
                     }
 
+                    // Request own avatar profile so the Profile tab is populated
+                    // by the time the user opens it. Without this request the
+                    // sim never volunteers AvatarPropertiesReply for self and
+                    // the profile sits blank (2026-04-25 Athanasia capture).
+                    val myId = this@LinkpointApp.agentId
+                    if (myId != null && ::userProfileManager.isInitialized) {
+                        applicationScope.launch {
+                            try {
+                                userProfileManager.requestProfile(myId)
+                            } catch (e: Exception) {
+                                Log.w(TAG, "Failed to request own profile: ${e.message}")
+                            }
+                        }
+                    }
+
                     Log.i(TAG, "✓ Connection state set to CONNECTED - agent is in world")
                 } else {
                     com.linkpoint.utils.InitializationTracker.logWarning("AgentMovementComplete parse returned null")
@@ -2752,9 +2767,17 @@ class LinkpointApp : Application() {
                     val data = com.linkpoint.protocol.messages.AdditionalMessageParsers.parseUUIDNameReply(payload)
                     if (data != null) {
                         Log.d(TAG, "🏷️ UUIDNameReply: ${data.entries.size} names")
+                        // Feed legacy names into FriendsManager so the friends
+                        // list stops showing `Resident (xxxx)` placeholders
+                        // when GetDisplayNames cap silently fails (the 2026-04-25
+                        // Athanasia capture). Capability path remains primary;
+                        // this is the UDP fallback wired by sendUUIDNameRequest.
+                        val friendsReady = ::friendsManager.isInitialized
                         data.entries.forEach { entry ->
-                            // Cache names for display
-                            Log.d(TAG, "  ${entry.id} -> ${entry.firstName} ${entry.lastName}")
+                            val resolved = "${entry.firstName} ${entry.lastName}".trim()
+                            if (resolved.isNotBlank() && friendsReady) {
+                                friendsManager.updateFriendName(entry.id, resolved)
+                            }
                         }
                     }
                 }

--- a/Linkpoint/src/main/java/com/linkpoint/network/SecondLifeProtocol.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/SecondLifeProtocol.kt
@@ -541,7 +541,12 @@ class SecondLifeProtocol(private val context: Context) {
                                         app.capabilityManager.isReady.filter { it }.first()
                                     } ?: false
                                     if (!ready) {
-                                        Log.w(TAG, "[LOGIN DATA] Display name lookup skipped: capabilities not ready")
+                                        Log.w(TAG, "[LOGIN DATA] Capabilities not ready in 10s; using UDP UUIDNameRequest for ${friendIds.size} friends")
+                                        try {
+                                            app.udpConnection.sendUUIDNameRequest(friendIds)
+                                        } catch (e: Exception) {
+                                            Log.w(TAG, "[LOGIN DATA] UUIDNameRequest fallback failed: ${e.message}")
+                                        }
                                         return@launch
                                     }
 
@@ -549,9 +554,32 @@ class SecondLifeProtocol(private val context: Context) {
                                     displayNames.forEach { (agentId, displayName) ->
                                         app.friendsManager.updateFriendName(agentId, displayName)
                                     }
-                                    Log.i(TAG, "[LOGIN DATA] ✓ Resolved display names for ${displayNames.size} friends")
+                                    Log.i(TAG, "[LOGIN DATA] ✓ Resolved display names for ${displayNames.size}/${friendIds.size} friends via cap")
+
+                                    // UDP fallback: anything the GetDisplayNames cap
+                                    // didn't resolve is asked over UDP UUIDNameRequest.
+                                    // The cap silently failed in the 2026-04-25 Athanasia
+                                    // capture (851 friends stuck on `Resident (xxxx)`);
+                                    // UDP UUIDNameRequest is `NotTrusted Unencoded` and
+                                    // works even when the HTTP cap pipeline is broken.
+                                    val unresolved = friendIds - displayNames.keys
+                                    if (unresolved.isNotEmpty()) {
+                                        Log.i(TAG, "[LOGIN DATA] Falling back to UUIDNameRequest for ${unresolved.size} unresolved friends")
+                                        try {
+                                            app.udpConnection.sendUUIDNameRequest(unresolved.toList())
+                                        } catch (e: Exception) {
+                                            Log.w(TAG, "[LOGIN DATA] UUIDNameRequest fallback failed: ${e.message}")
+                                        }
+                                    }
                                 } catch (e: Exception) {
                                     Log.w(TAG, "[LOGIN DATA] Failed to resolve some display names: ${e.message}")
+                                    // If the whole HTTP batch threw, still try the UDP
+                                    // fallback so the friends list isn't all placeholders.
+                                    try {
+                                        app.udpConnection.sendUUIDNameRequest(friendIds)
+                                    } catch (udpErr: Exception) {
+                                        Log.w(TAG, "[LOGIN DATA] UUIDNameRequest fallback also failed: ${udpErr.message}")
+                                    }
                                 }
                             }
                         } catch (e: Exception) {

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -193,6 +193,22 @@ class UDPConnectionFixed {
          * Android socket errors like "Operation not permitted" indicate socket invalidation.
          */
         const val CONSECUTIVE_ERROR_THRESHOLD = 5
+
+        /**
+         * Maximum time without ANY new received packet before we treat the
+         * inbound side as dead and force a socket rebind. Set above the
+         * unanswered-ping window (3 × 5s + slack) so the cheaper ping-based
+         * watchdog gets first shot, but well below typical user-visible
+         * timeouts so a stuck cellular NAT clears within ~45s.
+         */
+        const val INBOUND_DATA_STALL_MS = 45_000L
+
+        /**
+         * Cooldown after a socket rebind. Prevents tight reconnect loops if
+         * the rebind itself doesn't restore inbound flow (e.g. carrier-side
+         * outage rather than NAT eviction).
+         */
+        const val SOCKET_REBIND_COOLDOWN_MS = 30_000L
     }
     
     // Connection parameters
@@ -266,9 +282,22 @@ class UDPConnectionFixed {
     
     /** Timestamp of last packet received (for timing diagnostics) */
     private var lastReceiveTime = 0L
-    
+
     /** Timestamp of last packet sent (for timing diagnostics) */
     private var lastSendTime = 0L
+
+    /**
+     * Inbound-flow watchdog state. Catches "send-only zombie circuits" — the
+     * 2026-04-25 Athanasia capture showed 4+ minutes of pings + AgentUpdate
+     * going outbound while no application data ever arrived. Pings can keep
+     * `lastReceiveTime` fresh on cellular even when the data path is dead
+     * (NAT idle eviction often kills only large flows), so the existing
+     * unanswered-ping watchdog never triggered. We track packets-received
+     * growth instead and force a true socket rebind if it stalls.
+     */
+    private var lastInboundFlowSnapshot = 0
+    private var lastInboundFlowGrowthTime = 0L
+    private var lastSocketRebindTime = 0L
     
     /** Timestamp when connection was attempted (for connection duration) */
     private var connectionAttemptTime = 0L
@@ -667,6 +696,13 @@ class UDPConnectionFixed {
             // matching Lumiya's SLCircuit pattern.
             sequenceNumber.set(0)
             
+            // Reset inbound-flow watchdog state so the first observation
+            // after handshake establishes the baseline (rather than tripping
+            // off an old snapshot from a previous circuit).
+            lastInboundFlowSnapshot = 0
+            lastInboundFlowGrowthTime = 0L
+            lastSocketRebindTime = 0L
+
             // Reset packet statistics for accurate per-session tracking
             packetsReceived.set(0)
             packetsSent.set(0)
@@ -965,6 +1001,7 @@ class UDPConnectionFixed {
                 }
                 if (now - lastTimeoutCheckTime >= 1000L) {
                     checkPingHealth()
+                    checkInboundFlow()
                     checkMessageTimeouts()
                     lastTimeoutCheckTime = now
                 }
@@ -1161,6 +1198,83 @@ class UDPConnectionFixed {
         if (timeSinceReceive > NEED_PING_TIMEOUT_MS &&
             timeSincePing > LinkpointConstants.PING_INTERVAL_MS) {
             sendStartPingCheck()
+        }
+    }
+
+    /**
+     * Inbound-flow watchdog (independent of the unanswered-ping check).
+     *
+     * The unanswered-ping watchdog only catches "no response of any kind".
+     * On cellular networks the simulator's small ping-replies sometimes
+     * survive while the larger data flow (ObjectUpdate, AgentGroupDataUpdate,
+     * IM, friend status) is silently dropped — typically because the carrier
+     * NAT timed out the high-volume path or the per-flow rate-limiter capped
+     * the sim → client direction. The 2026-04-25 Athanasia capture showed
+     * exactly that: 4.5 minutes with `Unanswered Pings: 0` and 89 received
+     * packets total, all in the first 2 seconds.
+     *
+     * If [packetsReceived] hasn't grown in [INBOUND_DATA_STALL_MS] AND we're
+     * still actively sending, force a socket rebind to clear the stuck NAT
+     * mapping. A new `connect()` on the DatagramChannel picks a fresh
+     * ephemeral source port, which forces the carrier NAT to allocate a new
+     * mapping and the sim re-targets us via the follow-up `UseCircuitCode`.
+     *
+     * Cooled down by [SOCKET_REBIND_COOLDOWN_MS] so a carrier-side outage
+     * doesn't cause us to thrash.
+     */
+    private fun checkInboundFlow() {
+        if (!_isConnected.value) return
+
+        val now = System.currentTimeMillis()
+        val received = packetsReceived.get()
+
+        // Initialise snapshot the first time we observe any traffic.
+        if (lastInboundFlowGrowthTime == 0L) {
+            lastInboundFlowSnapshot = received
+            lastInboundFlowGrowthTime = now
+            return
+        }
+
+        // Refresh snapshot whenever inbound is healthy.
+        if (received > lastInboundFlowSnapshot) {
+            lastInboundFlowSnapshot = received
+            lastInboundFlowGrowthTime = now
+            return
+        }
+
+        // Don't trip the watchdog while we're still in the cooldown after a
+        // previous rebind (the new circuit needs time to receive its first
+        // packet through the freshly-allocated NAT mapping).
+        if (now - lastSocketRebindTime < SOCKET_REBIND_COOLDOWN_MS) return
+
+        val stallMs = now - lastInboundFlowGrowthTime
+        if (stallMs < INBOUND_DATA_STALL_MS) return
+
+        // Require evidence we're actually sending. If `packetsSent` isn't
+        // growing either, the unanswered-ping path will handle it; firing a
+        // rebind here would just race with that.
+        if (packetsSent.get() <= lastInboundFlowSnapshot) return
+
+        NetworkLogger.log(
+            NetworkLogger.Level.WARN,
+            NetworkLogger.Category.UDP,
+            "Inbound stalled for ${stallMs}ms (received=$received, sent=${packetsSent.get()}) - forcing socket rebind"
+        )
+        lastSocketRebindTime = now
+        emitNetworkState(NetworkStateTransition.RECONNECTING)
+        scope.launch {
+            val ok = try { reconnect() } catch (e: Exception) { false }
+            if (ok) {
+                emitNetworkState(NetworkStateTransition.CONNECTED)
+            } else {
+                NetworkLogger.log(
+                    NetworkLogger.Level.ERROR,
+                    NetworkLogger.Category.UDP,
+                    "Inbound-stall socket rebind failed; deferring to higher-level reconnect"
+                )
+                emitNetworkState(NetworkStateTransition.FAULTED)
+                reconnectionCallback?.invoke()
+            }
         }
     }
     
@@ -1683,7 +1797,35 @@ class UDPConnectionFixed {
         
         sendPacket(MessageIds.REQUEST_MULTIPLE_OBJECTS, payload.array(), reliable = true)
     }
-    
+
+    /**
+     * UDP fallback for resolving avatar UUIDs to legacy first/last name pairs.
+     * Used when the GetDisplayNames capability is unavailable, times out, or
+     * returns no entries for a subset of IDs (the 2026-04-25 Athanasia capture
+     * showed 851 friends stuck on `Resident (xxxx)` because the cap path
+     * silently failed). Reply arrives as `UUIDNameReply` and is handled by
+     * `LinkpointApp` to feed `FriendsManager` / display-name caches.
+     *
+     * Wire format (LL message template `UUIDNameRequest`, low-freq 235):
+     *   UUIDNameBlock (Variable u8 count): { ID LLUUID }
+     * No AgentData block — this message is `NotTrusted Unencoded`.
+     */
+    fun sendUUIDNameRequest(ids: List<UUID>) {
+        if (ids.isEmpty()) return
+        // Cap at 60 per packet to stay well under the ~1200B UDP MTU
+        // (1 + count*16). Sender batches if larger.
+        for (batch in ids.chunked(60)) {
+            val payload = ByteBuffer.allocate(1 + batch.size * 16).order(ByteOrder.LITTLE_ENDIAN)
+            payload.put(batch.size.toByte())
+            for (id in batch) {
+                payload.put(id.asBytes())
+            }
+            sendPacket(MessageIds.UUID_NAME_REQUEST, payload.array(), reliable = true)
+        }
+        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
+            "→ Sent UUIDNameRequest for ${ids.size} ids")
+    }
+
     /**
      * Send a packet with proper SL protocol encoding
      * 
@@ -2054,6 +2196,13 @@ class UDPConnectionFixed {
         lastPingTime.set(now)
         unansweredPings.set(0)
         consecutiveSendErrors.set(0)
+
+        // Re-baseline the inbound-flow watchdog. lastSocketRebindTime is
+        // set to `now` so the cooldown protects this attempt from being
+        // immediately retripped if the new socket also can't receive.
+        lastInboundFlowSnapshot = packetsReceived.get()
+        lastInboundFlowGrowthTime = now
+        lastSocketRebindTime = now
 
         try {
             val address = InetSocketAddress(simIP, simPort)


### PR DESCRIPTION
## Summary
This PR adds two resilience improvements to handle cellular network issues and capability service failures:

1. **Inbound-flow watchdog**: Detects "send-only zombie circuits" where outbound traffic (pings, updates) succeeds but inbound data silently stalls due to NAT eviction or carrier rate-limiting. Forces a socket rebind to allocate a fresh NAT mapping.

2. **UDP UUIDNameRequest fallback**: When the GetDisplayNames capability times out or silently fails, falls back to a UDP-based legacy name lookup to prevent friends lists from showing `Resident (xxxx)` placeholders.

## Key Changes

- **UDPConnectionFixed.kt**:
  - Added `INBOUND_DATA_STALL_MS` (45s) and `SOCKET_REBIND_COOLDOWN_MS` (30s) constants to tune the watchdog behavior
  - Added inbound-flow tracking state: `lastInboundFlowSnapshot`, `lastInboundFlowGrowthTime`, `lastSocketRebindTime`
  - Implemented `checkInboundFlow()` method that monitors packet-received growth and triggers socket rebind if stalled
  - Integrated watchdog check into the 1-second timeout loop (alongside existing ping health check)
  - Reset watchdog state on successful handshake and socket reconnect
  - Added `sendUUIDNameRequest()` to send batched UDP UUIDNameRequest messages (max 60 IDs per packet)

- **SecondLifeProtocol.kt**:
  - Modified login display-name resolution to fall back to `sendUUIDNameRequest()` if capabilities aren't ready within 10s
  - Added fallback for unresolved friends after capability path succeeds (partial resolution case)
  - Added fallback if the entire capability batch throws an exception

- **LinkpointApp.kt**:
  - Added proactive request for own avatar profile on connection to populate the Profile tab
  - Wired `UUIDNameReply` handler to feed resolved names into `FriendsManager` (the UDP fallback path)

## Implementation Details

The inbound-flow watchdog is independent of the existing unanswered-ping check because small ping replies can survive on cellular networks while larger data flows are silently dropped. The watchdog tracks whether `packetsReceived` is growing; if it stalls for 45s while we're still sending, a socket rebind is forced. A 30s cooldown prevents thrashing if the carrier-side issue persists.

The UDP fallback uses the `NotTrusted Unencoded` UUIDNameRequest message (LL template 235), which works even when the HTTP capability pipeline is broken. Batching is capped at 60 IDs per packet to stay well under the ~1200B UDP MTU.

https://claude.ai/code/session_011KA9uHUATabvfCgZwVn8bn

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds two resilience mechanisms to handle cellular network issues where outbound traffic succeeds but inbound data silently stalls. The **inbound-flow watchdog** monitors whether received packets are growing and triggers a socket rebind if data stalls for 45 seconds while still sending (addressing NAT eviction or carrier rate-limiting). The **UDP UUIDNameRequest fallback** resolves friend names via legacy UDP messages when the GetDisplayNames capability times out or partially fails, preventing friends lists from displaying `Resident (xxxx)` placeholders. Additionally, the app now proactively requests the user's own avatar profile on connection to populate the Profile tab.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/network/SecondLifeProtocol.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved friend display name resolution with automatic fallback mechanism
  * Enhanced network connection stability with inbound data monitoring and automatic recovery
  * Fixed profile tab population after agent movement completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->