### PR TITLE
Refactor CI workflow: centralize env vars and improve Gradle caching

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,27 +7,26 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  JAVA_VERSION: '17'
+  ANDROID_SDK_VERSION: '35'
+  NDK_VERSION: '26.3.11579264'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    
-    defaults:
-      run:
-        working-directory: Linkpoint
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
-
-      - name: Cache Gradle
-        uses: gradle/actions/setup-gradle@v4
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: 'gradle'
 
       # setup-android@v3 dropped the api-level/build-tools/cmake/ndk inputs;
       # only `packages`, `cmdline-tools-version`, and the license toggles are
@@ -40,28 +39,50 @@ jobs:
         with:
           packages: >-
             platform-tools
-            platforms;android-35
+            platforms;android-${{ env.ANDROID_SDK_VERSION }}
             build-tools;35.0.0
             cmake;3.22.1
-            ndk;26.3.11579264
+            ndk;${{ env.NDK_VERSION }}
 
       - name: Verify Android SDK install
         run: |
           set -euo pipefail
           echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
-          test -d "$ANDROID_SDK_ROOT/platforms/android-35"
+          test -d "$ANDROID_SDK_ROOT/platforms/android-${{ env.ANDROID_SDK_VERSION }}"
           test -d "$ANDROID_SDK_ROOT/build-tools/35.0.0"
           test -d "$ANDROID_SDK_ROOT/cmake/3.22.1"
-          test -d "$ANDROID_SDK_ROOT/ndk/26.3.11579264"
+          test -d "$ANDROID_SDK_ROOT/ndk/${{ env.NDK_VERSION }}"
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+            .gradle
+          key: ${{ runner.os }}-gradle-release-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-release-
+            ${{ runner.os }}-gradle-
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # Run via the root composite build (settings.gradle :: includeBuild('Linkpoint'))
+      # so we use the same Gradle wrapper / classpath path as build-linkpoint.yml,
+      # which is the proven-passing CI invocation. Running `./gradlew assembleDebug`
+      # from inside `Linkpoint/` uses a different wrapper version and skips the
+      # composite build setup, which has been failing at the Build Debug step.
       - name: Build Debug
-        run: ./gradlew assembleDebug --stacktrace
+        run: ./gradlew :Linkpoint:assembleDebug --stacktrace
+        env:
+          GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
 
       - name: Build Release
-        run: ./gradlew assembleRelease --stacktrace
+        run: ./gradlew :Linkpoint:assembleRelease --stacktrace
+        env:
+          GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Refactored the build-release GitHub Actions workflow to improve maintainability, build performance, and reliability by centralizing environment variables, optimizing Gradle caching, and fixing the Gradle invocation path.

## Key Changes
- **Centralized environment variables**: Moved Java version, Android SDK version, and NDK version to workflow-level `env` section for easier maintenance and consistency
- **Improved Gradle caching**: Replaced `gradle/actions/setup-gradle@v4` with explicit `actions/cache@v4` configuration that caches Gradle packages, wrapper, and Android build cache with proper cache keys
- **Fixed Gradle invocation**: Changed build commands from `./gradlew assembleDebug` to `./gradlew :Linkpoint:assembleDebug` to use the root composite build (via `settings.gradle`), ensuring consistent wrapper version and classpath with the proven-passing `build-linkpoint.yml` workflow
- **Added JVM memory configuration**: Set `GRADLE_OPTS` with explicit heap and metaspace settings to prevent out-of-memory errors during builds
- **Removed working directory default**: Eliminated the `defaults.run.working-directory: Linkpoint` configuration in favor of explicit task paths, improving clarity and consistency
- **Updated verification step**: Changed hardcoded paths to use environment variables for Android SDK and NDK verification

## Notable Implementation Details
- The Gradle invocation change addresses a previous issue where running `./gradlew` from inside `Linkpoint/` used a different wrapper version and skipped the composite build setup, causing build failures
- Cache configuration now includes `.gradle` directory alongside standard Gradle cache paths for more comprehensive caching
- Environment variables are used consistently throughout the workflow for version numbers, reducing duplication and maintenance burden

https://claude.ai/code/session_01MbkZhwHvWEb7epHaAiGLhz

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the `build-release.yml` GitHub Actions workflow to improve maintainability and build reliability. The changes centralize version numbers (Java, Android SDK, NDK) as workflow-level environment variables, replace the Gradle setup action with explicit `actions/cache@v4` configuration for better caching control, and fix the Gradle invocation to use the root composite build (`:Linkpoint:assembleDebug` instead of `assembleDebug` from the `Linkpoint/` directory). Additionally, JVM memory settings (`GRADLE_OPTS`) are added to prevent out-of-memory errors, and the default working directory is removed in favor of explicit task paths for improved clarity.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/build-release.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions build workflow configuration with improved environment variable management and enhanced caching strategy for more efficient CI/CD pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->