### PR TITLE
Fix auto-reconnect coalescing with CAS gate instead of mutex

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -331,16 +331,36 @@ class LinkpointApp : Application() {
 
     /**
      * Drive the auto-reconnect loop. Safe to call from anywhere; a single
-     * coordinator runs at a time (gated by [reloginMutex]). Bails when:
+     * coordinator runs at a time (gated by [isReconnecting] CAS, which
+     * also coalesces duplicate triggers). Bails when:
      *   - the user explicitly logged out (`userWantsConnected == false`),
      *   - we have no cached credentials (no login yet, or already cleared),
      *   - we've exhausted [reloginMaxAttempts], OR
      *   - cumulative recovery time exceeds [reloginMaxWindowMs].
+     *
+     * Coalescing is load-bearing: every watchdog in [UDPConnectionFixed]
+     * (unanswered-pings, post-reconnect-silence, inbound-stall, send-error,
+     * receive-loop-exit) fires `reconnectionCallback` independently. Without
+     * this gate, a single dead-circuit event triggers all five callbacks,
+     * each launching a coroutine that queues on [reloginMutex]. The mutex
+     * serialises them but does not dedupe — so each one runs its own
+     * `disconnect()` + `login()` cycle, tearing down whatever the previous
+     * iteration just established (visible in the 2026-04-26 Athanasia
+     * capture as UseCircuitCode resends every ~5-6s = 3s backoff + 2s HTTP
+     * login + connect).
      */
     internal fun attemptAutoRelogin() {
+        if (!isReconnecting.compareAndSet(false, true)) {
+            Log.d(TAG, "Auto re-login already in progress — ignoring duplicate trigger")
+            return
+        }
         applicationScope.launch {
-            reloginMutex.withLock {
-                runReloginLoop()
+            try {
+                reloginMutex.withLock {
+                    runReloginLoop()
+                }
+            } finally {
+                isReconnecting.set(false)
             }
         }
     }
@@ -356,86 +376,85 @@ class LinkpointApp : Application() {
         }
 
         if (firstReconnectAttemptAt == 0L) firstReconnectAttemptAt = System.currentTimeMillis()
-        isReconnecting.set(true)
+        // [isReconnecting] is owned by [attemptAutoRelogin], which performs
+        // the CAS that gates entry to this loop and clears the flag in its
+        // own finally block. Setting it again here would mask a future bug
+        // where someone calls runReloginLoop directly without the gate.
 
-        try {
-            while (userWantsConnected.get()) {
-                val attempt = reconnectAttempts.incrementAndGet()
-                val elapsed = System.currentTimeMillis() - firstReconnectAttemptAt
+        while (userWantsConnected.get()) {
+            val attempt = reconnectAttempts.incrementAndGet()
+            val elapsed = System.currentTimeMillis() - firstReconnectAttemptAt
 
-                if (attempt > reloginMaxAttempts) {
-                    Log.e(TAG, "Auto re-login: exceeded $reloginMaxAttempts attempts — giving up")
-                    sessionManager.setConnectionState(
-                        com.linkpoint.network.events.ConnectionState.DISCONNECTED
-                    )
-                    return
-                }
-                if (elapsed >= reloginMaxWindowMs) {
-                    Log.e(TAG, "Auto re-login: ${elapsed}ms exceeds ${reloginMaxWindowMs}ms window — giving up")
-                    sessionManager.setConnectionState(
-                        com.linkpoint.network.events.ConnectionState.DISCONNECTED
-                    )
-                    return
-                }
-
-                Log.i(TAG, "🔄 Auto re-login attempt $attempt/$reloginMaxAttempts (elapsed=${elapsed}ms)")
-                protocol.stateManager.setStatus(
-                    com.linkpoint.network.core.NetworkStateManager.ConnectionStatus.RECONNECTING
+            if (attempt > reloginMaxAttempts) {
+                Log.e(TAG, "Auto re-login: exceeded $reloginMaxAttempts attempts — giving up")
+                sessionManager.setConnectionState(
+                    com.linkpoint.network.events.ConnectionState.DISCONNECTED
                 )
+                return
+            }
+            if (elapsed >= reloginMaxWindowMs) {
+                Log.e(TAG, "Auto re-login: ${elapsed}ms exceeds ${reloginMaxWindowMs}ms window — giving up")
+                sessionManager.setConnectionState(
+                    com.linkpoint.network.events.ConnectionState.DISCONNECTED
+                )
+                return
+            }
 
-                // Tear down the dead UDP socket cleanly so the new login
-                // doesn't fight with stale I/O thread state.
-                try { udpConnection.disconnect() } catch (e: Exception) {
-                    Log.w(TAG, "udpConnection.disconnect() during re-login: ${e.message}")
+            Log.i(TAG, "🔄 Auto re-login attempt $attempt/$reloginMaxAttempts (elapsed=${elapsed}ms)")
+            protocol.stateManager.setStatus(
+                com.linkpoint.network.core.NetworkStateManager.ConnectionStatus.RECONNECTING
+            )
+
+            // Tear down the dead UDP socket cleanly so the new login
+            // doesn't fight with stale I/O thread state.
+            try { udpConnection.disconnect() } catch (e: Exception) {
+                Log.w(TAG, "udpConnection.disconnect() during re-login: ${e.message}")
+            }
+
+            delay(reloginBackoffMs)
+
+            val result = try {
+                protocol.login(
+                    firstName = creds.firstName,
+                    lastName = creds.lastName,
+                    password = creds.password,
+                    loginUri = creds.loginUri,
+                    startLocation = creds.startLocation,
+                    mfaToken = "",
+                    mfaHash = creds.mfaHash
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Auto re-login attempt $attempt threw: ${e.message}")
+                null
+            }
+
+            when (result) {
+                is com.linkpoint.network.LoginResult.Success -> {
+                    Log.i(TAG, "✓ Auto re-login succeeded on attempt $attempt")
+                    // Refresh cached MFA hash — Linden rotates these.
+                    cachedLoginCredentials = creds.copy(mfaHash = result.mfaHash ?: creds.mfaHash)
+                    reconnectAttempts.set(0)
+                    firstReconnectAttemptAt = 0L
+                    return
                 }
-
-                delay(reloginBackoffMs)
-
-                val result = try {
-                    protocol.login(
-                        firstName = creds.firstName,
-                        lastName = creds.lastName,
-                        password = creds.password,
-                        loginUri = creds.loginUri,
-                        startLocation = creds.startLocation,
-                        mfaToken = "",
-                        mfaHash = creds.mfaHash
+                is com.linkpoint.network.LoginResult.MFARequired -> {
+                    Log.w(TAG, "Auto re-login: server now requires MFA — cannot proceed automatically")
+                    userWantsConnected.set(false)
+                    sessionManager.setConnectionState(
+                        com.linkpoint.network.events.ConnectionState.DISCONNECTED
                     )
-                } catch (e: Exception) {
-                    Log.w(TAG, "Auto re-login attempt $attempt threw: ${e.message}")
-                    null
+                    return
                 }
-
-                when (result) {
-                    is com.linkpoint.network.LoginResult.Success -> {
-                        Log.i(TAG, "✓ Auto re-login succeeded on attempt $attempt")
-                        // Refresh cached MFA hash — Linden rotates these.
-                        cachedLoginCredentials = creds.copy(mfaHash = result.mfaHash ?: creds.mfaHash)
-                        reconnectAttempts.set(0)
-                        firstReconnectAttemptAt = 0L
-                        return
-                    }
-                    is com.linkpoint.network.LoginResult.MFARequired -> {
-                        Log.w(TAG, "Auto re-login: server now requires MFA — cannot proceed automatically")
-                        userWantsConnected.set(false)
-                        sessionManager.setConnectionState(
-                            com.linkpoint.network.events.ConnectionState.DISCONNECTED
-                        )
-                        return
-                    }
-                    is com.linkpoint.network.LoginResult.Failure -> {
-                        Log.w(TAG, "Auto re-login attempt $attempt failed: ${result.message} [${result.errorCode}]")
-                        // Loop continues; next iteration applies backoff.
-                    }
-                    null -> {
-                        // Exception path — treat like failure, retry.
-                    }
+                is com.linkpoint.network.LoginResult.Failure -> {
+                    Log.w(TAG, "Auto re-login attempt $attempt failed: ${result.message} [${result.errorCode}]")
+                    // Loop continues; next iteration applies backoff.
+                }
+                null -> {
+                    // Exception path — treat like failure, retry.
                 }
             }
-            Log.i(TAG, "Auto re-login loop exited: user no longer wants connected")
-        } finally {
-            isReconnecting.set(false)
         }
+        Log.i(TAG, "Auto re-login loop exited: user no longer wants connected")
     }
 
     /**


### PR DESCRIPTION
## Summary
Refactored the auto-reconnect mechanism to use a compare-and-set (CAS) gate (`isReconnecting`) to prevent duplicate reconnection attempts, rather than relying solely on a mutex. This addresses a critical issue where multiple watchdog callbacks firing simultaneously would each launch independent reconnection cycles, causing rapid disconnect/reconnect loops.

## Key Changes
- **Added CAS gate in `attemptAutoRelogin()`**: Uses `isReconnecting.compareAndSet(false, true)` to prevent duplicate triggers from entering the reconnection loop. Early returns if a reconnection is already in progress.
- **Moved flag management**: The `isReconnecting` flag is now owned by `attemptAutoRelogin()`, which sets it via CAS and clears it in a finally block after the mutex-protected `runReloginLoop()` completes.
- **Removed redundant flag setting**: Eliminated the `isReconnecting.set(true)` call from `runReloginLoop()` and its corresponding finally block, since the flag is now managed at the entry point.
- **Simplified `runReloginLoop()` structure**: Removed the outer try-finally block and unindented the while loop, making the code cleaner and preventing accidental direct calls to this method from bypassing the CAS gate.
- **Enhanced documentation**: Added detailed comments explaining the coalescing mechanism and why it's necessary, referencing the specific watchdog callbacks in `UDPConnectionFixed` that can trigger simultaneous reconnection attempts.

## Implementation Details
The coalescing is critical because every watchdog in the UDP connection layer (unanswered-pings, post-reconnect-silence, inbound-stall, send-error, receive-loop-exit) independently fires `reconnectionCallback`. Without the CAS gate, a single dead-circuit event would trigger all five callbacks, each launching a coroutine that queues on the mutex. While the mutex serializes execution, it doesn't deduplicate—so each callback runs its own disconnect/login cycle, tearing down whatever the previous iteration just established. The CAS gate ensures only one reconnection attempt proceeds at a time, with subsequent triggers coalesced into a no-op.

https://claude.ai/code/session_01BPBHmucP4LhiHgwZ5WaVAq

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the auto-reconnect mechanism to use a **compare-and-set (CAS) gate** instead of relying solely on a mutex to prevent duplicate reconnection attempts. The issue was that multiple watchdog callbacks in the UDP connection layer could fire simultaneously when a connection died, each launching their own reconnection coroutine. While the mutex serialized execution, it didn't deduplicate, causing each callback to run a full `disconnect()` and `login()` cycle that tore down what the previous iteration established. The fix adds `isReconnecting.compareAndSet(false, true)` at the entry point of `attemptAutoRelogin()` to coalesce duplicate triggers, with the flag cleared in a finally block after the mutex-protected reconnection loop completes. The code structure is also simplified by moving flag ownership to the entry point and removing redundant flag management from the inner loop.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->