### PR TITLE
Add inbound traffic rate tracking and lifecycle logging for diagnostics

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
@@ -306,6 +306,13 @@ object NetworkLogger {
         const val UDP = "UDP"
         const val UDP_MALFORMED = "UDP_MALFORMED"
         const val UDP_PACKET = "UDP_PKT"
+        // App-level events interleaved with UDP/HTTP traffic so a single log
+        // file shows whether the activity was paused, the surface was lost,
+        // or the OS network interface dropped at the moment inbound traffic
+        // stopped. Investigated after the 2026-04-26 Athanasia capture
+        // showed 24s of inbound silence with no contextual signal.
+        const val LIFECYCLE = "LIFECYCLE"
+        const val CONNECTIVITY = "CONNECTIVITY"
     }
     
     // ==================== HTTP/2 PROTOCOL TRACKING ====================

--- a/Linkpoint/src/main/java/com/linkpoint/network/core/ConnectionQualityManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/core/ConnectionQualityManager.kt
@@ -8,6 +8,7 @@ import android.net.NetworkRequest
 import android.os.Build
 import android.util.Log
 import com.linkpoint.network.NetworkDiagnostics
+import com.linkpoint.network.NetworkLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -108,24 +109,35 @@ class ConnectionQualityManager(private val context: Context) {
         networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 Log.d(TAG, "Network available")
+                NetworkLogger.log(
+                    NetworkLogger.Level.INFO,
+                    NetworkLogger.Category.CONNECTIVITY,
+                    "🟢 Network available (handle=${network.networkHandle})"
+                )
                 _isConnected.value = true
                 updateNetworkInfo()
                 // Notify listeners of network change (for DNS cache clearing, etc.)
                 notifyNetworkChange()
             }
-            
+
             override fun onLost(network: Network) {
                 Log.d(TAG, "Network lost")
+                NetworkLogger.log(
+                    NetworkLogger.Level.WARN,
+                    NetworkLogger.Category.CONNECTIVITY,
+                    "🔴 Network lost (handle=${network.networkHandle})"
+                )
                 _isConnected.value = false
                 _quality.value = Quality.UNKNOWN
                 // Notify listeners of network change
                 notifyNetworkChange()
             }
-            
+
             override fun onCapabilitiesChanged(
                 network: Network,
                 capabilities: NetworkCapabilities
             ) {
+                logCapabilitiesChanged(network, capabilities)
                 updateFromCapabilities(capabilities)
             }
         }
@@ -214,6 +226,41 @@ class ConnectionQualityManager(private val context: Context) {
         }
     }
     
