### PR TITLE
Refactor voice signaling into orchestrator layer

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/voice/VoiceManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/voice/VoiceManager.kt
@@ -4,11 +4,10 @@ import android.content.Context
 import android.util.Log
 import com.linkpoint.protocol.capabilities.CapabilityManager
 import com.linkpoint.protocol.llsd.*
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
@@ -656,23 +655,18 @@ private class SessionObserver(private val session: VoiceSession) : PeerConnectio
  * gathering surfaced via [localIceCandidates] flow, and remote ICE
  * candidate application via [addRemoteIceCandidate].
  *
- * **What is still TODO** (the signaling layer):
- *   1. POST the local SDP offer to the simulator's WebRTC voice channel
- *      endpoint (`channelUri`) and read back the SDP answer.
- *   2. Trickle local ICE candidates from [localIceCandidates] to the
- *      same endpoint.
- *   3. Receive remote ICE candidates from the same endpoint and feed
- *      them via [addRemoteIceCandidate].
- *
- * That signaling layer needs Linden's WebRTC voice REST shape — easy
- * to add once we can test against a live voice server with a real
- * device. For now the WebRTC primitives are correctly wired so that
- * work can be a focused REST glue layer rather than re-doing SDP/ICE.
+ * Signaling orchestration (offer/answer exchange, local ICE trickle,
+ * and remote ICE ingest/polling) is delegated to a dedicated layer so
+ * transport + REST parsing remain separate from peer-connection state.
  */
 class VoiceSession(
     val channelUri: String,
     @Volatile private var peerConnection: PeerConnection?,
-    private val dispatcher: CoroutineDispatcher
+    private val dispatcher: CoroutineDispatcher,
+    private val signalingOrchestrator: VoiceSignalingOrchestrator = VoiceSignalingOrchestrator(
+        transport = HttpVoiceSignalingTransport(),
+        codec = JsonVoiceSignalingPayloadCodec()
+    )
 ) {
     private var isConnected = false
     private var outputGain = 1.0f
@@ -693,6 +687,8 @@ class VoiceSession(
     )
     /** ICE candidates gathered locally that the signaling layer must relay. */
     val localIceCandidates: SharedFlow<IceCandidate> = _localIceCandidates
+    private val sessionScope = CoroutineScope(dispatcher + SupervisorJob())
+    @Volatile private var signalingJob: Job? = null
 
     fun attachPeerConnection(pc: PeerConnection?) {
         peerConnection = pc
@@ -726,89 +722,21 @@ class VoiceSession(
      * the channel credentials carried as an `Authorization: Bearer ...`
      * header. The response carries `{ "jsep": { "type": "answer",
      * "sdp": "..." } }` with optional initial-candidate trickle data
-     * inside `ice_candidates`. Subsequent local ICE candidates are
-     * trickled via [trickleLocalIceCandidates] which posts each
-     * candidate as it arrives on [localIceCandidates].
+     * inside `ice_candidates`. Subsequent local ICE candidates and
+     * optional remote-candidate polling are handled by the signaling
+     * orchestrator injected into this session.
      *
      * If the SDP offer can't be created (no peer connection) or the
      * POST fails, [isConnected] stays false so callers can fall back
      * to the legacy Vivox path or surface the failure to the user.
      */
     fun connect(uri: String, credentials: String) {
-        kotlinx.coroutines.CoroutineScope(dispatcher).launch {
+        signalingJob?.cancel()
+        signalingJob = sessionScope.launch {
             try {
-                val offerSdp = createOffer()
-                if (offerSdp.isEmpty()) {
-                    android.util.Log.w("VoiceSession", "SDP offer empty; cannot connect to $uri")
-                    return@launch
-                }
-
-                val httpClient = okhttp3.OkHttpClient.Builder()
-                    .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
-                    .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
-                    .build()
-
-                val jsepBody = org.json.JSONObject().apply {
-                    put("jsep", org.json.JSONObject().apply {
-                        put("type", "offer")
-                        put("sdp", offerSdp)
-                    })
-                }.toString()
-
-                val mediaType = "application/json; charset=utf-8".toMediaType()
-                val request = okhttp3.Request.Builder()
-                    .url(uri)
-                    .apply {
-                        if (credentials.isNotEmpty()) header("Authorization", "Bearer $credentials")
-                    }
-                    .post(jsepBody.toRequestBody(mediaType))
-                    .build()
-
-                val response = withContext(kotlinx.coroutines.Dispatchers.IO) {
-                    httpClient.newCall(request).execute()
-                }
-                response.use { resp ->
-                    val bodyString = resp.body?.string().orEmpty()
-                    if (!resp.isSuccessful) {
-                        android.util.Log.w("VoiceSession",
-                            "Voice signaling POST returned HTTP ${resp.code}: ${bodyString.take(256)}")
-                        return@launch
-                    }
-                    val parsed = try {
-                        org.json.JSONObject(bodyString)
-                    } catch (e: Exception) {
-                        android.util.Log.w("VoiceSession", "Voice signaling response not JSON: ${e.message}")
-                        return@launch
-                    }
-                    val jsep = parsed.optJSONObject("jsep")
-                    val answerSdp = jsep?.optString("sdp", "").orEmpty()
-                    if (answerSdp.isEmpty()) {
-                        android.util.Log.w("VoiceSession", "Voice signaling response missing jsep.sdp")
-                        return@launch
-                    }
-                    if (!handleAnswer(answerSdp)) {
-                        android.util.Log.w("VoiceSession", "setRemoteDescription failed for SDP answer")
-                        return@launch
-                    }
-
-                    // Apply any initial ICE candidates from the response.
-                    val initialCandidates = parsed.optJSONArray("ice_candidates")
-                    if (initialCandidates != null) {
-                        for (i in 0 until initialCandidates.length()) {
-                            val c = initialCandidates.optJSONObject(i) ?: continue
-                            val sdpMid = c.optString("sdpMid")
-                            val mLineIdx = c.optInt("sdpMLineIndex", 0)
-                            val candidate = c.optString("candidate")
-                            if (sdpMid.isNotEmpty() && candidate.isNotEmpty()) {
-                                addRemoteIceCandidate(sdpMid, mLineIdx, candidate)
-                            }
-                        }
-                    }
-                }
-
+                signalingOrchestrator.connect(this@VoiceSession, uri, credentials, localIceCandidates)
                 isConnected = true
                 android.util.Log.i("VoiceSession", "Voice signaling complete for $uri")
-                trickleLocalIceCandidates(uri, credentials)
             } catch (e: Exception) {
                 android.util.Log.e("VoiceSession", "Failed to connect to voice channel", e)
                 isConnected = false
@@ -816,48 +744,10 @@ class VoiceSession(
         }
     }
 
-    /**
-     * Stream local ICE candidates to the signaling endpoint as they
-     * arrive on [localIceCandidates]. POSTs each candidate as a JSON
-     * blob `{ "ice_candidate": { "sdpMid": ..., "sdpMLineIndex": ...,
-     * "candidate": "..." } }`. Stops when the session disconnects.
-     */
-    private fun trickleLocalIceCandidates(uri: String, credentials: String) {
-        kotlinx.coroutines.CoroutineScope(dispatcher).launch {
-            val client = okhttp3.OkHttpClient()
-            try {
-                _localIceCandidates.collect { c ->
-                    val jsonBody = org.json.JSONObject().apply {
-                        put("ice_candidate", org.json.JSONObject().apply {
-                            put("sdpMid", c.sdpMid ?: "")
-                            put("sdpMLineIndex", c.sdpMLineIndex)
-                            put("candidate", c.sdp)
-                        })
-                    }.toString()
-                    val req = okhttp3.Request.Builder()
-                        .url(uri)
-                        .apply {
-                            if (credentials.isNotEmpty()) header("Authorization", "Bearer $credentials")
-                        }
-                        .post(jsonBody.toRequestBody("application/json; charset=utf-8".toMediaType()))
-                        .build()
-                    try {
-                        withContext(kotlinx.coroutines.Dispatchers.IO) {
-                            client.newCall(req).execute().use { /* drain body */ }
-                        }
-                    } catch (e: Exception) {
-                        android.util.Log.w("VoiceSession", "ICE trickle POST failed: ${e.message}")
-                    }
-                }
-            } catch (e: Exception) {
-                android.util.Log.d("VoiceSession", "ICE trickle ended: ${e.message}")
-            }
-        }
-    }
-
-
     fun disconnect() {
         try {
+            signalingJob?.cancel()
+            signalingJob = null
             localAudioTrack?.setEnabled(false)
             peerConnection?.close()
             isConnected = false

--- a/Linkpoint/src/main/java/com/linkpoint/voice/VoiceSignalingOrchestrator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/voice/VoiceSignalingOrchestrator.kt
@@ -1,0 +1,224 @@
+package com.linkpoint.voice
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import org.webrtc.IceCandidate
+import java.util.concurrent.TimeUnit
+
+internal data class SignalingIceCandidate(
+    val sdpMid: String,
+    val sdpMLineIndex: Int,
+    val candidate: String
+)
+
+internal data class OfferResponsePayload(
+    val answerSdp: String,
+    val remoteCandidates: List<SignalingIceCandidate>,
+    val pollUri: String?
+)
+
+internal interface VoiceSignalingTransport {
+    suspend fun post(uri: String, credentials: String, body: String): String
+    suspend fun poll(uri: String, credentials: String): String
+}
+
+internal class HttpVoiceSignalingTransport(
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(15, TimeUnit.SECONDS)
+        .build(),
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : VoiceSignalingTransport {
+    override suspend fun post(uri: String, credentials: String, body: String): String = withContext(ioDispatcher) {
+        val req = Request.Builder()
+            .url(uri)
+            .apply {
+                if (credentials.isNotEmpty()) {
+                    header("Authorization", "Bearer $credentials")
+                }
+            }
+            .post(body.toRequestBody("application/json; charset=utf-8".toMediaType()))
+            .build()
+        client.newCall(req).execute().use { resp ->
+            val responseBody = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) {
+                throw IllegalStateException("HTTP ${resp.code}: ${responseBody.take(256)}")
+            }
+            responseBody
+        }
+    }
+
+    override suspend fun poll(uri: String, credentials: String): String = withContext(ioDispatcher) {
+        val req = Request.Builder()
+            .url(uri)
+            .apply {
+                if (credentials.isNotEmpty()) {
+                    header("Authorization", "Bearer $credentials")
+                }
+            }
+            .get()
+            .build()
+        client.newCall(req).execute().use { resp ->
+            val responseBody = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) {
+                throw IllegalStateException("HTTP ${resp.code}: ${responseBody.take(256)}")
+            }
+            responseBody
+        }
+    }
+}
+
+internal interface VoiceSignalingPayloadCodec {
+    fun encodeOffer(offerSdp: String): String
+    fun encodeLocalIce(candidate: IceCandidate): String
+    fun decodeOfferResponse(responseBody: String): OfferResponsePayload
+    fun decodeRemoteIce(responseBody: String): List<SignalingIceCandidate>
+}
+
+internal class JsonVoiceSignalingPayloadCodec : VoiceSignalingPayloadCodec {
+    override fun encodeOffer(offerSdp: String): String = JSONObject().apply {
+        put("jsep", JSONObject().apply {
+            put("type", "offer")
+            put("sdp", offerSdp)
+        })
+    }.toString()
+
+    override fun encodeLocalIce(candidate: IceCandidate): String = JSONObject().apply {
+        put("ice_candidate", JSONObject().apply {
+            put("sdpMid", candidate.sdpMid ?: "")
+            put("sdpMLineIndex", candidate.sdpMLineIndex)
+            put("candidate", candidate.sdp)
+        })
+    }.toString()
+
+    override fun decodeOfferResponse(responseBody: String): OfferResponsePayload {
+        val json = JSONObject(responseBody)
+        val answerSdp = json.optJSONObject("jsep")?.optString("sdp", "").orEmpty()
+        if (answerSdp.isEmpty()) {
+            throw IllegalArgumentException("Voice signaling response missing jsep.sdp")
+        }
+        return OfferResponsePayload(
+            answerSdp = answerSdp,
+            remoteCandidates = decodeCandidates(json),
+            pollUri = json.optString("poll_uri").takeIf { !it.isNullOrBlank() }
+        )
+    }
+
+    override fun decodeRemoteIce(responseBody: String): List<SignalingIceCandidate> {
+        val json = JSONObject(responseBody)
+        return decodeCandidates(json)
+    }
+
+    private fun decodeCandidates(json: JSONObject): List<SignalingIceCandidate> {
+        val candidates = mutableListOf<SignalingIceCandidate>()
+        val array = json.optJSONArray("ice_candidates") ?: return emptyList()
+        for (i in 0 until array.length()) {
+            val candidateObj = array.optJSONObject(i) ?: continue
+            val sdpMid = candidateObj.optString("sdpMid")
+            val candidate = candidateObj.optString("candidate")
+            if (sdpMid.isNotEmpty() && candidate.isNotEmpty()) {
+                candidates.add(
+                    SignalingIceCandidate(
+                        sdpMid = sdpMid,
+                        sdpMLineIndex = candidateObj.optInt("sdpMLineIndex", 0),
+                        candidate = candidate
+                    )
+                )
+            }
+        }
+        return candidates
+    }
+}
+
+internal class VoiceSignalingOrchestrator(
+    private val transport: VoiceSignalingTransport,
+    private val codec: VoiceSignalingPayloadCodec,
+    private val pollIntervalMs: Long = 1_000L
+) {
+    suspend fun connect(
+        session: VoiceSession,
+        channelUri: String,
+        credentials: String,
+        localIceCandidates: SharedFlow<IceCandidate>
+    ) {
+        val offerSdp = session.createOffer()
+        if (offerSdp.isEmpty()) {
+            throw IllegalStateException("SDP offer was empty")
+        }
+
+        val offerResponse = transport.post(
+            uri = channelUri,
+            credentials = credentials,
+            body = codec.encodeOffer(offerSdp)
+        )
+        val offerPayload = codec.decodeOfferResponse(offerResponse)
+        if (!session.handleAnswer(offerPayload.answerSdp)) {
+            throw IllegalStateException("setRemoteDescription failed for SDP answer")
+        }
+        ingestRemoteCandidates(session, offerPayload.remoteCandidates)
+
+        coroutineScope {
+            launchTrickle(this, channelUri, credentials, localIceCandidates)
+            launchPolling(this, session, offerPayload.pollUri, credentials)
+        }
+    }
+
+    private fun ingestRemoteCandidates(session: VoiceSession, candidates: List<SignalingIceCandidate>) {
+        for (candidate in candidates) {
+            session.addRemoteIceCandidate(candidate.sdpMid, candidate.sdpMLineIndex, candidate.candidate)
+        }
+    }
+
+    private fun launchTrickle(
+        scope: kotlinx.coroutines.CoroutineScope,
+        channelUri: String,
+        credentials: String,
+        localIceCandidates: SharedFlow<IceCandidate>
+    ) {
+        scope.launch {
+            localIceCandidates.collect { candidate ->
+                try {
+                    transport.post(
+                        uri = channelUri,
+                        credentials = credentials,
+                        body = codec.encodeLocalIce(candidate)
+                    )
+                } catch (e: Exception) {
+                    android.util.Log.w("VoiceSession", "ICE trickle POST failed: ${e.message}")
+                }
+            }
+        }
+    }
+
+    private fun launchPolling(
+        scope: kotlinx.coroutines.CoroutineScope,
+        session: VoiceSession,
+        pollUri: String?,
+        credentials: String
+    ) {
+        if (pollUri.isNullOrEmpty()) return
+        scope.launch {
+            while (isActive) {
+                try {
+                    val pollResponse = transport.poll(pollUri, credentials)
+                    ingestRemoteCandidates(session, codec.decodeRemoteIce(pollResponse))
+                } catch (e: Exception) {
+                    android.util.Log.w("VoiceSession", "Remote ICE poll failed: ${e.message}")
+                }
+                delay(pollIntervalMs)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Separate signaling transport/REST parsing from peer-connection state so SDP/ICE handling can be unit-tested independently of HTTP details.
- Implement the missing pieces of the signaling contract: POST local offer (`jsep`), trickle local ICE candidates, and ingest remote ICE candidates (initial + polling).
- Make the signaling glue replaceable and testable via explicit transport and payload codec abstractions.

### Description
- Add `VoiceSignalingOrchestrator` (new file `VoiceSignalingOrchestrator.kt`) which orchestrates the offer/answer POST, parses the answer, applies initial remote ICE candidates, launches local ICE trickle from `localIceCandidates`, and optionally polls a `poll_uri` for remote ICE; it runs the orchestration in coroutines.
- Introduce `VoiceSignalingTransport` and `VoiceSignalingPayloadCodec` abstractions with production defaults `HttpVoiceSignalingTransport` and `JsonVoiceSignalingPayloadCodec` to keep transport and JSON parsing testable and injectable.
- Update `VoiceSession` in `VoiceManager.kt` to delegate signaling to the orchestrator by calling `signalingOrchestrator.connect(...)`, add a session coroutine scope and signaling job lifecycle management, and remove inline HTTP/trickle logic so the session focuses on `createOffer`, `handleAnswer`, and `addRemoteIceCandidate`.
- Preserve wire-format expectations (JSON `jsep`/`sdp`, optional `ice_candidates`, optional `poll_uri`) and map them into internal `SignalingIceCandidate` / `OfferResponsePayload` structures.

### Testing
- Attempted to compile Kotlin with `./gradlew :Linkpoint:compileDebugKotlin`; the build failed due to the environment missing Android SDK configuration (`sdk.dir` / `ANDROID_HOME`).
- No other automated tests were run in this environment because compilation could not complete due to the SDK path issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0fb6a9688323ab4fd1fe1a53844c)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extracts WebRTC voice signaling orchestration (SDP offer/answer exchange, local ICE trickling, and remote ICE polling) from `VoiceSession` into a new dedicated `VoiceSignalingOrchestrator` layer. The refactor introduces testable abstractions (`VoiceSignalingTransport` and `VoiceSignalingPayloadCodec`) with production implementations (`HttpVoiceSignalingTransport` and `JsonVoiceSignalingPayloadCodec`) to separate HTTP transport and JSON parsing from peer-connection state management, enabling unit testing of signaling logic independently of REST details and completing the previously missing pieces of the signaling contract.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/voice/VoiceSignalingOrchestrator.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/voice/VoiceManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->