### PR TITLE
Introduce RenderBackend abstraction and delegate WorldViewActivity renderer lifecycle

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/backend/FilamentBackend.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/backend/FilamentBackend.kt
@@ -1,0 +1,46 @@
+package com.linkpoint.render.backend
+
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import com.linkpoint.render.RenderManager
+
+class FilamentBackend(
+    private val renderManager: RenderManager,
+    private val surfaceView: SurfaceView
+) : RenderBackend {
+
+    init {
+        renderManager.initializeOnRenderThread(surfaceView)
+    }
+
+    override fun attachSurface(holder: SurfaceHolder) {
+        renderManager.dispatcher.post(Runnable { renderManager.recreateSwapChain() })
+    }
+
+    override fun onSurfaceChanged(width: Int, height: Int) {
+        renderManager.dispatcher.post(Runnable { renderManager.recreateSwapChain(width, height) })
+    }
+
+    override fun onSurfaceDestroyed() {
+        renderManager.pauseDrawing("surface_destroyed")
+    }
+
+    override fun onResume() {
+        renderManager.dispatcher.post(Runnable {
+            renderManager.resumeDrawing("activity_resumed")
+            renderManager.recreateSwapChain()
+        })
+    }
+
+    override fun onPause() {
+        renderManager.pauseDrawing("activity_paused")
+    }
+
+    override fun renderFrame(frameTimeNanos: Long) {
+        renderManager.renderFrame()
+    }
+
+    override fun shutdown() {
+        renderManager.pauseDrawing("activity_destroyed")
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/backend/OpenGLES3Backend.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/backend/OpenGLES3Backend.kt
@@ -1,0 +1,44 @@
+package com.linkpoint.render.backend
+
+import android.opengl.GLSurfaceView
+import android.view.SurfaceHolder
+import com.linkpoint.render.lumiya.core.LumiyaGLSurfaceView
+
+class OpenGLES3Backend(
+    private val glSurfaceView: LumiyaGLSurfaceView
+) : RenderBackend {
+
+    init {
+        glSurfaceView.renderMode = GLSurfaceView.RENDERMODE_WHEN_DIRTY
+    }
+
+    override fun attachSurface(holder: SurfaceHolder) {
+        // GLSurfaceView owns EGL/surface wiring internally.
+    }
+
+    override fun onSurfaceChanged(width: Int, height: Int) {
+        // Forwarded through GLSurfaceView.Renderer.onSurfaceChanged.
+    }
+
+    override fun onSurfaceDestroyed() {
+        glSurfaceView.queueEvent {
+            glSurfaceView.getRenderer().onSurfaceDestroyed()
+        }
+    }
+
+    override fun onResume() {
+        glSurfaceView.onResume()
+    }
+
+    override fun onPause() {
+        glSurfaceView.onPause()
+    }
+
+    override fun renderFrame(frameTimeNanos: Long) {
+        glSurfaceView.requestRender()
+    }
+
+    override fun shutdown() {
+        glSurfaceView.shutdown()
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/backend/RenderBackend.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/backend/RenderBackend.kt
@@ -1,0 +1,16 @@
+package com.linkpoint.render.backend
+
+import android.view.SurfaceHolder
+
+/**
+ * Backend-agnostic render lifecycle contract used by WorldViewActivity.
+ */
+interface RenderBackend {
+    fun attachSurface(holder: SurfaceHolder)
+    fun onSurfaceChanged(width: Int, height: Int)
+    fun onSurfaceDestroyed()
+    fun onResume()
+    fun onPause()
+    fun renderFrame(frameTimeNanos: Long)
+    fun shutdown()
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
@@ -15,6 +15,9 @@ import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
 import com.linkpoint.render.CameraController
+import com.linkpoint.render.backend.FilamentBackend
+import com.linkpoint.render.backend.OpenGLES3Backend
+import com.linkpoint.render.backend.RenderBackend
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
@@ -62,6 +65,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
     private lateinit var navigationView: NavigationView
     private lateinit var surfaceView: SurfaceView
     private var lumiyaSurfaceView: LumiyaGLSurfaceView? = null
+    private var renderBackend: RenderBackend? = null
     private lateinit var renderContainer: FrameLayout
     
     // HUD elements
@@ -645,38 +649,47 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         useSecondaryRenderer = prefs.getBoolean("enable_secondary_renderer", false)
 
-        if (useSecondaryRenderer) {
-            initSecondaryRenderer()
-            return
+        renderBackend?.shutdown()
+        renderBackend = null
+        isSurfaceReady = false
+        isRendering = false
+
+        val renderView: View = if (useSecondaryRenderer) {
+            LumiyaGLSurfaceView(this).also { glView ->
+                glView.layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT
+                )
+                lumiyaSurfaceView = glView
+                renderBackend = OpenGLES3Backend(glView)
+                android.util.Log.i(TAG, "✓ Secondary Lumiya renderer enabled")
+            }
+        } else {
+            SurfaceView(this).also { filamentSurface ->
+                filamentSurface.layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT
+                )
+                surfaceView = filamentSurface
+                lumiyaSurfaceView = null
+                renderBackend = FilamentBackend(app.renderManager, filamentSurface)
+                android.util.Log.i(TAG, "Initializing RenderManager...")
+            }
         }
 
-        surfaceView = SurfaceView(this).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT
-            )
-        }
         renderContainer.removeAllViews()
-        renderContainer.addView(surfaceView)
-        
-        // Add a callback to ensure SwapChain is created when surface is available
-        surfaceView.holder.addCallback(object : android.view.SurfaceHolder.Callback {
+        renderContainer.addView(renderView)
+
+        renderView.holderOrNull()?.addCallback(object : android.view.SurfaceHolder.Callback {
             override fun surfaceCreated(holder: android.view.SurfaceHolder) {
                 android.util.Log.i(TAG, "╔══════════════════════════════════════════════════════════════════")
                 android.util.Log.i(TAG, "║ ⭐ Surface created - Surface is now ready")
                 android.util.Log.i(TAG, "║ Surface valid: ${holder.surface.isValid}")
                 android.util.Log.i(TAG, "╚══════════════════════════════════════════════════════════════════")
-                
-                // Mark surface as ready (volatile ensures visibility across threads)
+
                 isSurfaceReady = true
-                
-                // Eagerly create SwapChain now that surface is available
-                // This is more efficient than waiting for ensureSwapChain() to detect it on first render frame
-                app.renderManager.dispatcher.post(
-                    Runnable { app.renderManager.recreateSwapChain() }
-                )
-                
-                // Start render loop only if not already rendering (synchronized to avoid race)
+                renderBackend?.attachSurface(holder)
+
                 synchronized(this@WorldViewActivity) {
                     if (!isRendering) {
                         android.util.Log.i(TAG, "✓ Starting render loop now that surface is ready")
@@ -685,36 +698,39 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     }
                 }
             }
-            
+
             override fun surfaceChanged(holder: android.view.SurfaceHolder, format: Int, width: Int, height: Int) {
                 android.util.Log.d(TAG, "Surface changed: ${width}x${height}")
-                // Recreate SwapChain to handle new dimensions or format changes.
-                // Pass the known width/height so the Filament View viewport is
-                // applied from the surface's real dimensions instead of
-                // surfaceView.width (which can still be 0 here on the first
-                // surfaceChanged before the View has been laid out).
                 if (isSurfaceReady) {
-                    app.renderManager.dispatcher.post(
-                        Runnable { app.renderManager.recreateSwapChain(width, height) }
-                    )
+                    renderBackend?.onSurfaceChanged(width, height)
                 }
             }
-            
+
             override fun surfaceDestroyed(holder: android.view.SurfaceHolder) {
                 android.util.Log.w(TAG, "⚠ Surface destroyed - stopping render loop")
-                // Mark surface as not ready first to prevent new render operations
-                // Then stop rendering (volatile + synchronized ensures atomicity)
                 synchronized(this@WorldViewActivity) {
                     isSurfaceReady = false
                     isRendering = false
                 }
+                renderBackend?.onSurfaceDestroyed()
             }
         })
-        
-        // Initialize RenderManager with the SurfaceView
-        android.util.Log.i(TAG, "Initializing RenderManager...")
-        app.renderManager.initializeOnRenderThread(surfaceView)
 
+        if (!useSecondaryRenderer) {
+            wireFilamentDataPipelines()
+            android.util.Log.i(TAG, "✓ RenderManager initialized, waiting for surface to be ready...")
+        }
+    }
+
+    private fun View.holderOrNull(): android.view.SurfaceHolder? {
+        return when (this) {
+            is SurfaceView -> this.holder
+            is LumiyaGLSurfaceView -> this.holder
+            else -> null
+        }
+    }
+
+    private fun wireFilamentDataPipelines() {
         // Connect protocol-side TerrainManager to the now-instantiated
         // TerrainRenderer so incoming LayerData packets actually mesh into
         // visible terrain. No-op if either side isn't ready yet.
@@ -747,14 +763,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     for (avatar in app.avatarManager.getAllAvatars()) {
                         avatar.animator.update(dt)
                         avatar.skeleton.updateBoneMatrices()
-                        // Pose path: drives the articulated capsule
-                        // segment transforms (no-op for system-mesh
-                        // avatars whose bodySegmentBones list is empty).
                         sm.applyAvatarPose(avatar.agentId, avatar.skeleton)
-                        // Skinning path: pushes per-bone skinning matrices
-                        // to Filament so system-mesh avatars deform on
-                        // the GPU. No-op for capsule avatars (the segments
-                        // have no BONE_INDICES attribute).
                         sm.applyAvatarSkinning(avatar.agentId, avatar.skeleton)
                     }
                 }
@@ -762,31 +771,13 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                 android.util.Log.v(TAG, "avatar pose tick error: ${e.message}")
             }
         }
-
-        // Don't start render loop here - wait for surfaceCreated callback
-        android.util.Log.i(TAG, "✓ RenderManager initialized, waiting for surface to be ready...")
     }
 
