### PR TITLE
Implement full RenderEngineSwitcher lifecycle and add switch test

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineSwitcher.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineSwitcher.kt
@@ -35,6 +35,9 @@ class RenderEngineSwitcher(private val context: Context) {
     private var activeType: EngineType = EngineType.FILAMENT
     private var active: RenderEngineProvider? = null
     private var pendingSwitch: EngineType? = null
+    private var lastSurface: Surface? = null
+    private var lastWidth: Int = 0
+    private var lastHeight: Int = 0
 
     // ── Registration ─────────────────────────────────────────────────────
 
@@ -62,6 +65,10 @@ class RenderEngineSwitcher(private val context: Context) {
     // ── Lifecycle ────────────────────────────────────────────────────────
 
     fun initialize(surface: Surface, width: Int, height: Int): Boolean {
+        lastSurface = surface
+        lastWidth = width
+        lastHeight = height
+
         val engine = engines[activeType]
         if (engine == null) {
             Log.e(TAG, "No engine registered for ${activeType.name}")
@@ -85,11 +92,14 @@ class RenderEngineSwitcher(private val context: Context) {
     }
 
     fun onSurfaceChanged(width: Int, height: Int) {
+        lastWidth = width
+        lastHeight = height
         active?.onSurfaceChanged(width, height)
     }
 
     fun onSurfaceDestroyed() {
         active?.onSurfaceDestroyed()
+        lastSurface = null
     }
 
     fun shutdown() {
@@ -123,20 +133,34 @@ class RenderEngineSwitcher(private val context: Context) {
             return
         }
 
+        val previousType = activeType
         Log.i(TAG, "Performing engine switch: ${activeType.name} → ${newType.name}")
 
         // Shutdown old engine
         active?.shutdown()
-
-        // Initialise new engine with current surface dimensions
-        val width = active?.viewportWidth ?: 0
-        val height = active?.viewportHeight ?: 0
         active = null
         activeType = newType
 
-        if (width > 0 && height > 0) {
-            // Re-initialisation will happen on next surface callback
-            Log.i(TAG, "Engine switch complete; new engine needs surface re-init")
+        val surface = lastSurface
+        val canInitialize = surface != null && lastWidth > 0 && lastHeight > 0
+        if (!canInitialize) {
+            Log.i(TAG, "Engine switch complete; awaiting valid surface lifecycle callbacks")
+            return
+        }
+
+        val initialized = try {
+            newEngine.initialize(context, surface, lastWidth, lastHeight)
+        } catch (t: Throwable) {
+            Log.e(TAG, "Failed to initialize ${newType.name} after switch", t)
+            false
+        }
+
+        if (initialized) {
+            active = newEngine
+            Log.i(TAG, "Engine switch complete; active=${newEngine.engineName}")
+        } else {
+            activeType = previousType
+            Log.e(TAG, "Engine switch failed; reverted active type to ${previousType.name}")
         }
     }
 }

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/RenderEngineSwitcherTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/RenderEngineSwitcherTest.kt
@@ -1,0 +1,108 @@
+package com.linkpoint.render.lumiya.core
+
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.test.mock.MockContext
+import android.view.Surface
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RenderEngineSwitcherTest {
+
+    @Test
+    fun `switch from filament to lumiya initializes new engine and renders frames`() {
+        val context: Context = MockContext()
+        val switcher = RenderEngineSwitcher(context)
+        val filamentEngine = FakeRenderEngine("Filament")
+        val lumiyaEngine = FakeRenderEngine("Lumiya")
+
+        switcher.registerEngine(RenderEngineSwitcher.EngineType.FILAMENT, filamentEngine)
+        switcher.registerEngine(RenderEngineSwitcher.EngineType.LUMIYA, lumiyaEngine)
+
+        val surfaceTexture = SurfaceTexture(0)
+        val surface = Surface(surfaceTexture)
+        try {
+            assertTrue(switcher.initialize(surface, 640, 480))
+            assertEquals(1, filamentEngine.initializeCalls)
+
+            switcher.setActiveEngine(RenderEngineSwitcher.EngineType.LUMIYA)
+            switcher.renderFrame()
+
+            val activeEngine = switcher.getActiveEngine()
+            assertNotNull(activeEngine)
+            assertEquals(RenderEngineSwitcher.EngineType.LUMIYA, switcher.getActiveType())
+            assertEquals(1, lumiyaEngine.initializeCalls)
+            assertEquals(1L, lumiyaEngine.frameCount)
+        } finally {
+            surface.release()
+            surfaceTexture.release()
+        }
+    }
+
+    private class FakeRenderEngine(
+        override val engineName: String,
+        private val shouldInitialize: Boolean = true
+    ) : RenderEngineProvider {
+
+        override var isInitialized: Boolean = false
+            private set
+        override var viewportWidth: Int = 0
+            private set
+        override var viewportHeight: Int = 0
+            private set
+        override var frameCount: Long = 0L
+            private set
+
+        var initializeCalls: Int = 0
+            private set
+
+        override fun initialize(context: Context, surface: Surface, width: Int, height: Int): Boolean {
+            initializeCalls += 1
+            if (!shouldInitialize) {
+                isInitialized = false
+                return false
+            }
+            viewportWidth = width
+            viewportHeight = height
+            isInitialized = true
+            return true
+        }
+
+        override fun onSurfaceChanged(width: Int, height: Int) {
+            viewportWidth = width
+            viewportHeight = height
+        }
+
+        override fun onSurfaceDestroyed() {
+            isInitialized = false
+        }
+
+        override fun renderFrame() {
+            if (isInitialized) {
+                frameCount += 1
+            }
+        }
+
+        override fun shutdown() {
+            isInitialized = false
+        }
+
+        override fun setCameraPosition(x: Float, y: Float, z: Float) = Unit
+
+        override fun setCameraTarget(x: Float, y: Float, z: Float) = Unit
+
+        override fun setFieldOfView(fovDegrees: Float) = Unit
+
+        override fun setDrawDistance(distance: Float) = Unit
+
+        override fun addObject(id: Long, posX: Float, posY: Float, posZ: Float) = Unit
+
+        override fun removeObject(id: Long) = Unit
+
+        override fun updateTerrain(heightmap: FloatArray, width: Int, depth: Int) = Unit
+
+        override fun clearScene() = Unit
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure engine switches are robust by preserving surface and viewport state across lifecycle calls so a new backend can be initialized immediately after a switch when possible.  

### Description

- Persist `lastSurface`, `lastWidth`, and `lastHeight` in `RenderEngineSwitcher.initialize(...)` and update/clear them in `onSurfaceChanged(...)` and `onSurfaceDestroyed()` respectively.  
- Enhance `performSwitch(newType)` to shut down the old engine, attempt to initialize the new engine immediately using cached `lastSurface`/dimensions when available, set `active` only when initialization succeeds, and revert `activeType` with error logging on failure (including exception handling).  
- Keep previous fallback behavior when no valid cached surface exists by deferring full initialization until lifecycle callbacks provide a surface/dimensions.  
- Add `RenderEngineSwitcherTest.kt` under `src/test/kotlin/com/linkpoint/render/lumiya/core/` implementing a `FakeRenderEngine` and a unit that validates a FILAMENT→LUMIYA switch results in a non-null active engine and an incremented `frameCount` after calling `renderFrame()`.

### Testing

- Added unit test file `src/test/kotlin/com/linkpoint/render/lumiya/core/RenderEngineSwitcherTest.kt` that covers the FILAMENT→LUMIYA switch and frame progression assertion.  
- Attempted to run the test via `./gradlew :Linkpoint:testDebugUnitTest --tests com.linkpoint.render.lumiya.core.RenderEngineSwitcherTest`, but the run failed in this environment due to a missing Android SDK location (`ANDROID_HOME`/`local.properties`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee72b179408323b7446f4b847773f4)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the `RenderEngineSwitcher` to preserve surface and viewport state across render engine switches, enabling immediate initialization of a new backend when switching. The implementation caches surface references and dimensions across lifecycle callbacks, improves the `performSwitch` method with proper error handling and state rollback on failure, and adds a comprehensive unit test with a `FakeRenderEngine` to validate the FILAMENT→LUMIYA switch scenario.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/RenderEngineSwitcherTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineSwitcher.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->