### PR TITLE
Introduce FrameScheduler and centralize pre-render phase across backends

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/FrameScheduler.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/FrameScheduler.kt
@@ -1,0 +1,79 @@
+package com.linkpoint.render
+
+import android.view.Choreographer
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Drives frame pacing from a single timing source and fans out to:
+ *  1) pre-render callbacks (simulation/camera sampling)
+ *  2) the currently active backend dispatcher (Filament or GLES)
+ */
+class FrameScheduler(
+    private val timingSource: FrameTimingSource = ChoreographerTimingSource()
+) {
+
+    private val running = AtomicBoolean(false)
+    private val preRenderCallbacks = CopyOnWriteArrayList<(Long) -> Unit>()
+    @Volatile
+    private var backendDispatcher: ((Long) -> Unit)? = null
+
+    private val frameListener: (Long) -> Unit = { frameTimeNanos ->
+        if (running.get()) {
+            preRenderCallbacks.forEach { it.invoke(frameTimeNanos) }
+            backendDispatcher?.invoke(frameTimeNanos)
+            if (running.get()) {
+                timingSource.requestFrame(frameListener)
+            }
+        }
+    }
+
+    fun setBackendDispatcher(dispatcher: ((Long) -> Unit)?) {
+        backendDispatcher = dispatcher
+    }
+
+    fun addPreRenderCallback(callback: (Long) -> Unit) {
+        preRenderCallbacks.add(callback)
+    }
+
+    fun removePreRenderCallback(callback: (Long) -> Unit) {
+        preRenderCallbacks.remove(callback)
+    }
+
+    fun clearPreRenderCallbacks() {
+        preRenderCallbacks.clear()
+    }
+
+    fun start() {
+        if (running.compareAndSet(false, true)) {
+            timingSource.requestFrame(frameListener)
+        }
+    }
+
+    fun stop() {
+        if (running.compareAndSet(true, false)) {
+            timingSource.cancelFrame(frameListener)
+        }
+    }
+}
+
+interface FrameTimingSource {
+    fun requestFrame(callback: (Long) -> Unit)
+    fun cancelFrame(callback: (Long) -> Unit)
+}
+
+class ChoreographerTimingSource : FrameTimingSource {
+    private val callbackMap = mutableMapOf<(Long) -> Unit, Choreographer.FrameCallback>()
+
+    override fun requestFrame(callback: (Long) -> Unit) {
+        val frameCallback = callbackMap.getOrPut(callback) {
+            Choreographer.FrameCallback { frameTimeNanos -> callback.invoke(frameTimeNanos) }
+        }
+        Choreographer.getInstance().postFrameCallback(frameCallback)
+    }
+
+    override fun cancelFrame(callback: (Long) -> Unit) {
+        val frameCallback = callbackMap.remove(callback) ?: return
+        Choreographer.getInstance().removeFrameCallback(frameCallback)
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -844,15 +844,19 @@ class RenderManager(private val context: Context) {
      * endFrame` triplet, but the queue draining + camera/avatar pose
      * tick still run so the world keeps simulating in the background.
      */
-    fun renderFrame() {
+    fun runPreRenderPhase(frameTimeNanos: Long) {
+        requireRenderThread("runPreRenderPhase")
+        if (!isInitialized) return
+        applyRenderUpdates()
+        applyCameraController()
+        avatarPoseProvider?.invoke()
+    }
+
+    fun renderFrame(frameTimeNanos: Long = System.nanoTime()) {
         requireRenderThread("renderFrame")
         if (!isInitialized) return
 
         try {
-            applyRenderUpdates()
-            applyCameraController()
-            avatarPoseProvider?.invoke()
-
             if (!drawingEnabled.get()) return
 
             val engine = this.engine ?: return
@@ -860,7 +864,7 @@ class RenderManager(private val context: Context) {
             val view = this.view ?: return
             val swapChain = ensureSwapChain(engine) ?: return
 
-            if (renderer.beginFrame(swapChain, System.nanoTime())) {
+            if (renderer.beginFrame(swapChain, frameTimeNanos)) {
                 renderer.render(view)
                 renderer.endFrame()
                 val count = frameCount.incrementAndGet()

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaGLSurfaceView.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaGLSurfaceView.kt
@@ -26,6 +26,7 @@ class LumiyaGLSurfaceView @JvmOverloads constructor(
 
     private val lumiyaRenderer = LumiyaRenderer()
     private var surfaceReady = false
+    private var schedulerDriven = false
 
     init {
         // Request GL ES 3.2 context
@@ -66,6 +67,22 @@ class LumiyaGLSurfaceView @JvmOverloads constructor(
     fun getRenderer(): LumiyaRenderer = lumiyaRenderer
 
     fun getEngineProvider(): RenderEngineProvider = lumiyaRenderer
+
+    /**
+     * Switch between legacy continuous GLSurfaceView pacing and scheduler-
+     * driven pacing where each tick maps to [requestRender].
+     */
+    fun setSchedulerDrivenRendering(enabled: Boolean) {
+        schedulerDriven = enabled
+        renderMode = if (enabled) RENDERMODE_WHEN_DIRTY else RENDERMODE_CONTINUOUSLY
+    }
+
+    fun dispatchScheduledFrame(@Suppress("UNUSED_PARAMETER") frameTimeNanos: Long) {
+        if (!surfaceReady) return
+        if (schedulerDriven) {
+            requestRender()
+        }
+    }
 
     override fun onPause() {
         super.onPause()

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
@@ -27,6 +27,7 @@ import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.core.ConnectionState
+import com.linkpoint.render.FrameScheduler
 import com.linkpoint.ui.chat.ChatActivity
 import com.linkpoint.ui.friends.FriendsActivity
 import com.linkpoint.ui.inventory.InventoryActivity
@@ -113,11 +114,20 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
     @Volatile private var isRendering = false
     @Volatile private var isSurfaceReady = false
     private var useSecondaryRenderer: Boolean = false
+    private val frameScheduler = FrameScheduler()
     private var hudsVisibleFromManager: Boolean = true
     private var isLayoutEditorMode: Boolean = false
     
     // Track current orientation setting to avoid unnecessary changes
     private var currentOrientationPref: String? = null
+    private var lastPoseTickMs: Long = System.currentTimeMillis()
+    private val filamentPreRenderCallback: (Long) -> Unit = { frameTimeNanos ->
+        if (!useSecondaryRenderer && isRendering) {
+            app.renderManager.dispatcher.post(
+                Runnable { app.renderManager.runPreRenderPhase(frameTimeNanos) }
+            )
+        }
+    }
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -129,6 +139,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         
         initViews()
         initDebugFloater()
+        frameScheduler.addPreRenderCallback(filamentPreRenderCallback)
         initRenderer()
         setupNavigation()
         setupBackPressHandler()
@@ -681,7 +692,8 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     if (!isRendering) {
                         android.util.Log.i(TAG, "✓ Starting render loop now that surface is ready")
                         isRendering = true
-                        startRenderLoop()
+                        configureSchedulerDispatcher()
+                        frameScheduler.start()
                     }
                 }
             }
@@ -708,6 +720,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     isSurfaceReady = false
                     isRendering = false
                 }
+                frameScheduler.stop()
             }
         })
         
@@ -736,7 +749,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         // skeleton, advance the AvatarAnimator and write the resulting
         // bone matrices into SceneManager so the body segments visibly
         // animate. Cheap: ~1ms even for 30 nearby avatars.
-        var lastPoseTickMs = System.currentTimeMillis()
+        lastPoseTickMs = System.currentTimeMillis()
         app.renderManager.avatarPoseProvider = {
             try {
                 val sm = app.renderManager.getSceneManager()
@@ -777,20 +790,29 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         lumiyaSurfaceView = glView
         renderContainer.removeAllViews()
         renderContainer.addView(glView)
+        glView.setSchedulerDrivenRendering(true)
         isSurfaceReady = true
-        isRendering = false
+        isRendering = true
+        configureSchedulerDispatcher()
+        frameScheduler.start()
         android.util.Log.i(TAG, "✓ Secondary Lumiya renderer enabled")
     }
-    
-    private fun startRenderLoop() {
-        app.renderManager.dispatcher.post(object : Runnable {
-            override fun run() {
+
+    private fun configureSchedulerDispatcher() {
+        if (useSecondaryRenderer) {
+            frameScheduler.setBackendDispatcher { frameTimeNanos ->
                 if (isRendering) {
-                    app.renderManager.renderFrame()
-                    app.renderManager.dispatcher.postDelayed(this, 16) // ~60fps
+                    lumiyaSurfaceView?.dispatchScheduledFrame(frameTimeNanos)
                 }
             }
-        })
+            return
+        }
+        frameScheduler.setBackendDispatcher { frameTimeNanos ->
+            if (!isRendering) return@setBackendDispatcher
+            app.renderManager.dispatcher.post(
+                Runnable { app.renderManager.renderFrame(frameTimeNanos) }
+            )
+        }
     }
     
     private fun setupNavigation() {
@@ -1011,6 +1033,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
             // 60 Hz while the activity is in the background.
             isRendering = false
         }
+        frameScheduler.stop()
     }
 
     override fun onResume() {
@@ -1033,6 +1056,9 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
 
         if (useSecondaryRenderer) {
             lumiyaSurfaceView?.onResume()
+            isRendering = true
+            configureSchedulerDispatcher()
+            frameScheduler.start()
             return
         }
 
@@ -1058,7 +1084,8 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     Runnable { app.renderManager.recreateSwapChain() }
                 )
                 isRendering = true
-                startRenderLoop()
+                configureSchedulerDispatcher()
+                frameScheduler.start()
             } else if (!isSurfaceReady) {
                 android.util.Log.w(TAG, "onResume: Surface not ready yet, will start when ready")
             }
@@ -1073,5 +1100,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         } else {
             isRendering = false
         }
+        frameScheduler.stop()
+        frameScheduler.removePreRenderCallback(filamentPreRenderCallback)
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single timing source to drive frame timestamps and ensure camera sampling and avatar-pose ticks run before any backend GPU work.  
- Remove backend-specific continuous loops and map GLES draws to scheduler ticks so GLSurfaceView behavior matches Filament timing semantics.

### Description
- Added a new `FrameScheduler` abstraction with a `ChoreographerTimingSource` to emit frame timestamps and fan out to pre-render callbacks and an active backend dispatcher (`Linkpoint/src/main/java/com/linkpoint/render/FrameScheduler.kt`).
- Split Filament flow so the simulation/camera sampling and avatar-pose updates run in an explicit pre-render phase `RenderManager.runPreRenderPhase(frameTimeNanos)` and `renderFrame` now accepts the scheduler timestamp (`Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt`).
- Replaced the ad-hoc Filament `postDelayed` loop in `WorldViewActivity` with `FrameScheduler` integration, registering a pre-render callback and setting a backend dispatcher that posts `renderFrame(frameTimeNanos)` for Filament (`Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt`).
- Added scheduler-driven pacing support for the GLES backend in `LumiyaGLSurfaceView` via `setSchedulerDrivenRendering(enabled: Boolean)` and `dispatchScheduledFrame` which maps scheduler ticks to `requestRender()` under `RENDERMODE_WHEN_DIRTY` (`Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaGLSurfaceView.kt`).
- Updated lifecycle handling to start/stop the `FrameScheduler` with surface/create/pause/resume/destroy events so the scheduler is the single owner of frame pacing.

### Testing
- Attempted a Gradle Kotlin compile with `./gradlew :Linkpoint:compileDebugKotlin --no-daemon`, but the build failed because the Android SDK location is not configured in this environment (`ANDROID_HOME` / `local.properties sdk.dir` missing), so no compile or unit tests completed.
- No automated unit tests were executed in this environment due to the SDK configuration issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef105aa43083238f7f5638edae1d05)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a centralized `FrameScheduler` to unify frame timing and pacing across multiple rendering backends (Filament and GLES). The scheduler uses Android's Choreographer as the single timing source, ensuring that pre-render work such as camera sampling and avatar pose updates execute before GPU rendering begins. The refactor replaces backend-specific timing loops with a coordinated approach: pre-render callbacks run first, then the active backend dispatcher posts the actual render frame. Both Filament and the GLES-based Lumiya renderer now receive scheduler-driven ticks, with lifecycle management centralized in `WorldViewActivity` to start and stop frame pacing consistently across surface creation, pause, resume, and destroy events.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/FrameScheduler.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaGLSurfaceView.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->