### PR TITLE
Honor LLUDP extra-header in MessageParser.extractMessageId

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt
@@ -116,36 +116,38 @@ object MessageParser {
      * @return The message ID (may be negative), or Int.MIN_VALUE if packet is malformed
      */
     fun extractMessageId(rawPacket: ByteArray): Int {
-        if (rawPacket.size < PACKET_HEADER_SIZE + 1) return Int.MIN_VALUE
-        
-        var offset = PACKET_HEADER_SIZE
-        
+        if (rawPacket.size < PACKET_HEADER_SIZE) return Int.MIN_VALUE
+
+        val extraHeaderLen = rawPacket[5].toInt() and 0xFF
+        var offset = PACKET_HEADER_SIZE + extraHeaderLen
+        if (offset >= rawPacket.size) return Int.MIN_VALUE
+
         // Signed byte interpretation - intentional for SL protocol compatibility
         val b1 = rawPacket[offset].toInt()
         offset++
-        
+
         if (b1 != -1) {
             // High frequency message - return signed byte value directly
             // Examples: 4 = AgentUpdate, 12 = ObjectUpdate, -5 (0xFB) = PacketAck
             return b1
         }
-        
-        if (rawPacket.size < offset + 1) return Int.MIN_VALUE
+
+        if (offset >= rawPacket.size) return Int.MIN_VALUE
         val b2 = rawPacket[offset].toInt()
         offset++
-        
+
         if (b2 != -1) {
             // Medium frequency: byte | 65280
             return b2 or 65280
         }
-        
+
         // Low frequency: next two bytes as short | -65536
-        if (rawPacket.size < offset + 2) return Int.MIN_VALUE
-        
+        if (offset + 1 >= rawPacket.size) return Int.MIN_VALUE
+
         val byte3 = rawPacket[offset].toInt() and 0xFF
         val byte4 = rawPacket[offset + 1].toInt() and 0xFF
         val shortValue = ((byte3 shl 8) or byte4).toShort().toInt()
-        
+
         return shortValue or -65536
     }
     

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageParserConformanceFixtureTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageParserConformanceFixtureTest.kt
@@ -31,6 +31,39 @@ class MessageParserConformanceFixtureTest {
         }
     }
 
+
+    @Test
+    fun `message id extraction matches UDPConnectionFixed decoder`() {
+        val text = javaClass.classLoader!!.getResource("fixtures/messages/parser_conformance_fixtures.json")!!.readText()
+        val fixtures = JSONArray(text)
+        val udpConnection = UDPConnectionFixed()
+
+        val getMessageStartOffset = UDPConnectionFixed::class.java.getDeclaredMethod("getMessageStartOffset", ByteArray::class.java)
+            .apply { isAccessible = true }
+        val decodeMessageIdSLProtocol = UDPConnectionFixed::class.java
+            .getDeclaredMethod("decodeMessageIdSLProtocol", ByteArray::class.java, Int::class.javaPrimitiveType)
+            .apply { isAccessible = true }
+
+        for (i in 0 until fixtures.length()) {
+            val fixture = fixtures.getJSONObject(i)
+            val packet = fixture.getString("rawPacketHex").hexToBytes()
+
+            val startOffset = getMessageStartOffset.invoke(udpConnection, packet) as Int?
+            val decodedId = if (startOffset == null) {
+                Int.MIN_VALUE
+            } else {
+                val result = decodeMessageIdSLProtocol.invoke(udpConnection, packet, startOffset) as Pair<*, *>?
+                (result?.first as Int?) ?: Int.MIN_VALUE
+            }
+
+            assertEquals(
+                fixture.getString("name"),
+                decodedId,
+                MessageParser.extractMessageId(packet)
+            )
+        }
+    }
+
     @Test
     fun `registry parses chat payload`() {
         val payload = buildList<Byte> {

--- a/Linkpoint/src/test/resources/fixtures/messages/parser_conformance_fixtures.json
+++ b/Linkpoint/src/test/resources/fixtures/messages/parser_conformance_fixtures.json
@@ -22,5 +22,29 @@
     "rawPacketHex": "000000000000FFFF01",
     "expectedMessageId": -2147483648,
     "expectedPayloadHex": null
+  },
+  {
+    "name": "high-frequency-with-extra-header",
+    "rawPacketHex": "000000000003AABBCC0C1122",
+    "expectedMessageId": 12,
+    "expectedPayloadHex": "1122"
+  },
+  {
+    "name": "medium-frequency-with-extra-header",
+    "rawPacketHex": "0000000000020102FF063344",
+    "expectedMessageId": 65286,
+    "expectedPayloadHex": "3344"
+  },
+  {
+    "name": "low-frequency-with-extra-header",
+    "rawPacketHex": "0000000000017FFFFFFF0094A1",
+    "expectedMessageId": -65388,
+    "expectedPayloadHex": "A1"
+  },
+  {
+    "name": "malformed-truncated-after-extra-header",
+    "rawPacketHex": "000000000002AABB",
+    "expectedMessageId": -2147483648,
+    "expectedPayloadHex": null
   }
 ]


### PR DESCRIPTION
### Motivation
- Ensure `MessageParser.extractMessageId` skips the LLUDP extra-header bytes like `extractPayload` does so message-id decoding aligns with other code paths.
- Prevent incorrect truncation and mis-decoding for packets where the simulator includes a non-zero extra-header length.

### Description
- Refactored `MessageParser.extractMessageId` to read `extraHeaderLen = rawPacket[5] & 0xFF` and start decoding at `PACKET_HEADER_SIZE + extraHeaderLen`, with truncation checks validated against that offset. (modified `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt`).
- Updated boundary checks for high/medium/low frequency decoding to use the computed post-extra-header offset. (same file).
- Added fixtures containing non-zero extra-header cases for high, medium, and low frequency message IDs and a malformed/truncated-after-extra-header case. (modified `Linkpoint/src/test/resources/fixtures/messages/parser_conformance_fixtures.json`).
- Added a conformance test that reflects into `UDPConnectionFixed` and asserts `MessageParser.extractMessageId` matches `UDPConnectionFixed`'s `getMessageStartOffset` + `decodeMessageIdSLProtocol` decoding for the same raw packets. (modified `Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageParserConformanceFixtureTest.kt`).

### Testing
- Added unit test `message id extraction matches UDPConnectionFixed decoder` in `MessageParserConformanceFixtureTest` which verifies parity with `UDPConnectionFixed` for the fixture packets (new extra-header cases).
- Attempted to run `./gradlew :Linkpoint:test --tests com.linkpoint.protocol.messages.MessageParserConformanceFixtureTest` but the run failed in this environment due to missing Android SDK configuration (`SDK location not found` / `ANDROID_HOME` or `local.properties`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee72aa58288323a141c24d9d41ed2a)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the `MessageParser.extractMessageId` method to correctly handle LLUDP packets with non-zero extra-header lengths. The method now reads the extra-header byte count from the packet and adjusts its offset accordingly before decoding message IDs, ensuring consistency with other parsing code paths like `extractPayload`. The change updates boundary validation logic for high, medium, and low frequency message ID decoding, and adds comprehensive test fixtures and a conformance test that verifies parity with the `UDPConnectionFixed` decoder using reflection.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt` |
| 2 | `Linkpoint/src/test/resources/fixtures/messages/parser_conformance_fixtures.json` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/MessageParserConformanceFixtureTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->