### PR TITLE
Add backend-neutral MaterialDescriptor and translators (Filament + GLES) with BoM handling

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -1478,34 +1478,40 @@ class LinkpointApp : Application() {
                                 null
                             }
                             if (meshData != null) {
-                                // TextureBinder: per face, BoM-resolve the
-                                // texture UUID, fetch via TextureManager,
-                                // hop to the render thread and call onLoaded.
+                                // TextureBinder: fetch already-resolved per-face
+                                // texture UUID and return Texture? (null keeps
+                                // the same baseColor/alpha fallback in both backends).
                                 val binder = com.linkpoint.render.prims.MeshPrimRenderer.TextureBinder { _, texId, onLoaded ->
-                                    val resolvedId = if (::avatarManager.isInitialized) {
-                                        com.linkpoint.avatar.BakesOnMesh.resolve(texId) { slot ->
-                                            avatarManager.getMyAvatar()?.baker?.getBakedTextures()?.get(slot)
-                                        }
-                                    } else texId
-                                    if (!com.linkpoint.protocol.textures.TextureEntryParser.shouldDownload(resolvedId)) return@TextureBinder
-                                    if (!::textureManager.isInitialized) return@TextureBinder
+                                    if (!::textureManager.isInitialized) {
+                                        onLoaded(null)
+                                        return@TextureBinder
+                                    }
                                     applicationScope.launch {
-                                        val bmp = try { textureManager.getTexture(resolvedId) } catch (_: Exception) { null }
+                                        val bmp = try { textureManager.getTexture(texId) } catch (_: Exception) { null }
                                         if (bmp != null) {
                                             renderManager.dispatcher.post(Runnable {
                                                 // Route through the LinkpointTexture-tracked path so
                                                 // every per-face mesh texture participates in VRAM
                                                 // accounting and gets a clean Filament release path.
-                                                val pair = renderManager.uploadBitmapAsLinkpointTexture(resolvedId, bmp)
-                                                if (pair != null) onLoaded(pair.first)
+                                                val pair = renderManager.uploadBitmapAsLinkpointTexture(texId, bmp)
+                                                onLoaded(pair?.first)
                                             })
+                                        } else {
+                                            renderManager.dispatcher.post(Runnable { onLoaded(null) })
                                         }
                                     }
+                                }
+                                val bomResolver: (UUID) -> UUID = { declaredId ->
+                                    if (::avatarManager.isInitialized) {
+                                        com.linkpoint.avatar.BakesOnMesh.resolve(declaredId) { slot ->
+                                            avatarManager.getMyAvatar()?.baker?.getBakedTextures()?.get(slot)
+                                        }
+                                    } else declaredId
                                 }
                                 renderManager.dispatcher.post(Runnable {
                                     renderManager.attachMeshAsset(
                                         update.localId, meshData,
-                                        textureEntrySnapshot, binder
+                                        textureEntrySnapshot, binder, bomResolver
                                     )
                                 })
                             }

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -1021,7 +1021,8 @@ class RenderManager(private val context: Context) {
         localId: Int,
         meshData: com.linkpoint.assets.MeshData,
         textureEntry: ByteArray? = null,
-        binder: com.linkpoint.render.prims.MeshPrimRenderer.TextureBinder? = null
+        binder: com.linkpoint.render.prims.MeshPrimRenderer.TextureBinder? = null,
+        bomResolver: ((java.util.UUID) -> java.util.UUID)? = null
     ) {
         requireRenderThread("attachMeshAsset")
         val mp = meshPrimRenderer ?: return
@@ -1032,7 +1033,7 @@ class RenderManager(private val context: Context) {
                 val inst = rm.getInstance(entity)
                 if (inst != 0) rm.destroy(entity)
             }
-            mp.attach(entity, compiled, textureEntry, binder)
+            mp.attach(entity, compiled, textureEntry, binder, bomResolver)
         }
     }
 

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt
@@ -4,6 +4,8 @@ import android.opengl.GLES32
 import android.opengl.Matrix
 import com.linkpoint.render.lumiya.core.LumiyaRenderContext
 import com.linkpoint.render.lumiya.glres.GLBufferManager
