### PR TITLE
Harden LLUDP decode path for extra-header packets and ACK parsing

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -666,8 +666,15 @@ class UDPConnectionFixed {
      */
     private fun handlePacketAck(data: ByteArray): Boolean {
         try {
+            val messageStartOffset = getMessageStartOffset(data)
+            if (messageStartOffset == null) {
+                NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
+                    "PacketAck: Invalid packet header (size=${data.size})")
+                return false
+            }
+
             // Use the same message ID decoder to find where the payload starts
-            val decodeResult = decodeMessageIdSLProtocol(data, PACKET_HEADER_SIZE)
+            val decodeResult = decodeMessageIdSLProtocol(data, messageStartOffset)
             if (decodeResult == null) {
                 NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
                     "PacketAck: Failed to decode message ID")
@@ -1792,10 +1799,26 @@ class UDPConnectionFixed {
      * - Low frequency: 4 bytes (0xFF, 0xFF, then 2-byte big-endian short) - short | -65536
      */
     private fun extractMessageId(data: ByteArray): Int {
-        if (data.size < PACKET_HEADER_SIZE + 1) return INVALID_MESSAGE_ID
-        
-        val result = decodeMessageIdSLProtocol(data, PACKET_HEADER_SIZE)
+        val messageStartOffset = getMessageStartOffset(data) ?: return INVALID_MESSAGE_ID
+        val result = decodeMessageIdSLProtocol(data, messageStartOffset)
         return result?.first ?: INVALID_MESSAGE_ID
+    }
+
+    /**
+     * Resolve start offset of message ID by honoring LLUDP extra header length.
+     *
+     * Header layout:
+     * - byte 0   flags
+     * - bytes 1-4 sequence
+     * - byte 5   extra header length (N)
+     * - bytes 6..(6+N-1) extra header bytes
+     * - byte 6+N first message ID byte
+     */
+    private fun getMessageStartOffset(data: ByteArray): Int? {
+        if (data.size < PACKET_HEADER_SIZE) return null
+        val extraHeaderLength = data[5].toInt() and 0xFF
+        val messageStart = PACKET_HEADER_SIZE + extraHeaderLength
+        return if (messageStart < data.size) messageStart else null
     }
     
     /**
@@ -2915,9 +2938,15 @@ class UDPConnectionFixed {
     private fun zeroDecode(data: ByteArray): ByteArray {
         val result = mutableListOf<Byte>()
         var i = 0
-        
-        // Copy header unchanged (first PACKET_HEADER_SIZE bytes are not zero-coded)
-        while (i < PACKET_HEADER_SIZE && i < data.size) {
+
+        // Copy fixed header plus any "extra header" bytes unchanged.
+        val headerBytes = if (data.size >= PACKET_HEADER_SIZE) {
+            PACKET_HEADER_SIZE + (data[5].toInt() and 0xFF)
+        } else {
+            PACKET_HEADER_SIZE
+        }
+
+        while (i < headerBytes && i < data.size) {
             result.add(data[i])
             i++
         }
@@ -3319,7 +3348,8 @@ class UDPConnectionFixed {
      * - These are piggybacked on the server's outgoing packets as an optimization
      */
     private fun processAppendedAcks(data: ByteArray) {
-        if (data.size < PACKET_HEADER_SIZE + 2) return
+        val messageStartOffset = getMessageStartOffset(data) ?: return
+        if (data.size < messageStartOffset + 2) return
 
         // Verify the appended ACK flag is set (0x10) before processing
         val flags = data[0].toInt() and 0xFF
@@ -3329,7 +3359,7 @@ class UDPConnectionFixed {
         if (count == 0) return
 
         val acksStart = data.size - 1 - (count * 4)
-        if (acksStart < PACKET_HEADER_SIZE) return
+        if (acksStart < messageStartOffset) return
 
         var pos = acksStart
         for (i in 0 until count) {


### PR DESCRIPTION
### Motivation
- Some valid LLUDP packets include a non-zero extra-header length byte which means the message ID and payload do not always start at the fixed offset 6, causing misaligned decoding and malformed packet interpretation. 
- Mis-parsing ACKs or zerocoded bodies from that misalignment can corrupt ACK state and lead to downstream parser errors or crashes. 
- The change ensures packet decoding honors the LLUDP header layout so Linkpoint matches the Second Life reference behavior for extra-header packets.

### Description
- Added `getMessageStartOffset(data: ByteArray)` to compute the true message start by reading the LLUDP extra-header-length byte and validating bounds. 
- Switched `handlePacketAck(...)` and `extractMessageId(...)` to decode message IDs from the computed message-start offset instead of assuming a fixed header length. 
- Updated `zeroDecode(...)` to preserve both the fixed header and any extra-header bytes before decoding the body so header bytes are not corrupted by zero-decoding. 
- Tightened appended-ACK parsing in `processAppendedAcks(...)` to validate ACK block boundaries against the computed message-start offset to avoid reading garbage from truncated or extra-header packets. 
- Changes applied in `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` and integrated with existing logging/diagnostics paths.

### Testing
- Attempted `./gradlew :Linkpoint:compileDebugKotlin` (without SDK configured) which failed due to missing `ANDROID_HOME`/SDK path in the environment. 
- Attempted `ANDROID_HOME=/workspace/Linkpoint/android-sdk ./gradlew :Linkpoint:compileDebugKotlin` which failed due to ambiguous task names for variant-specific Kotlin tasks. 
- Successfully compiled the module with `ANDROID_HOME=/workspace/Linkpoint/android-sdk ./gradlew :Linkpoint:compileStableDebugKotlin`, and the Kotlin compile completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4d981a74832398145c7c5810eff4)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the LLUDP (Linden Lab UDP) packet decoding path to correctly handle packets with non-zero extra-header lengths. The changes introduce a new `getMessageStartOffset` function that computes the true message start by reading the extra-header-length byte from the LLUDP header (byte 5), then updates packet ACK handling, message ID extraction, zero-decoding, and appended ACK parsing to use this computed offset instead of assuming a fixed header size. This prevents misaligned decoding that could corrupt ACK state or cause parser errors when processing valid LLUDP packets with extra headers, bringing the implementation in line with Second Life reference behavior.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->