-    private fun initSecondaryRenderer() {
-        val glView = LumiyaGLSurfaceView(this).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT
-            )
-        }
-        lumiyaSurfaceView = glView
-        renderContainer.removeAllViews()
-        renderContainer.addView(glView)
-        isSurfaceReady = true
-        isRendering = false
-        android.util.Log.i(TAG, "✓ Secondary Lumiya renderer enabled")
-    }
-    
     private fun startRenderLoop() {
         app.renderManager.dispatcher.post(object : Runnable {
             override fun run() {
                 if (isRendering) {
-                    app.renderManager.renderFrame()
+                    renderBackend?.renderFrame(System.nanoTime())
                     app.renderManager.dispatcher.postDelayed(this, 16) // ~60fps
                 }
             }
@@ -994,23 +985,15 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         // destroyed by `UiHelper.onDetachedFromSurface`, which threw a native
         // crash and tripped the auto-restart loop the user observed when
         // opening any panel.
-        if (!useSecondaryRenderer && app.isRenderManagerInitialized()) {
-            app.renderManager.pauseDrawing("activity_paused")
-        }
+        renderBackend?.onPause()
         super.onPause()
         NetworkLogger.log(
             NetworkLogger.Level.INFO,
             NetworkLogger.Category.LIFECYCLE,
             "🌐 WorldViewActivity onPause (renderer=${if (useSecondaryRenderer) "lumiya" else "filament"})"
         )
-        if (useSecondaryRenderer) {
-            lumiyaSurfaceView?.onPause()
-        } else {
-            // Stop the loop too. The drawing gate is the load-bearing guard,
-            // but we don't want the dispatcher posting empty-noop frames at
-            // 60 Hz while the activity is in the background.
-            isRendering = false
-        }
+        // Stop the loop while paused; backend-specific pause has already been delegated.
+        isRendering = false
     }
 
     override fun onResume() {
@@ -1031,32 +1014,12 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
             initRenderer()
         }
 
-        if (useSecondaryRenderer) {
-            lumiyaSurfaceView?.onResume()
-            return
-        }
-
-        // Re-open the drawing gate. Posted to the render thread so it
-        // happens AFTER any pending `recreateSwapChain` from the surface
-        // callback drained, mirroring Lumiya's `queueEvent { enableDrawing() }`
-        // ordering. If the surface isn't back yet, the gate flips here but
-        // `ensureSwapChain` will still no-op until `surfaceCreated` fires —
-        // both paths are safe.
-        if (app.isRenderManagerInitialized()) {
-            app.renderManager.dispatcher.post(
-                Runnable { app.renderManager.resumeDrawing("activity_resumed") }
-            )
-        }
+        renderBackend?.onResume()
 
         // Only restart rendering if surface is ready (synchronized to avoid race)
         synchronized(this) {
             if (isSurfaceReady && !isRendering) {
                 android.util.Log.i(TAG, "onResume: Restarting render loop")
-                // Ensure SwapChain is recreated - it may have been destroyed when activity was paused
-                // The UiHelper may have called onDetachedFromSurface() while we were paused
-                app.renderManager.dispatcher.post(
-                    Runnable { app.renderManager.recreateSwapChain() }
-                )
                 isRendering = true
                 startRenderLoop()
             } else if (!isSurfaceReady) {
@@ -1067,11 +1030,9 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
     
     override fun onDestroy() {
         super.onDestroy()
-        if (useSecondaryRenderer) {
-            lumiyaSurfaceView?.shutdown()
-            lumiyaSurfaceView = null
-        } else {
-            isRendering = false
-        }
+        renderBackend?.shutdown()
+        renderBackend = null
+        lumiyaSurfaceView = null
+        isRendering = false
     }
 }


### PR DESCRIPTION
### Motivation
- Remove renderer-specific branching scattered through `WorldViewActivity` and provide a backend-agnostic contract so multiple rendering engines (Filament, Lumiya GL) can be plugged in and managed uniformly.
- Encapsulate lifecycle and surface/SWAP chain coordination for Filament and GL renderers to reduce duplication and race-prone code paths.

### Description
- Add `com.linkpoint.render.backend.RenderBackend` interface with `attachSurface(holder)`, `onSurfaceChanged(w,h)`, `onSurfaceDestroyed()`, `onResume()`, `onPause()`, `renderFrame(frameTimeNanos)`, and `shutdown()` to define a backend-agnostic lifecycle contract. (new file)
- Implement `FilamentBackend` that wraps `RenderManager` operations (initialize on render thread, recreate swap chain, pause/resume drawing, render frames). (new file)
- Implement `OpenGLES3Backend` that wraps `LumiyaGLSurfaceView`/GL renderer lifecycle (resume/pause, forward surface-destroy, request GL frames, shutdown). (new file)
- Refactor `WorldViewActivity.initRenderer()` to create/select a `RenderBackend` instance, add a common `SurfaceHolder` callback and delegate surface lifecycle events to the active backend, add helper `View.holderOrNull()` and centralize Filament wiring in `wireFilamentDataPipelines()`; update `onPause`, `onResume`, `onDestroy`, and the render loop to delegate to `RenderBackend`. (modified file)

### Testing
- Attempted to compile project via Gradle (`./gradlew projects` / attempted `:app:compileDebugKotlin`) but the build could not be completed in this environment due to missing Android SDK configuration (`SDK location not found`), so no successful compilation or unit test run was possible here.
- Code changes were locally committed (commit message: "Add backend-agnostic renderer lifecycle abstraction") and basic runtime wiring points were exercised by static inspection of the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef102fa90c8323a2941f5fb445a2ca)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a backend-agnostic renderer lifecycle abstraction to eliminate renderer-specific branching throughout `WorldViewActivity`. A new `RenderBackend` interface defines a unified contract for managing lifecycle events (surface attachment, pause/resume, rendering, shutdown) across multiple rendering engines. Two concrete implementations (`FilamentBackend` and `OpenGLES3Backend`) encapsulate the lifecycle and surface coordination for Filament and Lumiya GL renderers respectively. The activity delegates all renderer lifecycle events to the active backend, centralizing surface callbacks and eliminating scattered conditional logic, while Filament-specific data pipeline wiring is moved to a dedicated helper method.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/backend/RenderBackend.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/backend/FilamentBackend.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/render/backend/OpenGLES3Backend.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->