+import com.linkpoint.render.materials.GlesMaterialTranslator
+import com.linkpoint.render.materials.MaterialDescriptor
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -76,14 +78,11 @@ class DrawablePrimStore {
         for (prim in prims.values) {
             if (prim.isTransparent) continue
             program.setModelMatrix(prim.modelMatrix)
-            program.setTexMatrix(prim.texMatrix)
-            program.setColor(prim.colorR, prim.colorG, prim.colorB, prim.colorA)
-            program.setUseTexture(prim.textureHandle != 0)
-            if (prim.textureHandle != 0) {
-                GLES32.glActiveTexture(GLES32.GL_TEXTURE0)
-                GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, prim.textureHandle)
-                program.setTextureSampler(0)
-            }
+            GlesMaterialTranslator.apply(
+                program,
+                prim.toMaterialDescriptor(),
+                GlesMaterialTranslator.TextureBindings(baseColorHandle = prim.textureHandle)
+            )
             GLES32.glDrawElements(GLES32.GL_TRIANGLES, boxVAO.indexCount, GLES32.GL_UNSIGNED_SHORT, 0)
         }
         GLES32.glBindVertexArray(0)
@@ -108,17 +107,28 @@ class DrawablePrimStore {
         GLES32.glBindVertexArray(boxVAO.vao)
         for (prim in sorted) {
             program.setModelMatrix(prim.modelMatrix)
-            program.setTexMatrix(prim.texMatrix)
-            program.setColor(prim.colorR, prim.colorG, prim.colorB, prim.colorA)
-            program.setUseTexture(prim.textureHandle != 0)
-            if (prim.textureHandle != 0) {
-                GLES32.glActiveTexture(GLES32.GL_TEXTURE0)
-                GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, prim.textureHandle)
-                program.setTextureSampler(0)
-            }
+            GlesMaterialTranslator.apply(
+                program,
+                prim.toMaterialDescriptor(),
+                GlesMaterialTranslator.TextureBindings(baseColorHandle = prim.textureHandle)
+            )
             GLES32.glDrawElements(GLES32.GL_TRIANGLES, boxVAO.indexCount, GLES32.GL_UNSIGNED_SHORT, 0)
         }
         GLES32.glBindVertexArray(0)
+    }
+
+    private fun PrimInstance.toMaterialDescriptor(): MaterialDescriptor {
+        return MaterialDescriptor(
+            baseColor = MaterialDescriptor.Float4(colorR, colorG, colorB, colorA),
+            baseColorTexture = if (textureHandle != 0) {
+                // GLES path receives GL handles, not UUIDs.
+                MaterialDescriptor.TextureRef(
+                    java.util.UUID(0L, 0L),
+                    java.util.UUID(0L, 0L),
+                    isDownloadable = true
+                )
+            } else null
+        )
     }
 
     // ── Shared shape geometry ────────────────────────────────────────────

