### PR TITLE
Mesh pipeline: PrimRenderer requests parsed mesh data and replaces geometry

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -811,6 +811,59 @@ class LinkpointApp : Application() {
         meshManager = MeshManager(this, assetCache, capabilityManager)
         animationManager = AnimationManager(this, assetCache)
         soundManager = SoundManager(this, assetCache)
+        renderManager.configurePrimMeshPipeline(
+            requester = com.linkpoint.render.prims.PrimRenderer.MeshDataRequester { localId, meshId, lod, onResolved ->
+                applicationScope.launch {
+                    val meshData = try {
+                        meshManager.getMesh(meshId, lod)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Mesh load parse failure localId=$localId meshId=$meshId: ${e.message}")
+                        onResolved(com.linkpoint.render.prims.PrimRenderer.MeshLoadResult.ParseFailure(e.message))
+                        return@launch
+                    }
+                    if (meshData != null) {
+                        onResolved(com.linkpoint.render.prims.PrimRenderer.MeshLoadResult.Success(meshData))
+                    } else {
+                        val diagnostics = meshManager.getDiagnostics()
+                        val detail = diagnostics.lastError ?: "mesh not found"
+                        val parseFailure = detail.startsWith("Parse:") ||
+                            detail.contains("parse", ignoreCase = true)
+                        if (parseFailure) {
+                            onResolved(com.linkpoint.render.prims.PrimRenderer.MeshLoadResult.ParseFailure(detail))
+                        } else {
+                            onResolved(com.linkpoint.render.prims.PrimRenderer.MeshLoadResult.MissingAsset(detail))
+                        }
+                    }
+                }
+            },
+            geometryBuilder = com.linkpoint.render.prims.PrimRenderer.MeshGeometryBuilder { entity, meshData, textureEntry ->
+                val binder = com.linkpoint.render.prims.MeshPrimRenderer.TextureBinder { _, texId, onLoaded ->
+                    val resolvedId = if (::avatarManager.isInitialized) {
+                        com.linkpoint.avatar.BakesOnMesh.resolve(texId) { slot ->
+                            avatarManager.getMyAvatar()?.baker?.getBakedTextures()?.get(slot)
+                        }
+                    } else texId
+                    if (!com.linkpoint.protocol.textures.TextureEntryParser.shouldDownload(resolvedId)) return@TextureBinder
+                    if (!::textureManager.isInitialized) return@TextureBinder
+                    applicationScope.launch {
+                        val bmp = try { textureManager.getTexture(resolvedId) } catch (_: Exception) { null }
+                        if (bmp != null) {
+                            renderManager.dispatcher.post(Runnable {
+                                val pair = renderManager.uploadBitmapAsLinkpointTexture(resolvedId, bmp)
+                                if (pair != null) onLoaded(pair.first)
+                            })
+                        }
+                    }
+                }
+                renderManager.engine?.renderableManager?.let { rm ->
+                    val inst = rm.getInstance(entity)
+                    if (inst != 0) rm.destroy(entity)
+                }
+                renderManager.getMeshPrimRenderer()?.getOrCompile(meshData)?.let { compiled ->
+                    renderManager.getMeshPrimRenderer()?.attach(entity, compiled, textureEntry, binder)
+                }
+            }
+        )
         
         // World features
         worldMap = WorldMap(capabilityManager)
@@ -1461,55 +1514,6 @@ class LinkpointApp : Application() {
                     // PrimRenderer creates actual renderable meshes (box, sphere, etc.)
                     if (::renderManager.isInitialized) {
                         renderManager.enqueueUpdate(RenderableUpdate.PrimUpdate(update))
-                    }
-
-                    // Mesh-asset prims: kick off MeshManager fetch and ask
-                    // PrimRenderer to swap the path/profile fallback geometry
-                    // for the parsed mesh once it lands. Failures fall back
-                    // gracefully to the path/profile box already rendered.
-                    val meshAssetId = update.getMeshAssetId()
-                    if (meshAssetId != null && ::meshManager.isInitialized && ::renderManager.isInitialized) {
-                        val textureEntrySnapshot = update.textureEntry
-                        applicationScope.launch {
-                            val meshData = try {
-                                meshManager.getMesh(meshAssetId)
-                            } catch (e: Exception) {
-                                Log.w(TAG, "Mesh fetch failed for ${update.localId}: ${e.message}")
-                                null
-                            }
-                            if (meshData != null) {
-                                // TextureBinder: per face, BoM-resolve the
-                                // texture UUID, fetch via TextureManager,
-                                // hop to the render thread and call onLoaded.
-                                val binder = com.linkpoint.render.prims.MeshPrimRenderer.TextureBinder { _, texId, onLoaded ->
-                                    val resolvedId = if (::avatarManager.isInitialized) {
-                                        com.linkpoint.avatar.BakesOnMesh.resolve(texId) { slot ->
-                                            avatarManager.getMyAvatar()?.baker?.getBakedTextures()?.get(slot)
-                                        }
-                                    } else texId
-                                    if (!com.linkpoint.protocol.textures.TextureEntryParser.shouldDownload(resolvedId)) return@TextureBinder
-                                    if (!::textureManager.isInitialized) return@TextureBinder
-                                    applicationScope.launch {
-                                        val bmp = try { textureManager.getTexture(resolvedId) } catch (_: Exception) { null }
-                                        if (bmp != null) {
-                                            renderManager.dispatcher.post(Runnable {
-                                                // Route through the LinkpointTexture-tracked path so
-                                                // every per-face mesh texture participates in VRAM
-                                                // accounting and gets a clean Filament release path.
-                                                val pair = renderManager.uploadBitmapAsLinkpointTexture(resolvedId, bmp)
-                                                if (pair != null) onLoaded(pair.first)
-                                            })
-                                        }
-                                    }
-                                }
-                                renderManager.dispatcher.post(Runnable {
-                                    renderManager.attachMeshAsset(
-                                        update.localId, meshData,
-                                        textureEntrySnapshot, binder
-                                    )
-                                })
-                            }
-                        }
                     }
 
                     // Extract and prefetch textures from the object's TextureEntry

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -63,6 +63,8 @@ class RenderManager(private val context: Context) {
     private var primRenderer: PrimRenderer? = null
     private var meshPrimRenderer: MeshPrimRenderer? = null
     private var terrainRenderer: TerrainRenderer? = null
+    private var primMeshDataRequester: PrimRenderer.MeshDataRequester? = null
+    private var primMeshGeometryBuilder: PrimRenderer.MeshGeometryBuilder? = null
 
     // Helpers
     private var uiHelper: UiHelper? = null
@@ -172,6 +174,8 @@ class RenderManager(private val context: Context) {
                 if (litMaterial != null) {
                     primRenderer = PrimRenderer(filamentEngine, filamentScene)
                     primRenderer?.initialize(litMaterial)
+                    primRenderer?.setMeshDataRequester(primMeshDataRequester)
+                    primRenderer?.setMeshGeometryBuilder(primMeshGeometryBuilder)
                     Log.d(TAG, "PrimRenderer initialized")
 
                     // Mesh-asset prim renderer: shares the lit material with
@@ -1007,6 +1011,16 @@ class RenderManager(private val context: Context) {
     fun getPrimRenderer(): PrimRenderer? = primRenderer
 
     fun getMeshPrimRenderer(): MeshPrimRenderer? = meshPrimRenderer
+
+    fun configurePrimMeshPipeline(
+        requester: PrimRenderer.MeshDataRequester?,
+        geometryBuilder: PrimRenderer.MeshGeometryBuilder?
+    ) {
+        primMeshDataRequester = requester
+        primMeshGeometryBuilder = geometryBuilder
+        primRenderer?.setMeshDataRequester(requester)
+        primRenderer?.setMeshGeometryBuilder(geometryBuilder)
+    }
 
     /**
      * Compile a parsed [com.linkpoint.assets.MeshData] and attach it to the

--- a/Linkpoint/src/main/java/com/linkpoint/render/prims/PrimRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/prims/PrimRenderer.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import com.google.android.filament.*
 import com.google.android.filament.VertexBuffer.AttributeType
 import com.google.android.filament.VertexBuffer.VertexAttribute
+import com.linkpoint.assets.MeshData
+import com.linkpoint.assets.MeshLOD
 import com.linkpoint.avatar.BakesOnMesh
 import com.linkpoint.diagnostics.ScenePopulationDiagnostics
 import com.linkpoint.protocol.messages.ObjectUpdateData
@@ -45,6 +47,8 @@ class PrimRenderer(
 
     private var defaultMaterial: MaterialInstance? = null
     private val transformManager = engine.transformManager
+    private val pendingMeshLoads = ConcurrentHashMap<Int, UUID>()
+    private val loadedMeshIds = ConcurrentHashMap<Int, UUID>()
 
     /**
      * Optional Bakes-on-Mesh resolver. When set, a TextureEntry face that
@@ -55,9 +59,35 @@ class PrimRenderer(
      */
     @Volatile
     private var bomResolver: ((Int) -> UUID?)? = null
+    @Volatile
+    private var meshDataRequester: MeshDataRequester? = null
+    @Volatile
+    private var meshGeometryBuilder: MeshGeometryBuilder? = null
 
     fun setBomResolver(resolver: ((Int) -> UUID?)?) {
         bomResolver = resolver
+    }
+
+    fun interface MeshDataRequester {
+        fun request(localId: Int, meshId: UUID, lod: MeshLOD, onResolved: (MeshLoadResult) -> Unit)
+    }
+
+    fun interface MeshGeometryBuilder {
+        fun attach(entity: Int, meshData: MeshData, textureEntry: ByteArray)
+    }
+
+    sealed class MeshLoadResult {
+        data class Success(val meshData: MeshData) : MeshLoadResult()
+        data class ParseFailure(val reason: String? = null) : MeshLoadResult()
+        data class MissingAsset(val reason: String? = null) : MeshLoadResult()
+    }
+
+    fun setMeshDataRequester(requester: MeshDataRequester?) {
+        meshDataRequester = requester
+    }
+
+    fun setMeshGeometryBuilder(builder: MeshGeometryBuilder?) {
+        meshGeometryBuilder = builder
     }
     
     /**
@@ -86,17 +116,67 @@ class PrimRenderer(
             return false
         }
 
-        // Mesh-asset prims (extraParams type 0x30, sculptType 5) currently
-        // fall through to the path/profile path so they render as a box
-        // until MeshManager.parseMesh() lands. Logged so we can size the
-        // mesh-prim work later — most modern SL builds are mesh-heavy.
         val meshId = data.getMeshAssetId()
         if (meshId != null) {
-            // TODO: route through MeshManager.getMesh(meshId, LOD), parse
-            //       LLMesh format, build vertex/index buffers, attach via
-            //       RenderableManager.Builder. Tracked as a follow-up.
-            if (data.localId % 50 == 0) {
-                Log.d(TAG, "Mesh-asset prim ${data.localId} (mesh=$meshId) — falling back to path/profile box")
+            val requestChanged = pendingMeshLoads[data.localId] != meshId && loadedMeshIds[data.localId] != meshId
+            if (requestChanged) {
+                pendingMeshLoads[data.localId] = meshId
+                logMeshResolution(
+                    event = "pending_load",
+                    localId = data.localId,
+                    meshId = meshId
+                )
+                val requester = meshDataRequester
+                if (requester == null) {
+                    pendingMeshLoads.remove(data.localId, meshId)
+                    logMeshResolution(
+                        event = "missing_asset",
+                        localId = data.localId,
+                        meshId = meshId,
+                        detail = "mesh_requester_unavailable"
+                    )
+                } else {
+                    val textureEntrySnapshot = data.textureEntry.copyOf()
+                    requester.request(data.localId, meshId, MeshLOD.HIGH) { result ->
+                        when (result) {
+                            is MeshLoadResult.Success -> {
+                                pendingMeshLoads.remove(data.localId, meshId)
+                                loadedMeshIds[data.localId] = meshId
+                                replaceGeometry(data.localId) { entity ->
+                                    val builder = meshGeometryBuilder
+                                    if (builder == null) {
+                                        logMeshResolution(
+                                            event = "missing_asset",
+                                            localId = data.localId,
+                                            meshId = meshId,
+                                            detail = "mesh_geometry_builder_unavailable"
+                                        )
+                                    } else {
+                                        builder.attach(entity, result.meshData, textureEntrySnapshot)
+                                    }
+                                }
+                            }
+                            is MeshLoadResult.ParseFailure -> {
+                                pendingMeshLoads.remove(data.localId, meshId)
+                                logMeshResolution(
+                                    event = "parse_failure",
+                                    localId = data.localId,
+                                    meshId = meshId,
+                                    detail = result.reason
+                                )
+                            }
+                            is MeshLoadResult.MissingAsset -> {
+                                pendingMeshLoads.remove(data.localId, meshId)
+                                logMeshResolution(
+                                    event = "missing_asset",
+                                    localId = data.localId,
+                                    meshId = meshId,
+                                    detail = result.reason
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -150,10 +230,17 @@ class PrimRenderer(
     }
 
     fun removePrim(localId: Int) {
+        pendingMeshLoads.remove(localId)
+        loadedMeshIds.remove(localId)
         prims.remove(localId)?.let { prim ->
             scene.removeEntity(prim.entity)
             engine.destroyEntity(prim.entity)
         }
+    }
+
+    private fun logMeshResolution(event: String, localId: Int, meshId: UUID, detail: String? = null) {
+        val suffix = detail?.let { """, "detail":"$it"""" } ?: ""
+        Log.i(TAG, """{"event":"mesh_asset_resolution","state":"$event","localId":$localId,"meshId":"$meshId"$suffix}""")
     }
     
     /**


### PR DESCRIPTION
### Motivation
- Replace the existing TODO fallback in `PrimRenderer.updatePrim(...)` with a real mesh-resolution flow that requests parsed mesh data and only falls back when load/parse fails.
- Ensure successful mesh parses replace the existing prim renderable on the same entity via the existing `replaceGeometry` flow.
- Add structured logging to distinguish `pending_load`, `parse_failure`, and `missing_asset` states for clearer diagnostics.

### Description
- Introduced `MeshDataRequester` and `MeshGeometryBuilder` interfaces and a `MeshLoadResult` sealed class in `PrimRenderer` to drive async mesh requests and attach parsed geometry.
- Implemented per-prim tracking (`pendingMeshLoads`, `loadedMeshIds`) and structured logging via `logMeshResolution` inside `PrimRenderer`, and call `replaceGeometry(localId, attach)` on successful mesh resolution to rebuild the renderable for the same entity.
- Added `RenderManager.configurePrimMeshPipeline(...)` to store and apply pipeline callbacks and wired the pipeline into `PrimRenderer` when initialized.
- Wired the pipeline in `LinkpointApp` so the requester invokes `meshManager.getMesh(meshId, lod)`, maps outcomes into `Success`/`ParseFailure`/`MissingAsset` using `MeshManager` diagnostics, and the geometry builder compiles and attaches the parsed mesh using `MeshPrimRenderer` and a `TextureBinder`; the old per-update duplicate mesh-fetch/attach block was removed.

### Testing
- Ran `./gradlew -p Linkpoint app:compileDebugKotlin`, which failed due to the build layout in this environment not exposing an `app` project (not an issue with the changes themselves).
- Ran `./gradlew -p Linkpoint projects`, which failed because the Android SDK location is not configured in this environment (`/workspace/Linkpoint/Linkpoint/local.properties` missing), so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0faf70148323aaf120a424f2b6ca)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR replaces the TODO fallback for mesh-asset prims with a complete async mesh resolution pipeline. `PrimRenderer` now defines `MeshDataRequester` and `MeshGeometryBuilder` interfaces along with a `MeshLoadResult` sealed class to request parsed mesh data, track load state, and replace geometry on success. The pipeline is wired through `RenderManager.configurePrimMeshPipeline` and integrated in `LinkpointApp`, where the requester fetches mesh data via `MeshManager`, distinguishes parse failures from missing assets using diagnostics, and the builder attaches compiled meshes with texture binding. Structured JSON logging tracks `pending_load`, `parse_failure`, and `missing_asset` states, and the old duplicate mesh-fetch block in `LinkpointApp` has been removed in favor of this centralized pipeline.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/prims/PrimRenderer.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->