### PR TITLE
Fix UDP ACK handling and NAT keepalive for cellular networks

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -91,6 +91,7 @@ import com.linkpoint.protocol.types.getUUID
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -287,6 +288,16 @@ class LinkpointApp : Application() {
     private val userWantsConnected = AtomicBoolean(false)
     private val isReconnecting = AtomicBoolean(false)
     private val reconnectAttempts = AtomicInteger(0)
+
+    /**
+     * The collector job that mirrors `udpConnection.isConnected` into the
+     * foreground service. Owned by [initializeAgentManagers], which can run
+     * multiple times per process (one per login). Re-running the collector
+     * launch without cancelling the previous one would leak a coroutine
+     * per re-login — one observed Athanasia recovery cycle was 4 re-logins
+     * in 2 minutes, so the leak compounds quickly.
+     */
+    @Volatile private var fgsConnectStateMirrorJob: Job? = null
     @Volatile private var firstReconnectAttemptAt: Long = 0L
     private val reloginMutex = Mutex()
 
@@ -950,7 +961,51 @@ class LinkpointApp : Application() {
             applicationScope.launch { connectionKeepAlive.notifyConnectionIssue() }
             attemptAutoRelogin()
         }
-        
+
+        // Wire the foreground service's keepalive callback to the actual UDP
+        // ping. Without this, LinkpointConnectionService.performKeepAlive()
+        // is a no-op (its internal `connectionCallback` is never set
+        // anywhere — see the 2026-04-26 Athanasia capture, where the
+        // service was running with a wake lock for 2.3 minutes but never
+        // drove a single keepalive packet, letting the cellular NAT mapping
+        // expire). StartPingCheck is the right tool: it's a 12-byte packet,
+        // the simulator auto-replies with CompletePingCheck, and it
+        // refreshes the carrier NAT mapping in both directions.
+        com.linkpoint.service.LinkpointConnectionService.setProcessCallback(
+            object : com.linkpoint.service.ConnectionCallback {
+                override fun onSendPing() {
+                    if (!::udpConnection.isInitialized) return
+                    if (!udpConnection.isConnected.value) return
+                    try {
+                        udpConnection.sendStartPingCheck()
+                    } catch (e: Throwable) {
+                        Log.w(TAG, "FGS keepalive ping failed: ${e.message}")
+                    }
+                }
+                override fun onConnectionStale() {
+                    Log.w(TAG, "FGS reports connection stale (3× keepalive no inbound) — escalating to auto re-login")
+                    attemptAutoRelogin()
+                }
+            }
+        )
+        // Mirror the UDP up/down state into the service so it knows when to
+        // ping (no point pinging a dead socket) and what to put in the
+        // notification text. The networkStateListener above already fires
+        // on reconnect cycles; this catches the initial connect too.
+        // Cancel any prior collector — initializeAgentManagers re-runs on
+        // every re-login (see [attemptAutoRelogin]), and we don't want
+        // every re-login to leak another collector.
+        fgsConnectStateMirrorJob?.cancel()
+        fgsConnectStateMirrorJob = applicationScope.launch {
+            try {
+                udpConnection.isConnected.collect { connected ->
+                    com.linkpoint.service.LinkpointConnectionService.setProcessConnected(connected)
+                }
+            } catch (e: Throwable) {
+                Log.w(TAG, "FGS connect-state mirror collector ended: ${e.message}")
+            }
+        }
+
         // Start background service for connection persistence
         LinkpointConnectionService.start(this)
         

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -521,6 +521,24 @@ class UDPConnectionFixed {
      * ACKs are typically sent every 100ms or piggy-backed on outgoing packets.
      */
     private val ACK_SEND_INTERVAL_MS = 100L
+
+    /**
+     * Pending-ACK queue depth that forces an immediate drain regardless of
+     * [ACK_SEND_INTERVAL_MS]. The 100ms timer is a coalescing optimisation,
+     * but the simulator's reliable-retransmit timer is tighter than ours
+     * (~3-5s on the LL grid, but its first retry can fire as fast as 1s when
+     * it's reading a low-RTT path). On burst packets — region handshake,
+     * landing teleport, parcel-overlay batch — letting acks queue for the
+     * full 100ms window puts us right at the sim's first-retry edge, which
+     * triggers the duplicate-receive cascade visible in the 2026-04-26
+     * Athanasia capture (ParcelOverlay seq 14-17 received twice, full
+     * RegionHandshake/AgentMovementComplete pair retransmitted).
+     *
+     * 8 is conservative: ObjectUpdate batches in a busy region routinely
+     * cross this, while normal idle traffic (1-2 reliable per second)
+     * doesn't trip it and stays on the 100ms coalescing path.
+     */
+    private val ACK_FLUSH_QUEUE_THRESHOLD = 8
     
     /**
      * Last time ACKs were sent (for throttling standalone ACK packets).
@@ -1121,9 +1139,28 @@ class UDPConnectionFixed {
                                 val rawData = ByteArray(bytesRead)
                                 buffer.get(rawData)
 
-                                // Zero-decode if needed
-                                val isZerocoded = (rawData[0].toInt() and 0x80) != 0
-                                val data = if (isZerocoded) zeroDecode(rawData) else rawData
+                                // SL wire format: the trailing ACK appendix is appended
+                                // AFTER zero-coding (see OpenSimulator LLClientView.OutPacket
+                                // and Lumiya `AppendPendingAcks`), so we must strip the
+                                // appendix from the wire bytes BEFORE zeroDecode runs.
+                                // Otherwise the appendix bytes get fed into the zero-decoder
+                                // (where 0x00 means "next byte is run-length") and the
+                                // decoded payload is corrupted, while the ACKs at the end
+                                // are read from garbage bytes — which is the silent
+                                // dropped-ACK pathology that lets the simulator's reliable
+                                // queue retransmit forever.
+                                val (wireBody, trailingAcks) = stripTrailingAcksFromWire(rawData)
+                                val isZerocoded = (wireBody[0].toInt() and 0x80) != 0
+                                val data = if (isZerocoded) zeroDecode(wireBody) else wireBody
+
+                                // Process appendix ACKs immediately (they were extracted
+                                // from the wire, not from the decoded body, so endianness
+                                // and offsets are correct regardless of zero-coding).
+                                if (trailingAcks.isNotEmpty()) {
+                                    trailingAcks.forEach { processReceivedAck(it) }
+                                    NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
+                                        "📎 Processed ${trailingAcks.size} appended ACKs from wire (pre-zerocode)")
+                                }
 
                                 // Extract message info
                                 val messageId = extractMessageId(data)
@@ -1175,12 +1212,11 @@ class UDPConnectionFixed {
                                 // Track message stats
                                 trackMessageReceived(messageName)
 
-                                // Process appended ACKs ONLY when the flag is set (0x10)
-                                // CRITICAL FIX: Previously this was called unconditionally,
-                                // which read garbage from the end of normal packets as ACK data
-                                if (packetFlags.hasAcks) {
-                                    processAppendedAcks(data)
-                                }
+                                // Appendix ACKs are now extracted from the wire bytes
+                                // BEFORE zero-decoding (above). Don't re-process them here
+                                // from `data` — that path read LE bytes (wrong endianness)
+                                // and indexed into the zero-decoded buffer (wrong offset
+                                // for zero-coded packets), silently discarding most ACKs.
 
                                 // SYNCHRONOUS message dispatch from I/O thread.
                                 // This follows Lumiya's pattern where HandleMessage() is called
@@ -1195,10 +1231,13 @@ class UDPConnectionFixed {
                 // select() calls on the same thread that owns the channel, so
                 // there is no contention with the read path.
                 val now = System.currentTimeMillis()
-                if (now - lastAckCheckTime >= ACK_SEND_INTERVAL_MS) {
-                    if (pendingAcksToSend.isNotEmpty()) {
-                        sendPendingAcksFromIOThread()
-                    }
+                val queueDepth = pendingAcksToSend.size
+                val intervalElapsed = now - lastAckCheckTime >= ACK_SEND_INTERVAL_MS
+                val burstThresholdHit = queueDepth >= ACK_FLUSH_QUEUE_THRESHOLD
+                if (queueDepth > 0 && (intervalElapsed || burstThresholdHit)) {
+                    sendPendingAcksFromIOThread()
+                    lastAckCheckTime = now
+                } else if (intervalElapsed) {
                     lastAckCheckTime = now
                 }
                 if (now - lastTimeoutCheckTime >= 1000L) {
@@ -1398,6 +1437,91 @@ class UDPConnectionFixed {
     }
 
     /**
+     * Cap on how many acks we'll piggyback onto a single outgoing packet.
+     * Each ack is 5 bytes on the wire (4-byte seq + amortised 1/N count
+     * byte), so 64 acks = ~320 bytes — well under [PIGGYBACK_AVAILABLE_HEADROOM]
+     * and large enough that we drain the queue in one packet for typical
+     * burst loads (region handshake, parcel overlay batch).
+     */
+    private val MAX_PIGGYBACKED_ACKS = 64
+
+    /**
+     * Bytes we keep in reserve below [LinkpointConstants.MAX_TRANSMIT_SIZE]
+     * before we'll consider piggybacking acks. SL's MTU budget is 1024 and
+     * AgentUpdate is 121 bytes, so this leaves 200+ bytes headroom for the
+     * appendix on small packets and skips piggyback on already-fat packets
+     * (ObjectAdd, AgentSetAppearance) where a separate PacketAck is cheaper
+     * than risking fragmentation.
+     */
+    private val PIGGYBACK_AVAILABLE_HEADROOM = 256
+
+    /** Result of a piggyback attempt — the wire bytes to send and the
+     *  acks popped from [pendingAcksToSend] (so the catch path can requeue
+     *  them if the write fails). */
+    private data class PiggybackResult(val wireBytes: ByteArray, val consumedAcks: List<Int>)
+
+    /**
+     * Append a trailing ACK appendix to an outgoing packet's wire bytes if
+     * there are pending acks AND the packet has room. Returns the
+     * (possibly enlarged) wire bytes plus the list of consumed acks (empty
+     * when nothing was piggybacked). Called from the I/O thread, just
+     * before [DatagramChannel.write].
+     *
+     * Wire format matches OpenSimulator `LLClientView.OutPacket` and
+     * Lumiya `AppendPendingAcks`:
+     *
+     *   [original packet body] [seq1 BE u32] ... [seqN BE u32] [N: u8]
+     *
+     * The header's FLAG_ACK (0x10) bit is set in the returned bytes.
+     * Acks are popped from [pendingAcksToSend] before write — if the write
+     * later fails the call site MUST requeue [PiggybackResult.consumedAcks].
+     */
+    private fun maybeAppendAcksToOutgoing(pkt: OutboundPacket): PiggybackResult {
+        if (pendingAcksToSend.isEmpty()) return PiggybackResult(pkt.data, emptyList())
+
+        val headroom = LinkpointConstants.MAX_TRANSMIT_SIZE - pkt.data.size - PIGGYBACK_AVAILABLE_HEADROOM
+        if (headroom < 5) return PiggybackResult(pkt.data, emptyList())  // not enough room for even 1 ack + count byte
+
+        val maxByHeadroom = (headroom - 1) / 4
+        val maxThisPacket = minOf(maxByHeadroom, MAX_PIGGYBACKED_ACKS, pendingAcksToSend.size)
+        if (maxThisPacket <= 0) return PiggybackResult(pkt.data, emptyList())
+
+        val acks = ArrayList<Int>(maxThisPacket)
+        while (acks.size < maxThisPacket) {
+            val ack = pendingAcksToSend.poll() ?: break
+            acks.add(ack)
+        }
+        if (acks.isEmpty()) return PiggybackResult(pkt.data, emptyList())
+
+        val appendixSize = acks.size * 4 + 1
+        val out = ByteArray(pkt.data.size + appendixSize)
+        System.arraycopy(pkt.data, 0, out, 0, pkt.data.size)
+
+        // Set FLAG_ACK on the wire copy. (We deliberately don't mutate
+        // pkt.data — it's still in inflightReliablePackets and needs to
+        // re-encode the same way on retransmit if this send fails.)
+        out[0] = (out[0].toInt() or 0x10).toByte()
+
+        var pos = pkt.data.size
+        for (ack in acks) {
+            // BIG-endian per SL/OpenSim wire format.
+            out[pos] = (ack ushr 24).toByte()
+            out[pos + 1] = (ack ushr 16).toByte()
+            out[pos + 2] = (ack ushr 8).toByte()
+            out[pos + 3] = ack.toByte()
+            pos += 4
+        }
+        out[pos] = (acks.size and 0xFF).toByte()
+
+        // Bookkeeping mirror of sendPendingAcksFromIOThread so the live
+        // diagnostics still show where acks went.
+        acks.forEach { ackSeq -> EnhancedPacketLogger.logAckSent(ackSeq) }
+        lastAckSendTime = System.currentTimeMillis()
+
+        return PiggybackResult(out, acks)
+    }
+
+    /**
      * Check whether the connection needs a ping or should disconnect due to inactivity.
      *
      * IMPORTANT: The disconnect check runs BEFORE sending a new ping to avoid a race
@@ -1583,8 +1707,14 @@ class UDPConnectionFixed {
 
     /**
      * Send an explicit StartPingCheck packet so unanswered-ping tracking maps to real ping requests.
+     *
+     * Public so [com.linkpoint.service.LinkpointConnectionService] can drive
+     * NAT-keepalive pings from the foreground service when the app is
+     * backgrounded — see the wire-up in [com.linkpoint.LinkpointApp].
+     * Calling this off-thread is safe (sendPacket goes through the
+     * outgoingQueue + selector wakeup path).
      */
-    private fun sendStartPingCheck() {
+    fun sendStartPingCheck() {
         val pingId = (nextPingId.incrementAndGet() and 0xFF)
         lastPingTime.set(System.currentTimeMillis())
         val unanswered = unansweredPings.incrementAndGet()
@@ -2737,20 +2867,34 @@ class UDPConnectionFixed {
             val pkt = outgoingQueue.poll() ?: break
             val messageName = getMessageName(pkt.messageId)
 
+            // Opportunistic ACK piggyback — Lumiya's `AppendPendingAcks`.
+            // Cheaper than a separate PacketAck (no extra header, no extra
+            // selector wakeup, no extra UDP datagram) and tightens our ack
+            // latency so the simulator's reliable-retransmit timer doesn't
+            // fire on packets we've already received.
+            //
+            // The appendix sits AFTER the message body on the wire and is NOT
+            // zero-coded, so we can splice it onto the already-encoded packet
+            // bytes without touching the message body.
+            val piggyback = maybeAppendAcksToOutgoing(pkt)
+            val wireBytes = piggyback.wireBytes
+
             try {
-                val written = channel.write(ByteBuffer.wrap(pkt.data))
+                val written = channel.write(ByteBuffer.wrap(wireBytes))
                 if (written > 0) {
                     packetsSent.incrementAndGet()
                     bytesSent.addAndGet(written.toLong())
                     lastSendTime = System.currentTimeMillis()
                     consecutiveSendErrors.set(0)
 
+                    val piggybackedAcks = wireBytes.size - pkt.data.size
                     NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-                        "→ Sent packet: ${pkt.data.size} bytes (ID: ${pkt.messageId}, reliable: ${pkt.reliable})")
+                        "→ Sent packet: ${wireBytes.size} bytes (ID: ${pkt.messageId}, reliable: ${pkt.reliable}" +
+                            (if (piggybackedAcks > 0) ", +${piggybackedAcks}B ACK appendix" else "") + ")")
                     NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
                         "   Message: $messageName (seq: ${pkt.seqNum})")
                     NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-                        "   Full packet data: ${pkt.data.joinToString(" ") { "%02X".format(it) }}")
+                        "   Full packet data: ${wireBytes.joinToString(" ") { "%02X".format(it) }}")
 
                     recordPacketEvent(
                         type = PacketHistoryEntry.PacketEventType.SEND_SUCCESS,
@@ -2781,6 +2925,9 @@ class UDPConnectionFixed {
                         reliable = pkt.reliable
                     )
                 } else {
+                    // Requeue any acks we piggybacked — the wire bytes never left
+                    // the host, so the simulator hasn't seen them.
+                    piggyback.consumedAcks.forEach { pendingAcksToSend.offer(it) }
                     recordPacketEvent(
                         type = PacketHistoryEntry.PacketEventType.SEND_FAILED,
                         messageId = pkt.messageId,
@@ -2799,6 +2946,7 @@ class UDPConnectionFixed {
                 // in pendingCallbacks and will be resent. Don't count this
                 // as a send error and don't escalate; just bail out of the
                 // drain so the next iteration picks up the new channel.
+                piggyback.consumedAcks.forEach { pendingAcksToSend.offer(it) }
                 NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP,
                     "Channel closed during send (${getMessageName(pkt.messageId)} seq=${pkt.seqNum}) — will resume on new channel")
                 recordPacketEvent(
@@ -2811,6 +2959,7 @@ class UDPConnectionFixed {
                 )
                 break
             } catch (e: java.nio.channels.ClosedChannelException) {
+                piggyback.consumedAcks.forEach { pendingAcksToSend.offer(it) }
                 NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP,
                     "Channel closed during send (${getMessageName(pkt.messageId)} seq=${pkt.seqNum}) — will resume on new channel")
                 recordPacketEvent(
@@ -2823,6 +2972,7 @@ class UDPConnectionFixed {
                 )
                 break
             } catch (e: Exception) {
+                piggyback.consumedAcks.forEach { pendingAcksToSend.offer(it) }
                 // Use the exception class name when the message is null —
                 // otherwise the log just says "Send error: null", which
                 // hides AsynchronousCloseException etc. behind a useless
@@ -3335,42 +3485,59 @@ class UDPConnectionFixed {
     }
 
     /**
-     * Process ACKs appended to a received packet.
+     * Strip the trailing ACK appendix from a wire packet and return the
+     * appendix-stripped body alongside the parsed ACK seq numbers.
      *
-     * IMPORTANT: This should ONLY be called when the packet's flags byte has
-     * bit 0x10 set (hasAcks flag). Calling this on packets without appended ACKs
-     * will read garbage from the end of the payload as ACK sequence numbers,
-     * potentially corrupting the ACK state.
+     * SL wire format for the appendix (matches OpenSimulator
+     * `LLClientView.OutPacket` and Lumiya `AppendPendingAcks`):
      *
-     * SL Protocol appended ACK format:
-     * - The last byte of the packet is the count of appended ACKs
-     * - Before that are count * 4 bytes of ACKed sequence numbers (little-endian)
-     * - These are piggybacked on the server's outgoing packets as an optimization
+     *   [...packet body...] [seq1 BE u32] [seq2 BE u32] ... [seqN BE u32] [N: u8]
+     *
+     * - The last byte of the wire packet is the count N.
+     * - Immediately before it are N × 4 bytes of acked sequence numbers in
+     *   BIG-ENDIAN order (NOT little-endian — the previous implementation
+     *   here read them as LE, so every appendix-acked seq was decoded as
+     *   garbage and silently dropped, leaving our `inflightReliablePackets`
+     *   to retransmit forever).
+     * - The appendix is appended AFTER zero-coding, so the appendix bytes
+     *   themselves are NEVER zero-coded. The receiver must therefore strip
+     *   the appendix from the raw wire bytes before invoking [zeroDecode].
+     *
+     * Returns the original `wire` array unchanged and an empty list if the
+     * FLAG_ACK bit is clear or the appendix doesn't fit. Defensive — silent
+     * no-op on garbage rather than throwing into the I/O loop.
+     *
+     * The returned body has FLAG_ACK cleared so that downstream
+     * [extractPacketFlags] doesn't claim the (now-removed) appendix is still
+     * present.
      */
-    private fun processAppendedAcks(data: ByteArray) {
-        val messageStartOffset = getMessageStartOffset(data) ?: return
-        if (data.size < messageStartOffset + 2) return
+    private fun stripTrailingAcksFromWire(wire: ByteArray): Pair<ByteArray, List<Int>> {
+        if (wire.size < PACKET_HEADER_SIZE + 1) return wire to emptyList()
+        val flags = wire[0].toInt() and 0xFF
+        if ((flags and 0x10) == 0) return wire to emptyList()
 
-        // Verify the appended ACK flag is set (0x10) before processing
-        val flags = data[0].toInt() and 0xFF
-        if ((flags and 0x10) == 0) return
+        val count = wire[wire.size - 1].toInt() and 0xFF
+        if (count == 0) return wire to emptyList()
 
-        val count = data[data.size - 1].toInt() and 0xFF
-        if (count == 0) return
+        val appendixSize = 1 + (count * 4)
+        // Need at least header + 1 message-id byte + appendix to be coherent.
+        if (wire.size < PACKET_HEADER_SIZE + 1 + appendixSize) return wire to emptyList()
 
-        val acksStart = data.size - 1 - (count * 4)
-        if (acksStart < messageStartOffset) return
-
+        val acksStart = wire.size - appendixSize
+        val acks = ArrayList<Int>(count)
         var pos = acksStart
         for (i in 0 until count) {
-            if (pos + 4 > data.size - 1) break
-            val ackedSeq = ByteBuffer.wrap(data, pos, 4).order(ByteOrder.LITTLE_ENDIAN).int
+            val seq = ((wire[pos].toInt() and 0xFF) shl 24) or
+                      ((wire[pos + 1].toInt() and 0xFF) shl 16) or
+                      ((wire[pos + 2].toInt() and 0xFF) shl 8) or
+                      (wire[pos + 3].toInt() and 0xFF)
+            acks.add(seq)
             pos += 4
-            processReceivedAck(ackedSeq)
         }
 
-        NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-            "Processed $count appended ACKs from packet")
+        val body = wire.copyOfRange(0, acksStart)
+        body[0] = (body[0].toInt() and 0x10.inv()).toByte()
+        return body to acks
     }
     
     /**

--- a/Linkpoint/src/main/java/com/linkpoint/service/BackgroundRuntimeConfig.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/service/BackgroundRuntimeConfig.kt
@@ -1,6 +1,8 @@
 package com.linkpoint.service
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import androidx.preference.PreferenceManager
 
 /**
@@ -34,6 +36,26 @@ object BackgroundRuntimeConfig {
             idleIntervalMs = 30_000L,
             reconnectBackoffMs = 15 * 60_000L,
             wakeLockTimeoutMs = 10 * 60_000L
+        ),
+
+        /**
+         * Cellular-tuned profile. Carrier UDP NAT timeouts on LTE/5G are
+         * commonly 30 seconds (T-Mobile/Verizon docs cite 25-60s; in the
+         * wild 30s is the modal value). Anything ≥30s risks the NAT mapping
+         * being torn down between keepalives, after which the simulator's
+         * replies fall on the floor and the unanswered-pings watchdog has
+         * to escalate to a full re-login (visible in the 2026-04-26
+         * Athanasia capture as four UseCircuitCode-from-seq-1 cycles).
+         *
+         * 20s gives margin under the 30s NAT timeout while still being
+         * gentler on battery than AGGRESSIVE's 15s. Used automatically when
+         * the active network is cellular (see [getEffectiveProfile]).
+         */
+        CELLULAR_AGGRESSIVE(
+            keepAliveIntervalMs = 20_000L,
+            idleIntervalMs = 25_000L,
+            reconnectBackoffMs = 15 * 60_000L,
+            wakeLockTimeoutMs = 8 * 60_000L
         )
     }
 
@@ -53,10 +75,43 @@ object BackgroundRuntimeConfig {
         return mapIntensityProfile(raw)
     }
 
+    /**
+     * Like [getIntensityProfile] but auto-promotes the user's selected
+     * profile to [IntensityProfile.CELLULAR_AGGRESSIVE] when the active
+     * network is cellular AND the user hasn't explicitly chosen the
+     * already-aggressive profile. Wi-Fi NAT timeouts are typically ≥10
+     * minutes so the user-selected profile passes through unchanged.
+     *
+     * Falls back to [getIntensityProfile] on any error reading the network
+     * state — defensive, never throws into the keepalive loop.
+     */
+    fun getEffectiveProfile(context: Context): IntensityProfile {
+        val userChoice = getIntensityProfile(context)
+        // If the user explicitly picked AGGRESSIVE (15s) we honour that —
+        // it's already tighter than CELLULAR_AGGRESSIVE.
+        if (userChoice == IntensityProfile.AGGRESSIVE) return userChoice
+        return if (isOnCellular(context)) IntensityProfile.CELLULAR_AGGRESSIVE else userChoice
+    }
+
+    private fun isOnCellular(context: Context): Boolean {
+        return try {
+            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return false
+            val active = cm.activeNetwork ?: return false
+            val caps = cm.getNetworkCapabilities(active) ?: return false
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) &&
+                !caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) &&
+                !caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+        } catch (e: Throwable) {
+            false
+        }
+    }
+
     internal fun mapIntensityProfile(raw: String?): IntensityProfile {
         return when (raw) {
             "conservative" -> IntensityProfile.CONSERVATIVE
             "aggressive" -> IntensityProfile.AGGRESSIVE
+            "cellular_aggressive" -> IntensityProfile.CELLULAR_AGGRESSIVE
             else -> IntensityProfile.BALANCED
         }
     }

--- a/Linkpoint/src/main/java/com/linkpoint/service/LinkpointConnectionService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/service/LinkpointConnectionService.kt
@@ -44,6 +44,39 @@ class LinkpointConnectionService : Service() {
         private val _isRunning = MutableStateFlow(false)
         val isRunning: StateFlow<Boolean> = _isRunning
 
+        /**
+         * Process-wide callback the foreground service uses to drive UDP
+         * keepalive pings and to notify the app of dead-circuit conditions.
+         *
+         * This is a static slot rather than a per-instance binder so the
+         * [com.linkpoint.LinkpointApp] can register the callback once at
+         * Application.onCreate without having to bindService() (binding
+         * adds Context+lifecycle plumbing for no benefit when the only
+         * caller is the singleton Application). The service reads this
+         * each time it ticks; reassigning is safe.
+         */
+        @Volatile
+        private var processCallback: ConnectionCallback? = null
+
+        /**
+         * Process-wide flag for whether the UDP circuit is currently up.
+         * The Application toggles this when [com.linkpoint.protocol.messages.UDPConnectionFixed.isConnected]
+         * transitions; the service uses it to decide whether to ping (no
+         * point pinging a dead socket) and to phrase the notification.
+         */
+        @Volatile
+        private var processConnected: Boolean = false
+
+        /** Set by [com.linkpoint.LinkpointApp]; called from the service tick. */
+        fun setProcessCallback(callback: ConnectionCallback?) {
+            processCallback = callback
+        }
+
+        /** Toggled by [com.linkpoint.LinkpointApp]'s networkStateListener. */
+        fun setProcessConnected(connected: Boolean) {
+            processConnected = connected
+        }
+
         fun start(context: Context) {
             val intent = Intent(context, LinkpointConnectionService::class.java).apply {
                 action = ACTION_START
@@ -114,8 +147,16 @@ class LinkpointConnectionService : Service() {
     }
 
     private fun startForegroundService() {
-        val profile = BackgroundRuntimeConfig.getIntensityProfile(this)
-        val notification = createNotification("Connected to Second Life")
+        // Use the effective profile so cellular automatically gets the
+        // tighter 20s NAT-keepalive cadence. Wi-Fi falls through to the
+        // user's selection.
+        val profile = BackgroundRuntimeConfig.getEffectiveProfile(this)
+        Log.i(TAG, "Foreground service starting with profile=$profile (keepAlive=${profile.keepAliveIntervalMs}ms)")
+        // Mirror the process-wide flag onto the instance flag so isConnected
+        // queries stay consistent for callers that come in through the
+        // binder (notification text, isConnected getter).
+        if (processConnected) isConnected = true
+        val notification = createNotification(if (processConnected) "Connected to Second Life" else "Connecting…")
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
@@ -238,7 +279,19 @@ class LinkpointConnectionService : Service() {
 
     private suspend fun performKeepAlive() {
         lastPingTime = System.currentTimeMillis()
-        connectionCallback?.onSendPing()
+        // Skip when the circuit is known down — pinging into a dead socket
+        // races with the auto re-login coordinator and just spams logs.
+        if (!processConnected && !isConnected) {
+            return
+        }
+        // Process-wide callback (LinkpointApp) takes priority; the per-
+        // instance binder callback is only used by tests / future bound
+        // clients. Without this wiring, performKeepAlive was a no-op
+        // because nothing ever called setConnectionCallback — see the
+        // 2026-04-26 Athanasia capture, where the foreground service
+        // was running but never drove a single ping.
+        val cb = processCallback ?: connectionCallback
+        cb?.onSendPing()
     }
 
     private fun performPing() {
@@ -247,8 +300,10 @@ class LinkpointConnectionService : Service() {
 
     private fun checkConnection(profile: BackgroundRuntimeConfig.IntensityProfile) {
         val timeSinceLastPing = System.currentTimeMillis() - lastPingTime
-        if (isConnected && timeSinceLastPing > profile.keepAliveIntervalMs * 3) {
-            connectionCallback?.onConnectionStale()
+        val effectivelyConnected = processConnected || isConnected
+        if (effectivelyConnected && timeSinceLastPing > profile.keepAliveIntervalMs * 3) {
+            val cb = processCallback ?: connectionCallback
+            cb?.onConnectionStale()
             BackgroundResumeScheduler.schedule(this, immediate = true)
         }
     }

--- a/Linkpoint/src/main/java/com/linkpoint/util/LifecycleAwareScopeManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/util/LifecycleAwareScopeManager.kt
@@ -611,7 +611,16 @@ object LifecycleAwareScopeManager {
             try {
                 val app = com.linkpoint.LinkpointApp.getInstanceOrNull() ?: return
                 val udp = app.udpConnection
-                if (udp.isConnected.value) udp.sendAgentPause()
+                if (udp.isConnected.value) {
+                    udp.sendAgentPause()
+                    // Make sure the foreground service knows we're connected
+                    // so its keepalive loop runs at full cadence while the
+                    // app is backgrounded — this is the load-bearing piece
+                    // for keeping the cellular NAT mapping alive across
+                    // exit/resume.
+                    com.linkpoint.service.LinkpointConnectionService.setProcessConnected(true)
+                    com.linkpoint.service.LinkpointConnectionService.start(app)
+                }
             } catch (e: Throwable) {
                 android.util.Log.w(TAG, "AgentPause on background failed: ${e.message}")
             }
@@ -621,7 +630,19 @@ object LifecycleAwareScopeManager {
             try {
                 val app = com.linkpoint.LinkpointApp.getInstanceOrNull() ?: return
                 val udp = app.udpConnection
-                if (udp.isConnected.value) udp.sendAgentResume()
+                if (udp.isConnected.value) {
+                    udp.sendAgentResume()
+                    // Drive an immediate StartPingCheck so we discover a
+                    // dead path (cellular NAT change while we were away)
+                    // within ~1s, instead of waiting for the next FGS
+                    // keepalive tick or the 5-second in-circuit ping
+                    // cadence. Cheap: 12 bytes out, ~12 bytes back.
+                    try {
+                        udp.sendStartPingCheck()
+                    } catch (e: Throwable) {
+                        android.util.Log.w(TAG, "Immediate post-resume ping failed: ${e.message}")
+                    }
+                }
             } catch (e: Throwable) {
                 android.util.Log.w(TAG, "AgentResume on foreground failed: ${e.message}")
             }


### PR DESCRIPTION
## Summary
This PR fixes critical issues with UDP acknowledgment (ACK) handling and network keepalive that were causing packet retransmission cascades and connection loss on cellular networks. The changes address ACK corruption from zero-coding, implement opportunistic ACK piggybacking, add cellular-specific keepalive tuning, and wire the foreground service to actually drive keepalive pings.

## Key Changes

### ACK Processing Fixes
- **Strip ACKs before zero-decoding**: ACK appendices are now extracted from raw wire bytes BEFORE zero-decoding, preventing the decoder from corrupting the appendix bytes and losing ACK information. The previous implementation read ACKs from the decoded buffer with wrong endianness (little-endian instead of big-endian) and wrong offsets, silently discarding most ACKs.
- **Fix ACK byte order**: Changed from little-endian to big-endian when parsing ACK sequence numbers, matching the SL/OpenSim wire format.
- **Refactor ACK extraction**: Replaced `processAppendedAcks()` with `stripTrailingAcksFromWire()` that defensively validates the appendix before parsing and clears the FLAG_ACK bit from the body copy.

### ACK Transmission Optimization
- **Implement ACK piggybacking**: Added `maybeAppendAcksToOutgoing()` to append pending ACKs to outgoing packets when there's headroom, reducing the need for standalone PacketAck packets and tightening ACK latency.
- **Add burst-aware ACK flushing**: Introduced `ACK_FLUSH_QUEUE_THRESHOLD` (8 ACKs) to force immediate ACK transmission during burst traffic (region handshake, parcel overlays) instead of waiting the full 100ms coalescing window, preventing the simulator's retransmit timer from firing.
- **Requeue piggybacked ACKs on send failure**: If a packet write fails, any piggybacked ACKs are requeued to `pendingAcksToSend` so they're not lost.

### Cellular Network Keepalive
- **Add CELLULAR_AGGRESSIVE profile**: New intensity profile with 20s keepalive interval (vs. 15s for AGGRESSIVE, 30s for BALANCED) tuned for carrier UDP NAT timeouts (typically 25-60s, modal 30s).
- **Auto-promote to cellular profile**: `getEffectiveProfile()` automatically uses CELLULAR_AGGRESSIVE when the active network is cellular and the user hasn't explicitly chosen AGGRESSIVE.
- **Wire foreground service keepalive**: Connected `LinkpointConnectionService.performKeepAlive()` to actually call `udpConnection.sendStartPingCheck()` via a process-wide callback set by `LinkpointApp`.
- **Mirror connection state to service**: Added `setProcessConnected()` to let the app notify the service when the UDP circuit is up/down, so the service knows when to ping and what notification text to show.

### Public API Changes
- Made `sendStartPingCheck()` public so `LinkpointConnectionService` can call it for NAT keepalive.

### Lifecycle Integration
- **App backgrounding**: When the app pauses, explicitly set the service's connected flag and start the foreground service to ensure keepalive runs at full cadence.
- **App resuming**: When the app resumes, send an immediate `StartPingCheck` to detect dead paths (e.g., cellular NAT change) within ~1s instead of waiting for the next keepalive tick.
- **Collector lifecycle**: Cancel any prior FGS connect-state mirror collector on re-login to prevent coroutine leaks during auto-relogin cycles.

## Implementation Details
- ACK appendix format: `[packet body] [seq1 BE u32] ... [seqN BE u32] [N: u8]`, appended AFTER zero-coding per OpenSimulator/Lumiya.
- Piggybacking respects `PIGGYBACK_AVAILABLE_HEADROOM` (256 bytes) and `MAX_PIGGYBACKED_ACKS` (64) to avoid fragmentation on already-large packets.
- All ACK processing

https://claude.ai/code/session_01VYtieQzm4L6pkApnGZJU4B

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes critical UDP reliability issues that were causing packet retransmissions and connection loss on cellular networks. The core problem was that ACK appendices were being corrupted by the zero-decoding process and parsed with wrong endianness, causing most ACKs to be silently discarded. The fix extracts ACK appendices from raw wire bytes *before* zero-decoding and parses them in big-endian format. Additionally, the PR implements opportunistic ACK piggybacking to reduce latency, adds burst-aware ACK flushing to prevent simulator retransmits, introduces a cellular-specific keepalive profile with 20-second intervals tuned for carrier NAT timeouts, and wires the foreground service to actually drive keepalive pings when backgrounded. The changes also add immediate ping-on-resume to detect dead paths faster after the app returns from background.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/service/BackgroundRuntimeConfig.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/service/LinkpointConnectionService.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/util/LifecycleAwareScopeManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic network adaptation that optimizes performance settings for cellular connections.

* **Bug Fixes**
  * Improved connection state synchronization and keepalive mechanism reliability.
  * Fixed acknowledgment packet processing to prevent silent drops and incorrect parsing.
  * Enhanced dead network path detection for faster connection recovery.

* **Chores**
  * Optimized background connectivity management with improved service coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->