### PR TITLE
Mark early UDP warnings provisional and include UDP_CONNECTED elapsed time

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/EnhancedPacketLogger.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/EnhancedPacketLogger.kt
@@ -1,6 +1,7 @@
 package com.linkpoint.protocol.messages
 
 import android.util.Log
+import com.linkpoint.utils.InitializationTracker
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -26,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong
 object EnhancedPacketLogger {
     
     private const val TAG = "PacketLogger"
+    private const val EARLY_WARNING_GRACE_MS = 15_000L
     
     // Message names that should not count as handler misses
     // These are internal protocol messages or handled specially
@@ -90,6 +92,13 @@ object EnhancedPacketLogger {
     // Session tracking
     @Volatile
     private var sessionStartTime: Long = 0
+
+    private fun formatUdpConnectedWarningContext(): Pair<Boolean, String> {
+        val elapsedMs = InitializationTracker.getElapsedSincePhase(InitializationTracker.Phase.UDP_CONNECTED)
+        val timing = if (elapsedMs != null) "${formatDuration(elapsedMs)} since UDP_CONNECTED" else "UDP_CONNECTED time unavailable"
+        val provisional = elapsedMs != null && elapsedMs < EARLY_WARNING_GRACE_MS
+        return provisional to timing
+    }
     
     @Volatile
     private var lastPacketSentTime: Long = 0
@@ -880,7 +889,12 @@ object EnhancedPacketLogger {
             
             // Warning checks
             if (stats.packetsSent > 0 && stats.packetsReceived == 0L) {
-                appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED!")
+                val (provisional, timing) = formatUdpConnectedWarningContext()
+                if (provisional) {
+                    appendLine("⚠️ PROVISIONAL: PACKETS SENT BUT NONE RECEIVED ($timing)")
+                } else {
+                    appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED ($timing)")
+                }
                 appendLine("   Possible causes:")
                 appendLine("   - Firewall blocking UDP")
                 appendLine("   - NAT traversal issue")

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/translation/ProtocolDiagnostics.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/translation/ProtocolDiagnostics.kt
@@ -1,6 +1,7 @@
 package com.linkpoint.protocol.translation
 
 import android.util.Log
+import com.linkpoint.utils.InitializationTracker
 import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
 import java.util.*
@@ -25,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong
 object ProtocolDiagnostics {
     
     private const val TAG = "ProtocolDiag"
+    private const val EARLY_WARNING_GRACE_MS = 15_000L
     
     // Packet statistics
     private val packetsSent = AtomicLong(0)
@@ -56,6 +58,13 @@ object ProtocolDiagnostics {
     @Volatile
     var connectionPhase: String = "DISCONNECTED"
         private set
+
+    private fun formatUdpConnectedWarningContext(): Pair<Boolean, String> {
+        val elapsedMs = InitializationTracker.getElapsedSincePhase(InitializationTracker.Phase.UDP_CONNECTED)
+        val timing = if (elapsedMs != null) "${formatDuration(elapsedMs)} since UDP_CONNECTED" else "UDP_CONNECTED time unavailable"
+        val provisional = elapsedMs != null && elapsedMs < EARLY_WARNING_GRACE_MS
+        return provisional to timing
+    }
     
     /**
      * Record for a single packet event.
@@ -286,7 +295,12 @@ object ProtocolDiagnostics {
         
         // Check for common issues
         if (packetsSent.get() > 0 && packetsReceived.get() == 0L) {
-            sb.appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED!")
+            val (provisional, timing) = formatUdpConnectedWarningContext()
+            if (provisional) {
+                sb.appendLine("⚠️ PROVISIONAL: PACKETS SENT BUT NONE RECEIVED ($timing)")
+            } else {
+                sb.appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED ($timing)")
+            }
             sb.appendLine("   Possible causes:")
             sb.appendLine("   - Firewall blocking UDP")
             sb.appendLine("   - NAT traversal issue")

--- a/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
@@ -44,6 +44,7 @@ class DebugReportService private constructor(private val context: Context) {
         
         // Number of recent malformed packets to show in debug reports
         private const val MALFORMED_PACKET_HISTORY_COUNT = 5
+        private const val EARLY_WARNING_GRACE_MS = 15_000L
         
         @Volatile
         private var instance: DebugReportService? = null
@@ -83,6 +84,14 @@ class DebugReportService private constructor(private val context: Context) {
     
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var reportDirectory: File? = null
+
+    private fun udpConnectedElapsedMs(): Long? {
+        return InitializationTracker.getElapsedSincePhase(InitializationTracker.Phase.UDP_CONNECTED)
+    }
+
+    private fun formatUdpConnectedElapsed(elapsedMs: Long?): String {
+        return if (elapsedMs != null) "${formatDuration(elapsedMs)} since UDP_CONNECTED" else "UDP_CONNECTED time unavailable"
+    }
     
     init {
         initializeStorage()
@@ -553,8 +562,15 @@ class DebugReportService private constructor(private val context: Context) {
                             sendSuccessCount
                         }
                         if (totalReceivedEver == 0 && totalSentEver > 0) {
+                            val udpElapsedMs = udpConnectedElapsedMs()
+                            val isProvisional = udpElapsedMs != null && udpElapsedMs < EARLY_WARNING_GRACE_MS
+                            val timing = formatUdpConnectedElapsed(udpElapsedMs)
                             appendLine()
-                            appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED!")
+                            if (isProvisional) {
+                                appendLine("⚠️ PROVISIONAL: PACKETS SENT BUT NONE RECEIVED ($timing)")
+                            } else {
+                                appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED ($timing)")
+                            }
                             appendLine("   Possible causes:")
                             appendLine("   - Firewall blocking UDP")
                             appendLine("   - NAT traversal issue")
@@ -1289,7 +1305,14 @@ class DebugReportService private constructor(private val context: Context) {
                     val agentMovementTime = msgStats.lastMessageTimes["AgentMovementComplete"]
                     
                     if (regionHandshakeTime == null || regionHandshakeTime == 0L) {
-                        appendLine("⚠️ RegionHandshake never received - world data won't load!")
+                        val udpElapsedMs = udpConnectedElapsedMs()
+                        val isProvisional = udpElapsedMs != null && udpElapsedMs < EARLY_WARNING_GRACE_MS
+                        val timing = formatUdpConnectedElapsed(udpElapsedMs)
+                        if (isProvisional) {
+                            appendLine("⚠️ PROVISIONAL: RegionHandshake never received ($timing) - world data may not load yet.")
+                        } else {
+                            appendLine("⚠️ RegionHandshake never received ($timing) - world data won't load!")
+                        }
                     }
                     if (agentMovementTime == null || agentMovementTime == 0L) {
                         appendLine("⚠️ AgentMovementComplete never received - agent not in world!")
@@ -1453,8 +1476,15 @@ class DebugReportService private constructor(private val context: Context) {
                 }
                 
                 if (packetStats.packetsSent > 0 && packetStats.packetsReceived == 0L) {
+                    val udpElapsedMs = udpConnectedElapsedMs()
+                    val isProvisional = udpElapsedMs != null && udpElapsedMs < EARLY_WARNING_GRACE_MS
+                    val timing = formatUdpConnectedElapsed(udpElapsedMs)
                     appendLine()
-                    appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED!")
+                    if (isProvisional) {
+                        appendLine("⚠️ PROVISIONAL: PACKETS SENT BUT NONE RECEIVED ($timing)")
+                    } else {
+                        appendLine("⚠️ PACKETS SENT BUT NONE RECEIVED ($timing)")
+                    }
                     appendLine("   Possible causes:")
                     appendLine("   - Firewall blocking UDP")
                     appendLine("   - NAT traversal issue")

--- a/Linkpoint/src/main/java/com/linkpoint/utils/InitializationTracker.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/InitializationTracker.kt
@@ -278,6 +278,15 @@ object InitializationTracker {
             }
         }
     }
+
+    /**
+     * Returns elapsed milliseconds since the given phase was first recorded
+     * for the current session, or null if the phase has not started/reached.
+     */
+    fun getElapsedSincePhase(phase: Phase, nowMs: Long = System.currentTimeMillis()): Long? {
+        val phaseStart = phaseTimings[phase] ?: return null
+        return (nowMs - phaseStart).coerceAtLeast(0L)
+    }
     
     private fun formatTimestamp(timestamp: Long): String {
         if (timestamp == 0L) return "Not started"


### PR DESCRIPTION
### Motivation
- Immediate post-connect UDP diagnostics can produce noisy hard warnings (e.g. “PACKETS SENT BUT NONE RECEIVED”, “RegionHandshake never received”) while normal initialization completes, so they should be demoted or labeled provisional during the early connect window.
- Providing elapsed time since the `UDP_CONNECTED` milestone makes the warnings actionable and easier to interpret.

### Description
- Added `InitializationTracker.getElapsedSincePhase(phase)` to expose elapsed milliseconds since a recorded phase for the current session.
- Introduced a 15s early-warning grace window (`EARLY_WARNING_GRACE_MS`) and helper helpers to compute/format `UDP_CONNECTED` elapsed time in diagnostics modules.
- Updated `DebugReportService` so the debug report includes `UDP_CONNECTED` elapsed context and marks the following as provisional during the grace window: `PACKETS SENT BUT NONE RECEIVED` and `RegionHandshake never received` (text includes elapsed timing).
- Applied the same provisional + elapsed-time labeling to packet/protocol diagnostics in `EnhancedPacketLogger` and `ProtocolDiagnostics` so all warning surfaces stay consistent.

### Testing
- Attempted to compile Kotlin with `./gradlew :Linkpoint:compileDebugKotlin -q`; the build could not be executed in this environment because the Android SDK location is not configured (missing `ANDROID_HOME` / `sdk.dir`), so compilation was not run here (failure due to environment, not code).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7464fd008323a23b3f955788ff79)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves UDP connection diagnostics by introducing a 15-second grace period for early connection warnings and enriching warning messages with elapsed time since `UDP_CONNECTED`. The change adds a new `getElapsedSincePhase()` method to `InitializationTracker` that calculates time since a given initialization phase, then uses this across diagnostic surfaces (`DebugReportService`, `EnhancedPacketLogger`, `ProtocolDiagnostics`) to mark warnings as **PROVISIONAL** during the grace window and include timing context. This reduces noisy false-positive warnings during normal UDP initialization while making actual connection issues more actionable.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/utils/InitializationTracker.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/EnhancedPacketLogger.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/protocol/translation/ProtocolDiagnostics.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->