### PR TITLE
Route prim baseColorMap binding through TextureManager with BoM resolution

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -1460,6 +1460,25 @@ class LinkpointApp : Application() {
                     // Add object to scene for rendering using PrimRenderer
                     // PrimRenderer creates actual renderable meshes (box, sphere, etc.)
                     if (::renderManager.isInitialized) {
+                        renderManager.getPrimRenderer()?.apply {
+                            setBomResolver { slot ->
+                                if (::avatarManager.isInitialized) {
+                                    avatarManager.getMyAvatar()?.baker?.getBakedTextures()?.get(slot)
+                                } else null
+                            }
+                            setTextureBinder(com.linkpoint.render.prims.PrimRenderer.TextureBinder { texId, onLoaded ->
+                                if (!::textureManager.isInitialized) return@TextureBinder
+                                applicationScope.launch {
+                                    val bmp = try { textureManager.getTexture(texId) } catch (_: Exception) { null }
+                                    if (bmp != null) {
+                                        renderManager.dispatcher.post(Runnable {
+                                            val pair = renderManager.uploadBitmapAsLinkpointTexture(texId, bmp)
+                                            if (pair != null) onLoaded(pair.first)
+                                        })
+                                    }
+                                }
+                            })
+                        }
                         renderManager.enqueueUpdate(RenderableUpdate.PrimUpdate(update))
                     }
 

--- a/Linkpoint/src/main/java/com/linkpoint/render/prims/PrimRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/prims/PrimRenderer.kt
@@ -8,6 +8,7 @@ import com.linkpoint.avatar.BakesOnMesh
 import com.linkpoint.diagnostics.ScenePopulationDiagnostics
 import com.linkpoint.protocol.messages.ObjectUpdateData
 import com.linkpoint.protocol.messages.PrimShapeParams
+import com.linkpoint.protocol.textures.TextureEntryParser
 import com.linkpoint.protocol.types.LLQuaternion
 import com.linkpoint.protocol.types.LLVector3
 import java.nio.ByteBuffer
@@ -43,7 +44,7 @@ class PrimRenderer(
     // cardinality. Treat them as a uniform-scale or post-process for now.
     private val primMeshes = ConcurrentHashMap<PrimShapeKey, PrimMesh>()
 
-    private var defaultMaterial: MaterialInstance? = null
+    private var defaultMaterial: Material? = null
     private val transformManager = engine.transformManager
 
     /**
@@ -56,15 +57,26 @@ class PrimRenderer(
     @Volatile
     private var bomResolver: ((Int) -> UUID?)? = null
 
+    fun interface TextureBinder {
+        fun bind(textureId: UUID, onLoaded: (Texture) -> Unit)
+    }
+
+    @Volatile
+    private var textureBinder: TextureBinder? = null
+
     fun setBomResolver(resolver: ((Int) -> UUID?)?) {
         bomResolver = resolver
+    }
+
+    fun setTextureBinder(binder: TextureBinder?) {
+        textureBinder = binder
     }
     
     /**
      * Initialize with default material
      */
     fun initialize(material: Material) {
-        defaultMaterial = material.createInstance()
+        defaultMaterial = material
         // Pre-generate the default-shape mesh for each base shape kind so the
         // common case (no path/profile customisation) doesn't tessellate on
         // the first frame after each prim arrives.
@@ -152,6 +164,7 @@ class PrimRenderer(
     fun removePrim(localId: Int) {
         prims.remove(localId)?.let { prim ->
             scene.removeEntity(prim.entity)
+            engine.destroyMaterialInstance(prim.materialInstance)
             engine.destroyEntity(prim.entity)
         }
     }
@@ -173,9 +186,16 @@ class PrimRenderer(
         val shapeKey = PrimShapeKey.from(data.shapeParams)
         val mesh = getOrCreateMesh(shapeKey)
 
-        val material = defaultMaterial ?: throw IllegalStateException(
+        val material = defaultMaterial?.createInstance() ?: throw IllegalStateException(
             "Default material not initialized. Call initialize() first."
         )
+        material.setParameter("baseColor", 1f, 1f, 1f, 1f)
+        material.setParameter("texScale", 1f, 1f)
+        material.setParameter("texOffset", 0f, 0f)
+        material.setParameter("texRotation", 0f)
+        material.setParameter("metallic", 0f)
+        material.setParameter("roughness", 0.5f)
+        material.setParameter("hasTexture", 0f)
 
         // The base mesh is built in unit space (-0.5..0.5 cube envelope). The
         // prim's actual scale comes from the protocol's `scale` vector, so the
@@ -202,7 +222,8 @@ class PrimRenderer(
             position = data.position,
             rotation = data.rotation,
             scale = data.scale,
-            textureEntry = data.textureEntry
+            textureEntry = data.textureEntry,
+            materialInstance = material
         )
     }
 
@@ -1050,9 +1071,28 @@ class PrimRenderer(
                     } else if (BakesOnMesh.isBakeSentinel(defaultTextureId)) {
                         Log.v(TAG, "Prim ${prim.localId} BoM sentinel $defaultTextureId — no resolver")
                     }
-                    // TODO: feed `resolved` into TextureManager.getTexture()
-                    // and bind to the lit material's baseColorMap once that
-                    // sampler param is added to the lit material source.
+                    if (TextureEntryParser.shouldDownload(resolved)) {
+                        textureBinder?.bind(resolved) { tex ->
+                            try {
+                                prim.materialInstance.setParameter(
+                                    "baseColorMap", tex,
+                                    TextureSampler(
+                                        TextureSampler.MinFilter.LINEAR_MIPMAP_LINEAR,
+                                        TextureSampler.MagFilter.LINEAR,
+                                        TextureSampler.WrapMode.REPEAT
+                                    )
+                                )
+                                prim.materialInstance.setParameter("hasTexture", 1f)
+                            } catch (e: Exception) {
+                                prim.materialInstance.setParameter("hasTexture", 0f)
+                                Log.w(TAG, "Failed to bind prim texture ${prim.localId} ($resolved)", e)
+                            }
+                        } ?: run {
+                            prim.materialInstance.setParameter("hasTexture", 0f)
+                        }
+                    } else {
+                        prim.materialInstance.setParameter("hasTexture", 0f)
+                    }
                 }
             }
             
@@ -1072,6 +1112,7 @@ class PrimRenderer(
     fun shutdown() {
         for (prim in prims.values) {
             scene.removeEntity(prim.entity)
+            engine.destroyMaterialInstance(prim.materialInstance)
             engine.destroyEntity(prim.entity)
         }
         prims.clear()
@@ -1082,7 +1123,6 @@ class PrimRenderer(
         }
         primMeshes.clear()
         
-        defaultMaterial?.let { engine.destroyMaterialInstance(it) }
     }
 }
 
@@ -1148,5 +1188,6 @@ data class PrimInstance(
     var position: LLVector3,
     var rotation: LLQuaternion,
     var scale: LLVector3,
-    var textureEntry: ByteArray
+    var textureEntry: ByteArray,
+    val materialInstance: MaterialInstance
 )


### PR DESCRIPTION
### Motivation
- Route prim texture resolution and binding through the existing texture-loading pipeline so BoM sentinels and ordinary texture UUIDs use the same flow and are fetched via `TextureManager.getTexture(...)`.
- Ensure the lit material's `baseColorMap` sampler is used and that per-prim material instances can be updated independently with a safe fallback when a texture is unavailable.

### Description
- Added a `PrimRenderer.TextureBinder` callback and `textureBinder` field to `PrimRenderer` and wired `updatePrimMaterial(...)` to resolve the face texture UUID (including BoM sentinel resolution via `bomResolver`) and request the texture through the binder.
- Switched prims to create a per-prim `MaterialInstance` from the stored `Material` so each prim can set `baseColorMap` and material parameters (`baseColor`, `texScale`, `texOffset`, `texRotation`, `metallic`, `roughness`, `hasTexture`) independently, and cleaned up instances in `removePrim`/`shutdown`.
- When a resolved texture is downloadable (`TextureEntryParser.shouldDownload`), the binder uploads the bitmap via `uploadBitmapAsLinkpointTexture(...)` and the render-thread callback sets the `baseColorMap` sampler with a `TextureSampler` and flips `hasTexture` to `1`; failures set `hasTexture` to `0` as a safe fallback.
- Wired the application object-update flow to provide the `bomResolver` (avatar baked texture lookup) and a `TextureBinder` that calls `TextureManager.getTexture(...)` and uploads the resulting bitmap via the render manager so prims use the centralized texture pipeline.

### Testing
- Attempted to compile the module with `./gradlew :Linkpoint:compileDebugKotlin --no-daemon`, which could not run in this environment due to missing Android SDK configuration (`sdk.dir` / `ANDROID_HOME` not set).
- No runtime or unit tests were executed in this environment due to the build failure; behavior verified by code inspection to ensure the lit material already exposes `baseColorMap` and that `hasTexture` gating logic is present in the material source.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0fb2a6f083239b9a32cd6c6cb0d5)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR routes prim texture binding through the existing `TextureManager` pipeline to ensure Bakes-on-Mesh (BoM) sentinels and regular texture UUIDs use a unified flow. Each prim now creates its own `MaterialInstance` from a shared `Material`, allowing independent texture and material parameter management. The `PrimRenderer` resolves face texture UUIDs (including BoM resolution via `bomResolver`) and requests textures through a new `TextureBinder` callback, which uploads bitmaps and sets the `baseColorMap` sampler on the render thread. The `LinkpointApp` wires the resolver and binder to use `TextureManager.getTexture(...)` and `RenderManager.uploadBitmapAsLinkpointTexture(...)`, centralizing texture loading and handling failures gracefully with a `hasTexture` flag.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/prims/PrimRenderer.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->