--- a/Linkpoint/src/main/java/com/linkpoint/render/materials/FilamentMaterialTranslator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/materials/FilamentMaterialTranslator.kt
@@ -1,0 +1,50 @@
+package com.linkpoint.render.materials
+
+import com.google.android.filament.MaterialInstance
+import com.google.android.filament.Texture
+import com.google.android.filament.TextureSampler
+
+/** Converts [MaterialDescriptor] into Filament MaterialInstance parameters. */
+object FilamentMaterialTranslator {
+
+    private val REPEAT_SAMPLER = TextureSampler(
+        TextureSampler.MinFilter.LINEAR_MIPMAP_LINEAR,
+        TextureSampler.MagFilter.LINEAR,
+        TextureSampler.WrapMode.REPEAT
+    )
+
+    data class TextureBindings(
+        val baseColor: Texture? = null,
+        val normal: Texture? = null,
+        val metallicRoughness: Texture? = null,
+        val emissive: Texture? = null
+    )
+
+    fun apply(instance: MaterialInstance, descriptor: MaterialDescriptor, bindings: TextureBindings = TextureBindings()) {
+        instance.setParameter(
+            "baseColor",
+            descriptor.baseColor.x,
+            descriptor.baseColor.y,
+            descriptor.baseColor.z,
+            descriptor.baseColor.w
+        )
+        instance.setParameter("texScale", descriptor.uvTransform.scaleS, descriptor.uvTransform.scaleT)
+        instance.setParameter("texOffset", descriptor.uvTransform.offsetS, descriptor.uvTransform.offsetT)
+        instance.setParameter("texRotation", descriptor.uvTransform.rotation)
+        instance.setParameter("metallic", descriptor.metallicFactor)
+        instance.setParameter("roughness", descriptor.roughnessFactor)
+
+        // Explicit missing-texture handling: if base texture is unavailable,
+        // both backends fall back to descriptor baseColor/alpha with hasTexture=0.
+        if (descriptor.baseColorTexture != null && bindings.baseColor != null) {
+            instance.setParameter("baseColorMap", bindings.baseColor, REPEAT_SAMPLER)
+            instance.setParameter("hasTexture", 1f)
+        } else {
+            instance.setParameter("hasTexture", 0f)
+        }
+
+        bindings.normal?.let { instance.setParameter("normalMap", it, REPEAT_SAMPLER) }
+        bindings.metallicRoughness?.let { instance.setParameter("metallicRoughnessMap", it, REPEAT_SAMPLER) }
+        bindings.emissive?.let { instance.setParameter("emissiveMap", it, REPEAT_SAMPLER) }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/materials/GlesMaterialTranslator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/materials/GlesMaterialTranslator.kt
@@ -1,0 +1,46 @@
+package com.linkpoint.render.materials
+
+import android.opengl.GLES32
+import com.linkpoint.render.lumiya.shaders.PrimShaderProgram
+import kotlin.math.cos
+import kotlin.math.sin
+
+/** Converts [MaterialDescriptor] into GLES uniform + texture bindings. */
+object GlesMaterialTranslator {
+
+    data class TextureBindings(
+        val baseColorHandle: Int = 0,
+        val normalHandle: Int = 0,
+        val metallicRoughnessHandle: Int = 0,
+        val emissiveHandle: Int = 0
+    )
+
+    fun apply(program: PrimShaderProgram, descriptor: MaterialDescriptor, bindings: TextureBindings = TextureBindings()) {
+        program.setColor(
+            descriptor.baseColor.x,
+            descriptor.baseColor.y,
+            descriptor.baseColor.z,
+            descriptor.baseColor.w
+        )
+        program.setTexMatrix(buildTexMatrix(descriptor.uvTransform))
+
+        val useTexture = descriptor.baseColorTexture != null && bindings.baseColorHandle != 0
+        program.setUseTexture(useTexture)
+        if (useTexture) {
+            GLES32.glActiveTexture(GLES32.GL_TEXTURE0)
+            GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, bindings.baseColorHandle)
+            program.setTextureSampler(0)
+        }
+    }
+
+    private fun buildTexMatrix(uv: MaterialDescriptor.UvTransform): FloatArray {
+        val c = cos(uv.rotation)
+        val s = sin(uv.rotation)
+        return floatArrayOf(
+            uv.scaleS * c,  uv.scaleS * -s, 0f, 0f,
+            uv.scaleT * s,  uv.scaleT * c,  0f, 0f,
+            0f,             0f,             1f, 0f,
+            uv.offsetS,     uv.offsetT,     0f, 1f
+        )
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/materials/MaterialDescriptor.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/materials/MaterialDescriptor.kt
@@ -1,0 +1,45 @@
+package com.linkpoint.render.materials
+
+import com.linkpoint.protocol.textures.TextureEntryParser
+import java.util.UUID
+
+/** Backend-neutral material payload used by both Filament and GLES paths. */
+data class MaterialDescriptor(
+    val baseColor: Float4,
+    val baseColorTexture: TextureRef? = null,
+    val alphaMode: AlphaMode = AlphaMode.BLEND,
+    val normalTexture: TextureRef? = null,
+    val metallicRoughnessTexture: TextureRef? = null,
+    val metallicFactor: Float = 0f,
+    val roughnessFactor: Float = 0.5f,
+    val emissiveTexture: TextureRef? = null,
+    val emissiveFactor: Float3 = Float3.ZERO,
+    val uvTransform: UvTransform = UvTransform.IDENTITY
+) {
+    enum class AlphaMode { OPAQUE, MASK, BLEND }
+
+    data class TextureRef(
+        /** UUID on the object face (can be BoM sentinel). */
+        val declaredId: UUID,
+        /** Final UUID after BoM resolution (or declaredId when not BoM). */
+        val resolvedId: UUID,
+        /** True iff resolvedId is expected to be fetchable from the asset CDN. */
+        val isDownloadable: Boolean = TextureEntryParser.shouldDownload(resolvedId)
+    )
+
+    data class Float3(val x: Float, val y: Float, val z: Float) {
+        companion object { val ZERO = Float3(0f, 0f, 0f) }
+    }
+
+    data class Float4(val x: Float, val y: Float, val z: Float, val w: Float)
+
+    data class UvTransform(
+        val scaleS: Float,
+        val scaleT: Float,
+        val offsetS: Float,
+        val offsetT: Float,
+        val rotation: Float
+    ) {
+        companion object { val IDENTITY = UvTransform(1f, 1f, 0f, 0f, 0f) }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/prims/MeshPrimRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/prims/MeshPrimRenderer.kt
@@ -7,6 +7,8 @@ import com.google.android.filament.VertexBuffer.VertexAttribute
 import com.linkpoint.assets.MeshData
 import com.linkpoint.assets.MeshFace
 import com.linkpoint.protocol.textures.TextureEntryParser
+import com.linkpoint.render.materials.FilamentMaterialTranslator
+import com.linkpoint.render.materials.MaterialDescriptor
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.UUID
@@ -53,7 +55,7 @@ class MeshPrimRenderer(
      * frames; the binder doesn't need to hold the reference.
      */
     fun interface TextureBinder {
-        fun bind(face: Int, textureId: UUID, onLoaded: (Texture) -> Unit)
+        fun bind(face: Int, textureId: UUID, onLoaded: (Texture?) -> Unit)
     }
 
     private val compiled = ConcurrentHashMap<UUID, CompiledMesh>()
@@ -108,7 +110,8 @@ class MeshPrimRenderer(
         entity: Int,
         mesh: CompiledMesh,
         textureEntry: ByteArray? = null,
-        binder: TextureBinder? = null
+        binder: TextureBinder? = null,
+        bomResolver: ((UUID) -> UUID)? = null
     ) {
         val mat = litMaterial ?: return
         // Drop any prior per-face material instances for this entity so
@@ -129,26 +132,9 @@ class MeshPrimRenderer(
             .receiveShadows(true)
             .castShadows(true)
         for (i in 0 until faceCount) {
-            val faceProps = perFace?.getOrNull(i)
+            val descriptor = buildDescriptor(perFace?.getOrNull(i), bomResolver)
             val instance = mat.createInstance().apply {
-                if (faceProps != null) {
-                    setParameter("baseColor",
-                        faceProps.colorR, faceProps.colorG,
-                        faceProps.colorB, faceProps.colorA)
-                    setParameter("texScale", faceProps.scaleS, faceProps.scaleT)
-                    setParameter("texOffset", faceProps.offsetS, faceProps.offsetT)
-                    setParameter("texRotation", faceProps.rotation)
-                } else {
-                    setParameter("baseColor", 0.8f, 0.8f, 0.8f, 1f)
-                    setParameter("texScale", 1f, 1f)
-                    setParameter("texOffset", 0f, 0f)
-                    setParameter("texRotation", 0f)
-                }
-                setParameter("metallic", 0f)
-                setParameter("roughness", 0.5f)
-                // Default to "no texture"; the binder flips this to 1.0 when
-                // it sets the actual sampler.
-                setParameter("hasTexture", 0f)
+                FilamentMaterialTranslator.apply(this, descriptor)
             }
             instances.add(instance)
             builder.geometry(
@@ -166,25 +152,61 @@ class MeshPrimRenderer(
         if (perFace != null && binder != null) {
             for (i in 0 until faceCount) {
                 val faceProps = perFace[i] ?: continue
-                val texId = faceProps.textureId
-                if (texId == UUID(0L, 0L)) continue
+                val descriptor = buildDescriptor(faceProps, bomResolver)
+                val texRef = descriptor.baseColorTexture ?: continue
+                if (!texRef.isDownloadable) continue
                 val instance = instances[i]
-                binder.bind(i, texId) { tex ->
+                binder.bind(i, texRef.resolvedId) { tex ->
                     try {
-                        instance.setParameter("baseColorMap", tex,
-                            TextureSampler(
-                                TextureSampler.MinFilter.LINEAR_MIPMAP_LINEAR,
-                                TextureSampler.MagFilter.LINEAR,
-                                TextureSampler.WrapMode.REPEAT
-                            )
+                        FilamentMaterialTranslator.apply(
+                            instance,
+                            descriptor,
+                            FilamentMaterialTranslator.TextureBindings(baseColor = tex)
                         )
-                        instance.setParameter("hasTexture", 1f)
                     } catch (e: Exception) {
                         Log.w(TAG, "bind face $i failed: ${e.message}")
                     }
                 }
             }
         }
+    }
+
+    private fun buildDescriptor(
+        faceProps: TextureEntryParser.FaceProperties?,
+        bomResolver: ((UUID) -> UUID)?
+    ): MaterialDescriptor {
+        if (faceProps == null) {
+            return MaterialDescriptor(
+                baseColor = MaterialDescriptor.Float4(0.8f, 0.8f, 0.8f, 1f),
+                uvTransform = MaterialDescriptor.UvTransform.IDENTITY,
+                metallicFactor = 0f,
+                roughnessFactor = 0.5f
+            )
+        }
+        val declared = faceProps.textureId
+        val textureRef = if (declared != UUID(0L, 0L)) {
+            val resolved = bomResolver?.invoke(declared) ?: declared
+            MaterialDescriptor.TextureRef(declaredId = declared, resolvedId = resolved)
+        } else null
+        return MaterialDescriptor(
+            baseColor = MaterialDescriptor.Float4(
+                faceProps.colorR, faceProps.colorG, faceProps.colorB, faceProps.colorA
+            ),
+            baseColorTexture = textureRef,
+            alphaMode = if (faceProps.colorA < 0.999f) {
+                MaterialDescriptor.AlphaMode.BLEND
+            } else {
+                MaterialDescriptor.AlphaMode.OPAQUE
+            },
+            metallicFactor = 0f,
+            roughnessFactor = 0.5f,
+            emissiveFactor = MaterialDescriptor.Float3.ZERO,
+            uvTransform = MaterialDescriptor.UvTransform(
+                faceProps.scaleS, faceProps.scaleT,
+                faceProps.offsetS, faceProps.offsetT,
+                faceProps.rotation
+            )
+        )
     }
 
     private fun uploadFace(face: MeshFace): Pair<VertexBuffer, IndexBuffer>? {


### PR DESCRIPTION
### Motivation
- Provide a single, backend-neutral material model so both Filament and GLES render paths share the same material semantics (base color, alpha, UV transform, PBR/emissive, and BoM-aware texture resolution).
- Ensure mesh/face binding constructs the material once and reuses it for initial setup and async texture arrival, removing duplicated per-backend logic and keeping fallback behavior identical.
- Support BoM (Bakes-on-Mesh) by carrying both declared and resolved texture UUIDs so mesh code can request the correct CDN asset.

### Description
- Add `MaterialDescriptor` with `baseColor`, `baseColorTexture` (declared + resolved IDs), `alphaMode`, `normal`/`metallicRoughness`/`emissive` refs, `metallicFactor`/`roughnessFactor`, and `UvTransform` (`Linkpoint/src/main/java/com/linkpoint/render/materials/MaterialDescriptor.kt`).
- Implement `FilamentMaterialTranslator` to map a `MaterialDescriptor` into a Filament `MaterialInstance` (parameters + `TextureSampler`) and explicit missing-texture handling (`hasTexture = 0` when missing) (`Linkpoint/src/main/java/com/linkpoint/render/materials/FilamentMaterialTranslator.kt`).
- Implement `GlesMaterialTranslator` to set GLSL uniform values and bind GL textures for the Lumiya GLES shader path, including building the UV transform matrix and using the descriptor's texture presence to set `uUseTexture` (`Linkpoint/src/main/java/com/linkpoint/render/materials/GlesMaterialTranslator.kt`).
- Refactor mesh binding in `MeshPrimRenderer.attach` to build a single `MaterialDescriptor` per face (`buildDescriptor`) and reuse it for initial Filament instance creation and later async texture updates; the binder callback now accepts a nullable `Texture?` to explicitly indicate missing uploads (`Linkpoint/src/main/java/com/linkpoint/render/prims/MeshPrimRenderer.kt`).
- Extend `RenderManager.attachMeshAsset` to accept a `bomResolver` and thread the resolver through to `MeshPrimRenderer.attach` (`Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt`).
- Update object/mesh flow in `LinkpointApp` to supply a `bomResolver`, to use the binder with nullable texture results, and to ensure fallback behaviour when textures fail to fetch/upload (`Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt`).
- Route Lumiya prim draw code through `GlesMaterialTranslator` and add a lightweight `PrimInstance.toMaterialDescriptor()` so GLES draws follow the same fallback rules as Filament (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt`).

### Testing
- Ran an attempted Kotlin build: `./gradlew :Linkpoint:compileDebugKotlin`; this failed in the current environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties` `sdk.dir`), so no successful compile/test could be completed here.
- Local static checks: project files compile locally (not in this environment) was the intended verification path; CI / developer machine should run `./gradlew assembleDebug` or `./gradlew :Linkpoint:compileDebugKotlin` after SDK setup to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef105032c0832385df89f1a02fa98b)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a backend-neutral `MaterialDescriptor` abstraction to unify material handling across both Filament and GLES rendering paths. The new descriptor carries base color, alpha mode, UV transforms, PBR properties, and both declared and resolved texture UUIDs to support *Bakes-on-Mesh* (BoM) texture resolution. Two translator classes (`FilamentMaterialTranslator` and `GlesMaterialTranslator`) convert the descriptor into backend-specific parameters, eliminating duplicated logic and ensuring consistent fallback behavior when textures are missing. The mesh binding flow now constructs a single `MaterialDescriptor` per face and reuses it for both initial setup and async texture arrival, with BoM resolution handled by a `bomResolver` lambda threaded from `LinkpointApp` through `RenderManager` to `MeshPrimRenderer`.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/materials/MaterialDescriptor.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/materials/FilamentMaterialTranslator.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/render/materials/GlesMaterialTranslator.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/render/prims/MeshPrimRenderer.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced mesh asset texture handling with improved support for Bakes on Mesh resolution during rendering.
  
* **Refactor**
  * Reorganized texture binding and material application logic for improved performance and maintainability across rendering backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->