### PR TITLE
Add GL_EXT_buffer_storage JNI bindings via GlExtHelper

### DIFF
--- a/Linkpoint/src/main/cpp/CMakeLists.txt
+++ b/Linkpoint/src/main/cpp/CMakeLists.txt
@@ -6,6 +6,12 @@ project("linkpoint-j2k")
 # Package name is "openjpeg", target is "openjpeg::openjp2"
 find_package(openjpeg REQUIRED CONFIG)
 
+# ── lumiya-native: GL extension JNI bindings ─────────────────────────────────
+# android.opengl.GLES31Ext does not include GL_EXT_buffer_storage; we resolve
+# glBufferStorageEXT at runtime via eglGetProcAddress in this thin wrapper.
+add_library(lumiya-native SHARED jni/gl_ext_jni.cpp)
+target_link_libraries(lumiya-native android log EGL GLESv3)
+
 # TODO(docs/lumiya-port/README.md item 2): vendor etcpak (single-header,
 # MIT/BSD-3) under src/main/cpp/etcpak/ and add the source files here.
 # When this lands, define LINKPOINT_HAVE_ETCPAK so j2k_decoder.cpp can

--- a/Linkpoint/src/main/cpp/jni/gl_ext_jni.cpp
+++ b/Linkpoint/src/main/cpp/jni/gl_ext_jni.cpp
@@ -1,0 +1,55 @@
+#include <jni.h>
+#include <EGL/egl.h>
+#include <GLES3/gl3.h>
+#include <android/log.h>
+
+#define LOG_TAG "GlExtJni"
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN,  LOG_TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,  LOG_TAG, __VA_ARGS__)
+
+// GL_EXT_buffer_storage entry-point resolved lazily via eglGetProcAddress.
+// The Android SDK does not wrap this extension in any GLES3xExt Java class.
+typedef void (*PFNGLBUFFERSTORAGEEXTPROC)(GLenum target, GLsizeiptr size,
+                                          const void* data, GLbitfield flags);
+
+static PFNGLBUFFERSTORAGEEXTPROC s_glBufferStorageEXT = nullptr;
+static bool s_resolved = false;
+
+static void resolveBufferStorageEXT() {
+    if (s_resolved) return;
+    s_resolved = true;
+    s_glBufferStorageEXT = reinterpret_cast<PFNGLBUFFERSTORAGEEXTPROC>(
+        eglGetProcAddress("glBufferStorageEXT"));
+    if (!s_glBufferStorageEXT) {
+        LOGW("glBufferStorageEXT not found via eglGetProcAddress");
+    } else {
+        LOGI("glBufferStorageEXT resolved");
+    }
+}
+
+extern "C" {
+
+JNIEXPORT jboolean JNICALL
+Java_com_linkpoint_render_lumiya_core_GlExtHelper_nativeIsBufferStorageExtAvailable(
+        JNIEnv* /*env*/, jclass /*clazz*/) {
+    resolveBufferStorageEXT();
+    return s_glBufferStorageEXT != nullptr ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL
+Java_com_linkpoint_render_lumiya_core_GlExtHelper_nativeBufferStorageExt(
+        JNIEnv* env, jclass /*clazz*/,
+        jint target, jlong size, jobject data, jint flags) {
+    if (!s_glBufferStorageEXT) return;
+
+    void* dataPtr = nullptr;
+    if (data != nullptr) {
+        dataPtr = env->GetDirectBufferAddress(data);
+    }
+    s_glBufferStorageEXT(static_cast<GLenum>(target),
+                         static_cast<GLsizeiptr>(size),
+                         dataPtr,
+                         static_cast<GLbitfield>(flags));
+}
+
+} // extern "C"

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/GlExtHelper.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/GlExtHelper.kt
@@ -1,0 +1,55 @@
+package com.linkpoint.render.lumiya.core
+
+import android.util.Log
+import java.nio.Buffer
+
+/**
+ * Exposes GL_EXT_buffer_storage constants and glBufferStorageEXT via JNI.
+ *
+ * android.opengl.GLES31Ext does not include GL_EXT_buffer_storage bindings,
+ * so we define the constants from the extension registry and resolve the
+ * entry point at runtime through eglGetProcAddress in the native layer.
+ */
+internal object GlExtHelper {
+
+    private const val TAG = "GlExtHelper"
+
+    // GL_EXT_buffer_storage token values (Khronos registry)
+    const val GL_MAP_READ_BIT_EXT         = 0x0001
+    const val GL_MAP_WRITE_BIT_EXT        = 0x0002
+    const val GL_MAP_PERSISTENT_BIT_EXT   = 0x0040
+    const val GL_MAP_COHERENT_BIT_EXT     = 0x0080
+    const val GL_DYNAMIC_STORAGE_BIT_EXT  = 0x0100
+    const val GL_CLIENT_STORAGE_BIT_EXT   = 0x0200
+
+    @Volatile private var libraryLoaded = false
+    @Volatile private var nativeAvailable = false
+
+    fun isAvailable(): Boolean {
+        ensureLoaded()
+        return nativeAvailable
+    }
+
+    fun glBufferStorageExt(target: Int, size: Int, data: Buffer?, flags: Int) {
+        nativeBufferStorageExt(target, size.toLong(), data, flags)
+    }
+
+    private fun ensureLoaded() {
+        if (libraryLoaded) return
+        synchronized(this) {
+            if (libraryLoaded) return
+            libraryLoaded = true
+            try {
+                System.loadLibrary("lumiya-native")
+                nativeAvailable = nativeIsBufferStorageExtAvailable()
+                Log.i(TAG, "lumiya-native loaded; glBufferStorageEXT=${if (nativeAvailable) "available" else "unavailable"}")
+            } catch (e: UnsatisfiedLinkError) {
+                nativeAvailable = false
+                Log.w(TAG, "lumiya-native unavailable: ${e.message}")
+            }
+        }
+    }
+
+    private external fun nativeBufferStorageExt(target: Int, size: Long, data: Buffer?, flags: Int)
+    private external fun nativeIsBufferStorageExtAvailable(): Boolean
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
@@ -1,7 +1,6 @@
 package com.linkpoint.render.lumiya.core
 
 import android.opengl.GLES32
-import android.opengl.GLES31Ext
 import android.opengl.Matrix
 import android.util.Log
 import com.linkpoint.render.RenderDiagnostics
@@ -228,17 +227,22 @@ class LumiyaRenderContext {
         if (!extensions.contains("GL_EXT_buffer_storage")) {
             return false
         }
+        if (!GlExtHelper.isAvailable()) {
+            return false
+        }
         return try {
-            val flags = GLES31Ext.GL_MAP_WRITE_BIT_EXT or
-                GLES31Ext.GL_MAP_PERSISTENT_BIT_EXT or
-                GLES31Ext.GL_MAP_COHERENT_BIT_EXT or
-                GLES31Ext.GL_DYNAMIC_STORAGE_BIT_EXT
-            GLES31Ext.glBufferStorageExt(GLES32.GL_UNIFORM_BUFFER, globalUBOSizeBytes, null, flags)
+            val flags = GlExtHelper.GL_MAP_WRITE_BIT_EXT or
+                GlExtHelper.GL_MAP_PERSISTENT_BIT_EXT or
+                GlExtHelper.GL_MAP_COHERENT_BIT_EXT or
+                GlExtHelper.GL_DYNAMIC_STORAGE_BIT_EXT
+            GlExtHelper.glBufferStorageExt(GLES32.GL_UNIFORM_BUFFER, globalUBOSizeBytes, null, flags)
             val mapped = GLES32.glMapBufferRange(
                 GLES32.GL_UNIFORM_BUFFER,
                 0,
                 globalUBOSizeBytes,
-                GLES32.GL_MAP_WRITE_BIT or GLES31Ext.GL_MAP_PERSISTENT_BIT_EXT or GLES31Ext.GL_MAP_COHERENT_BIT_EXT
+                GLES32.GL_MAP_WRITE_BIT or
+                    GlExtHelper.GL_MAP_PERSISTENT_BIT_EXT or
+                    GlExtHelper.GL_MAP_COHERENT_BIT_EXT
             )
             if (mapped is ByteBuffer) {
                 mapped.order(ByteOrder.nativeOrder())


### PR DESCRIPTION
## Summary
This PR adds JNI bindings for the `GL_EXT_buffer_storage` extension, which is not exposed by the Android SDK's `GLES31Ext` class. A new `GlExtHelper` utility resolves `glBufferStorageEXT` at runtime via `eglGetProcAddress` and provides a Kotlin wrapper for safe access.

## Key Changes
- **New C++ JNI module** (`gl_ext_jni.cpp`): Implements lazy resolution of `glBufferStorageEXT` via `eglGetProcAddress` with availability checking and logging
- **New Kotlin helper** (`GlExtHelper.kt`): Provides:
  - GL_EXT_buffer_storage token constants (GL_MAP_READ_BIT_EXT, GL_MAP_WRITE_BIT_EXT, GL_MAP_PERSISTENT_BIT_EXT, GL_MAP_COHERENT_BIT_EXT, GL_DYNAMIC_STORAGE_BIT_EXT, GL_CLIENT_STORAGE_BIT_EXT)
  - Thread-safe lazy loading of the native library
  - Public `isAvailable()` and `glBufferStorageExt()` methods
- **Updated CMakeLists.txt**: Added `lumiya-native` shared library target linking against Android, EGL, and GLESv3
- **Updated LumiyaRenderContext.kt**: Migrated from `GLES31Ext` to `GlExtHelper` for buffer storage operations with additional availability check

## Implementation Details
- The native layer uses `eglGetProcAddress` to resolve the extension function pointer at runtime, with fallback logging if unavailable
- The Kotlin layer uses double-checked locking pattern for thread-safe lazy initialization
- Direct buffer address extraction via `GetDirectBufferAddress` for efficient data passing to native code
- Graceful degradation: if the extension is unavailable, operations return early without errors

https://claude.ai/code/session_01M194RqNiCptyBGfKkutyr6

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds JNI bindings for the `GL_EXT_buffer_storage` OpenGL extension which is not available in Android's standard SDK. It introduces a new native module (`lumiya-native`) that resolves the `glBufferStorageEXT` function at runtime using `eglGetProcAddress`, along with a Kotlin helper class (`GlExtHelper`) that provides thread-safe access to the extension constants and functions. The existing `LumiyaRenderContext` is updated to use the new helper instead of the unavailable `GLES31Ext` class for persistent mapped buffer operations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/GlExtHelper.kt` |
| 2 | `Linkpoint/src/main/cpp/jni/gl_ext_jni.cpp` |
| 3 | `Linkpoint/src/main/cpp/CMakeLists.txt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advanced OpenGL buffer storage extension, enabling optimized memory management and persistent buffer mapping for improved graphics rendering performance on compatible devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->