+    /**
+     * Emit a structured CONNECTIVITY log entry every time capabilities change.
+     * Capability churn (validated flips off, downstream bandwidth drops) often
+     * precedes the inbound-data stalls we've been chasing — surfacing it in
+     * the same log as UDP send/recv lets us correlate.
+     */
+    private fun logCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+        val transports = buildList {
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) add("WIFI")
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) add("CELLULAR")
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) add("ETHERNET")
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) add("VPN")
+        }.joinToString(",").ifEmpty { "?" }
+        val internet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        val validated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        val notMetered = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+        val downstream = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            capabilities.linkDownstreamBandwidthKbps
+        } else {
+            -1
+        }
+        val upstream = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            capabilities.linkUpstreamBandwidthKbps
+        } else {
+            -1
+        }
+        NetworkLogger.log(
+            NetworkLogger.Level.DEBUG,
+            NetworkLogger.Category.CONNECTIVITY,
+            "Capabilities (handle=${network.networkHandle}): transport=$transports " +
+                "internet=$internet validated=$validated notMetered=$notMetered " +
+                "down=${downstream}kbps up=${upstream}kbps"
+        )
+    }
+
     /**
      * Update from network capabilities
      * 

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/InboundRateTracker.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/InboundRateTracker.kt
@@ -1,0 +1,79 @@
+package com.linkpoint.protocol.messages
+
+/**
+ * Rolling per-second buckets of inbound UDP packet count and byte volume.
+ *
+ * Cumulative totals (`packetsReceived`, `bytesReceived`) tell you how much
+ * traffic arrived over the entire session but hide *when* it arrived. The
+ * 2026-04-26 Athanasia capture showed 220 objects loading cleanly, then 24
+ * seconds of complete inbound silence before the circuit watchdog tripped.
+ * Cumulative counters can't distinguish "steady stream" from "burst then
+ * nothing" — per-second buckets can.
+ *
+ * Implementation note: receive happens on a single I/O thread (`SLCircuitIO`
+ * / `CircuitThread`), so [record] is effectively single-producer. [snapshot]
+ * may be called from the debug-report thread, hence the synchronized block.
+ */
+class InboundRateTracker(private val windowSeconds: Int = 60) {
+
+    private val packetBuckets = LongArray(windowSeconds)
+    private val byteBuckets = LongArray(windowSeconds)
+    private val bucketSeconds = LongArray(windowSeconds)
+    private val lock = Any()
+
+    /**
+     * Record one received packet of [bytes] bytes against the current second.
+     * If the slot held a stale second (i.e. the window has wrapped), it is
+     * reset before incrementing.
+     */
+    fun record(bytes: Int) {
+        val nowSec = System.currentTimeMillis() / 1000L
+        val slot = ((nowSec % windowSeconds).toInt() + windowSeconds) % windowSeconds
+        synchronized(lock) {
+            if (bucketSeconds[slot] != nowSec) {
+                bucketSeconds[slot] = nowSec
+                packetBuckets[slot] = 0
+                byteBuckets[slot] = 0
+            }
+            packetBuckets[slot]++
+            byteBuckets[slot] += bytes.toLong()
+        }
+    }
+
+    /**
+     * Return the most recent [maxBuckets] one-second buckets, oldest first.
+     * Buckets that were never written within their second appear as zeros so
+     * the gaps are visible in the report.
+     */
+    fun snapshot(maxBuckets: Int = windowSeconds): List<RateBucket> {
+        val n = maxBuckets.coerceIn(1, windowSeconds)
+        val nowSec = System.currentTimeMillis() / 1000L
+        val result = ArrayList<RateBucket>(n)
+        synchronized(lock) {
+            for (offset in (n - 1) downTo 0) {
+                val sec = nowSec - offset
+                val slot = ((sec % windowSeconds).toInt() + windowSeconds) % windowSeconds
+                if (bucketSeconds[slot] == sec) {
+                    result += RateBucket(sec, packetBuckets[slot], byteBuckets[slot])
+                } else {
+                    result += RateBucket(sec, 0L, 0L)
+                }
+            }
+        }
+        return result
+    }
+
+    fun reset() {
+        synchronized(lock) {
+            packetBuckets.fill(0L)
+            byteBuckets.fill(0L)
+            bucketSeconds.fill(0L)
+        }
+    }
+
+    data class RateBucket(
+        val epochSecond: Long,
+        val packets: Long,
+        val bytes: Long
+    )
+}

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -300,9 +300,16 @@ class UDPConnectionFixed {
     
     /** Total bytes received from simulator */
     private val bytesReceived = AtomicLong(0)
-    
+
     /** Total bytes sent to simulator */
     private val bytesSent = AtomicLong(0)
+
+    /**
+     * Rolling per-second buckets of inbound packet count and byte volume.
+     * Cumulative counters can't tell you whether `bytesReceived = 30 MB` came
+     * in steadily or as a burst followed by silence — these can.
+     */
+    private val inboundRateTracker = InboundRateTracker()
     
     /** Count of messages successfully routed to handlers */
     private val messagesRouted = AtomicInteger(0)
@@ -764,6 +771,7 @@ class UDPConnectionFixed {
             bytesSent.set(0)
             messagesRouted.set(0)
             packetsResentCount.set(0)
+            inboundRateTracker.reset()
             
             // Reset timing information
             val now = System.currentTimeMillis()
@@ -1004,6 +1012,7 @@ class UDPConnectionFixed {
                                 packetsReceived.incrementAndGet()
                                 postReconnectPacketsReceived.incrementAndGet()
                                 bytesReceived.addAndGet(bytesRead.toLong())
+                                inboundRateTracker.record(bytesRead)
                                 lastReceiveTime = System.currentTimeMillis()
                                 unansweredPings.set(0)
 
@@ -2754,7 +2763,8 @@ class UDPConnectionFixed {
             totalBytesReceived = bytesReceived.get(),
             packetsResent = packetsResentCount.get(),
             messageTypeCounts = messageTypeCounts.mapValues { it.value.get() },
-            lastMessageTimes = lastMessageTimes.toMap()
+            lastMessageTimes = lastMessageTimes.toMap(),
+            inboundRateBuckets = inboundRateTracker.snapshot()
         )
     }
     
@@ -2826,7 +2836,8 @@ class UDPConnectionFixed {
         val totalBytesReceived: Long,
         val packetsResent: Int,
         val messageTypeCounts: Map<String, Int>,
-        val lastMessageTimes: Map<String, Long>
+        val lastMessageTimes: Map<String, Long>,
+        val inboundRateBuckets: List<InboundRateTracker.RateBucket> = emptyList()
     )
     
     /**

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt
@@ -1,6 +1,7 @@
 package com.linkpoint.render
 
 import android.util.Log
+import com.linkpoint.network.NetworkLogger
 import com.linkpoint.utils.SessionLogRecorder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -148,14 +149,19 @@ object RenderDiagnostics {
 
     fun filamentSurfaceAttached(width: Int, height: Int) {
         SessionLogRecorder.logRender("Filament", "surface_attached", "${width}x${height}")
+        logLifecycle(NetworkLogger.Level.INFO, "🖼️ Filament surface attached ${width}x${height}")
     }
 
     fun filamentSurfaceDetached(reason: String) {
         SessionLogRecorder.logRender("Filament", "surface_detached", reason)
+        // WARN level so it's visible at default log filter — surface loss
+        // is the strongest correlate with the inbound-stall/reconnect bug.
+        logLifecycle(NetworkLogger.Level.WARN, "🖼️ Filament surface detached: $reason")
     }
 
     fun filamentSurfaceChanged(width: Int, height: Int) {
         SessionLogRecorder.logRender("Filament", "surface_changed", "${width}x${height}")
+        logLifecycle(NetworkLogger.Level.DEBUG, "🖼️ Filament surface changed ${width}x${height}")
     }
 
     fun filamentSwapChainCreated(width: Int, height: Int) {
@@ -164,14 +170,28 @@ object RenderDiagnostics {
             "swapchain_created",
             if (width > 0 && height > 0) "${width}x${height}" else null
         )
+        val dims = if (width > 0 && height > 0) " (${width}x${height})" else ""
+        logLifecycle(NetworkLogger.Level.INFO, "🖼️ Filament SwapChain created$dims")
     }
 
     fun filamentSwapChainDestroyed(reason: String) {
         SessionLogRecorder.logRender("Filament", "swapchain_destroyed", reason)
+        logLifecycle(NetworkLogger.Level.WARN, "🖼️ Filament SwapChain destroyed: $reason")
     }
 
     fun filamentSwapChainFailed(reason: String) {
         SessionLogRecorder.logRender("Filament", "swapchain_failed", reason)
+        logLifecycle(NetworkLogger.Level.ERROR, "🖼️ Filament SwapChain FAILED: $reason")
+    }
+
+    /**
+     * Mirror render-lifecycle events into [NetworkLogger] under the LIFECYCLE
+     * category so they appear interleaved with UDP/HTTP traffic in
+     * `network_log_*.txt`. SessionLogRecorder still gets the structured
+     * record for the render-focused timeline; this is purely additional.
+     */
+    private fun logLifecycle(level: NetworkLogger.Level, message: String) {
+        NetworkLogger.log(level, NetworkLogger.Category.LIFECYCLE, message)
     }
 
     fun filamentViewport(width: Int, height: Int, callSite: String) {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
@@ -25,6 +25,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.navigation.NavigationView
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
+import com.linkpoint.network.NetworkLogger
 import com.linkpoint.core.ConnectionState
 import com.linkpoint.ui.chat.ChatActivity
 import com.linkpoint.ui.friends.FriendsActivity
@@ -987,15 +988,25 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
     
     override fun onPause() {
         super.onPause()
+        NetworkLogger.log(
+            NetworkLogger.Level.INFO,
+            NetworkLogger.Category.LIFECYCLE,
+            "🌐 WorldViewActivity onPause (renderer=${if (useSecondaryRenderer) "lumiya" else "filament"})"
+        )
         if (useSecondaryRenderer) {
             lumiyaSurfaceView?.onPause()
         } else {
             isRendering = false
         }
     }
-    
+
     override fun onResume() {
         super.onResume()
+        NetworkLogger.log(
+            NetworkLogger.Level.INFO,
+            NetworkLogger.Category.LIFECYCLE,
+            "🌐 WorldViewActivity onResume (renderer=${if (useSecondaryRenderer) "lumiya" else "filament"})"
+        )
         applyScreenOrientation() // Reapply orientation in case user changed setting
         updateDebugFloaterVisibility() // Update debug floater visibility based on settings
         applyInterfacePreferences()

--- a/Linkpoint/src/main/java/com/linkpoint/util/LifecycleAwareScopeManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/util/LifecycleAwareScopeManager.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.linkpoint.network.NetworkLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -583,10 +584,20 @@ object LifecycleAwareScopeManager {
         
         override fun onStop(owner: LifecycleOwner) {
             android.util.Log.d(TAG, "Application moved to background")
+            NetworkLogger.log(
+                NetworkLogger.Level.INFO,
+                NetworkLogger.Category.LIFECYCLE,
+                "📱 App → background (process onStop)"
+            )
         }
-        
+
         override fun onStart(owner: LifecycleOwner) {
             android.util.Log.d(TAG, "Application moved to foreground")
+            NetworkLogger.log(
+                NetworkLogger.Level.INFO,
+                NetworkLogger.Category.LIFECYCLE,
+                "📱 App → foreground (process onStart)"
+            )
         }
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
@@ -1256,6 +1256,33 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine()
                     }
                     
+                    if (msgStats.inboundRateBuckets.isNotEmpty()) {
+                        appendLine("Inbound Rate (last ${msgStats.inboundRateBuckets.size}s, oldest first):")
+                        appendLine("  second  packets    bytes")
+                        val nowSec = System.currentTimeMillis() / 1000L
+                        msgStats.inboundRateBuckets.forEach { bucket ->
+                            val ago = nowSec - bucket.epochSecond
+                            // Mark the silent buckets so a 24-second hole jumps out visually.
+                            val marker = if (bucket.packets == 0L) " ⚠" else ""
+                            appendLine(
+                                "  -%3ds  %7d  %7s%s".format(
+                                    ago,
+                                    bucket.packets,
+                                    formatBytes(bucket.bytes),
+                                    marker
+                                )
+                            )
+                        }
+                        val totalPackets = msgStats.inboundRateBuckets.sumOf { it.packets }
+                        val totalBytes = msgStats.inboundRateBuckets.sumOf { it.bytes }
+                        val silentBuckets = msgStats.inboundRateBuckets.count { it.packets == 0L }
+                        appendLine(
+                            "  window total: $totalPackets pkts / ${formatBytes(totalBytes)} " +
+                                "($silentBuckets silent seconds)"
+                        )
+                        appendLine()
+                    }
+
                     // Warning if critical messages haven't been received
                     val regionHandshakeTime = msgStats.lastMessageTimes["RegionHandshake"]
                     val agentMovementTime = msgStats.lastMessageTimes["AgentMovementComplete"]


### PR DESCRIPTION
## Summary
This PR enhances diagnostic capabilities by introducing per-second inbound traffic rate tracking and comprehensive lifecycle/connectivity event logging. These changes enable better correlation of network stalls with application state changes and network capability fluctuations.

## Key Changes

- **New `InboundRateTracker` class**: Implements rolling per-second buckets to track UDP packet count and byte volume, distinguishing between steady traffic streams and burst-then-silence patterns. Addresses the issue where cumulative counters couldn't reveal 24-second inbound silence windows.

- **Enhanced `UDPConnectionFixed`**: 
  - Integrated `InboundRateTracker` to record all inbound packets
  - Added `inboundRateBuckets` to `MessageStats` for debug reporting
  - Reset tracker on connection reset

- **Expanded `DebugReportService`**: Added formatted output of inbound rate buckets with visual markers (⚠) for silent seconds, making traffic gaps immediately visible in debug reports

- **Network capability logging in `ConnectionQualityManager`**: 
  - Logs network availability/loss events with emoji markers
  - Logs capability changes (transport type, validation status, bandwidth) to correlate with traffic anomalies

- **Render lifecycle logging in `RenderDiagnostics`**: 
  - Mirrors surface attach/detach/change and SwapChain events to `NetworkLogger`
  - Uses WARN level for surface loss (strongest correlate with inbound-stall bug)

- **App lifecycle logging**: 
  - `WorldViewActivity` logs onPause/onResume with renderer type
  - `LifecycleAwareScopeManager` logs app foreground/background transitions

- **New `NetworkLogger` categories**: Added `LIFECYCLE` and `CONNECTIVITY` categories to interleave app-level events with UDP/HTTP traffic in a single log file for comprehensive correlation analysis

## Implementation Details

- Thread-safe design: `InboundRateTracker.record()` runs on single I/O thread; `snapshot()` uses synchronized blocks for debug-report thread access
- Modulo arithmetic handles window wrapping correctly with `((sec % windowSeconds).toInt() + windowSeconds) % windowSeconds`
- Emoji markers (🟢🔴🖼️📱) improve visual scanning of logs
- All new logging respects existing `NetworkLogger.Level` filtering

https://claude.ai/code/session_019dRhvfhnEpS5ZnrD4ZVPYn

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive diagnostic logging and metrics to help troubleshoot network stalls by tracking per-second inbound UDP traffic rates and correlating them with application lifecycle events. A new `InboundRateTracker` class provides rolling time-window visibility into traffic patterns that cumulative counters cannot reveal, while new logging categories (`LIFECYCLE` and `CONNECTIVITY`) capture app state changes, surface attach/detach events, and network capability fluctuations in the same log file as network traffic for easier correlation analysis.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/InboundRateTracker.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/network/core/ConnectionQualityManager.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/util/LifecycleAwareScopeManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced inbound traffic rate tracking with per-second breakdown in diagnostic reports, enabling improved visibility into network performance and data patterns.

* **Chores**
  * Enhanced diagnostic logging to capture network quality changes, connectivity transitions, application lifecycle events, and render metrics for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->