### PR TITLE
Enforce Filament/GL thread affinity and drain GPU before backend teardown

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -121,7 +121,7 @@ class RenderManager(private val context: Context) {
      * Initialize the rendering engine
      */
     fun initialize(surfaceView: SurfaceView): Boolean {
-        requireRenderThread("initialize")
+        requireFilamentThread("initialize")
         if (isInitialized) {
             // Activity may have created a fresh SurfaceView (e.g. after a renderer
             // toggle or configuration change) while we're already initialized.
@@ -218,6 +218,7 @@ class RenderManager(private val context: Context) {
                             synchronized(swapChainLock) {
                                 swapChain?.let {
                                     Log.d(TAG, "Destroying old SwapChain")
+                                    waitForGpuIdle("native_window_changed")
                                     engine?.destroySwapChain(it)
                                     RenderDiagnostics.filamentSwapChainDestroyed("native_window_changed")
                                 }
@@ -244,6 +245,7 @@ class RenderManager(private val context: Context) {
                             displayHelper?.detach()
                             synchronized(swapChainLock) {
                                 swapChain?.let {
+                                    waitForGpuIdle("surface_lost")
                                     engine?.destroySwapChain(it)
                                     swapChain = null
                                     RenderDiagnostics.filamentSwapChainDestroyed("surface_lost")
@@ -504,7 +506,7 @@ class RenderManager(private val context: Context) {
      * recycled by the caller after this returns.
      */
     fun uploadTerrainDetailTexture(index: Int, bitmap: android.graphics.Bitmap) {
-        requireRenderThread("uploadTerrainDetailTexture")
+        requireFilamentThread("uploadTerrainDetailTexture")
         val eng = engine ?: return
         val tr = terrainRenderer ?: return
         try {
@@ -597,7 +599,10 @@ class RenderManager(private val context: Context) {
         }
         synchronized(swapChainLock) {
             swapChain?.let {
-                try { eng.destroySwapChain(it) } catch (_: Exception) {}
+                try {
+                    waitForGpuIdle("rebuildSwapChainForCurrentSurface")
+                    eng.destroySwapChain(it)
+                } catch (_: Exception) {}
             }
             swapChain = try {
                 eng.createSwapChain(surface)
@@ -746,7 +751,7 @@ class RenderManager(private val context: Context) {
     }
 
     private fun recreateSwapChainInternal(explicitWidth: Int, explicitHeight: Int) {
-        requireRenderThread("recreateSwapChain")
+        requireFilamentThread("recreateSwapChain")
         val engine = this.engine ?: return
         val surface = surfaceView?.holder?.surface ?: run {
             RenderDiagnostics.filamentSwapChainFailed("no surface")
@@ -768,6 +773,7 @@ class RenderManager(private val context: Context) {
             swapChain?.let { oldSwapChain ->
                 Log.i(TAG, "║ Destroying existing SwapChain before recreation")
                 try {
+                    waitForGpuIdle("recreateSwapChain")
                     engine.destroySwapChain(oldSwapChain)
                     RenderDiagnostics.filamentSwapChainDestroyed("recreate")
                 } catch (e: Exception) {
@@ -845,7 +851,7 @@ class RenderManager(private val context: Context) {
      * tick still run so the world keeps simulating in the background.
      */
     fun renderFrame() {
-        requireRenderThread("renderFrame")
+        requireFilamentThread("renderFrame")
         if (!isInitialized) return
 
         try {
@@ -890,7 +896,7 @@ class RenderManager(private val context: Context) {
      * Render a frame in XR mode (stereo rendering)
      */
     fun renderXRFrame(xrData: XRFrameData) {
-        requireRenderThread("renderXRFrame")
+        requireFilamentThread("renderXRFrame")
         if (!isInitialized) return
 
         try {
@@ -1023,7 +1029,7 @@ class RenderManager(private val context: Context) {
         textureEntry: ByteArray? = null,
         binder: com.linkpoint.render.prims.MeshPrimRenderer.TextureBinder? = null
     ) {
-        requireRenderThread("attachMeshAsset")
+        requireFilamentThread("attachMeshAsset")
         val mp = meshPrimRenderer ?: return
         val pr = primRenderer ?: return
         val compiled = mp.getOrCompile(meshData) ?: return
@@ -1052,7 +1058,7 @@ class RenderManager(private val context: Context) {
         uuid: java.util.UUID,
         bitmap: android.graphics.Bitmap
     ): Pair<Texture, com.linkpoint.assets.LinkpointTexture>? {
-        requireRenderThread("uploadBitmapAsLinkpointTexture")
+        requireFilamentThread("uploadBitmapAsLinkpointTexture")
         val eng = engine ?: return null
         val lpTex = com.linkpoint.assets.LinkpointTexture.fromBitmap(uuid, bitmap)
         val tex = lpTex.uploadToFilament(eng) ?: run {
@@ -1075,7 +1081,7 @@ class RenderManager(private val context: Context) {
      * have a UUID (HUD, snapshot preview).
      */
     fun uploadBitmapAsTexture(bitmap: android.graphics.Bitmap): Texture? {
-        requireRenderThread("uploadBitmapAsTexture")
+        requireFilamentThread("uploadBitmapAsTexture")
         val eng = engine ?: return null
         return try {
             val w = bitmap.width
@@ -1136,7 +1142,7 @@ class RenderManager(private val context: Context) {
      * This is the primary entry point for rendering prims from the network.
      */
     fun updatePrim(data: ObjectUpdateData): Boolean {
-        requireRenderThread("updatePrim")
+        requireFilamentThread("updatePrim")
         val renderer = primRenderer ?: return false
         return renderer.updatePrim(data)
     }
@@ -1145,7 +1151,7 @@ class RenderManager(private val context: Context) {
      * Remove a prim by its local ID.
      */
     fun removePrim(localId: Int) {
-        requireRenderThread("removePrim")
+        requireFilamentThread("removePrim")
         primRenderer?.removePrim(localId)
     }
     
@@ -1222,7 +1228,7 @@ class RenderManager(private val context: Context) {
      * Shutdown rendering
      */
     fun shutdown() {
-        requireRenderThread("shutdown")
+        requireFilamentThread("shutdown")
         Log.i(TAG, "Shutting down render manager")
         RenderDiagnostics.filamentShutdown(
             "frames=${frameCount.get()} viewport=${viewportWidth}x${viewportHeight}"
@@ -1241,7 +1247,10 @@ class RenderManager(private val context: Context) {
 
         engine?.let { eng ->
             synchronized(swapChainLock) {
-                swapChain?.let { eng.destroySwapChain(it) }
+                swapChain?.let {
+                    waitForGpuIdle("shutdown")
+                    eng.destroySwapChain(it)
+                }
                 swapChain = null
             }
             view?.let { eng.destroyView(it) }
@@ -1304,12 +1313,22 @@ class RenderManager(private val context: Context) {
         }
     }
 
-    private fun requireRenderThread(apiName: String) {
+    private fun requireFilamentThread(apiName: String) {
         if (!dispatcher.isRenderThread()) {
-            val message = "RenderManager.$apiName must run on render thread (${dispatcher.renderThreadName}); " +
+            val message = "RenderManager.$apiName must run on Filament render thread (${dispatcher.renderThreadName}); " +
                 "current=${Thread.currentThread().name}"
             Log.e(TAG, message)
             throw IllegalStateException(message)
+        }
+    }
+
+    private fun waitForGpuIdle(reason: String) {
+        val eng = engine ?: return
+        try {
+            eng.flushAndWait()
+            Log.d(TAG, "Filament GPU queue drained before teardown: $reason")
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to flush Filament GPU queue ($reason): ${e.message}")
         }
     }
     

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
@@ -20,7 +20,7 @@ import java.nio.FloatBuffer
  * Design lineage:  Lumiya `RenderContext.java`, modernised to GL ES 3.2 with
  * UBOs, VAOs, and structured buffer bindings.
  */
-class LumiyaRenderContext {
+class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null) {
 
     companion object {
         private const val TAG = "LumiyaRenderContext"
@@ -136,9 +136,10 @@ class LumiyaRenderContext {
     // =====================================================================
 
     fun initialize(): Boolean {
+        glThreadGuard?.invoke("initialize")
         return try {
             queryGPUCapabilities()
-            resourceManager = GLResourceManager()
+            resourceManager = GLResourceManager(glThreadGuard)
             frustumCuller = FrustumCuller()
             createGlobalUBO()
             compileShaders()

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
@@ -44,6 +44,9 @@ class LumiyaRenderer : RenderEngineProvider {
 
     private lateinit var ctx: LumiyaRenderContext
 
+    @Volatile private var glThreadId: Long = Long.MIN_VALUE
+    @Volatile private var glThreadName: String = "<unset>"
+
     // Drawable subsystems
     private var terrainDrawable: DrawableTerrain? = null
     private var waterDrawable: DrawableWater? = null
@@ -65,12 +68,13 @@ class LumiyaRenderer : RenderEngineProvider {
     // =====================================================================
 
     override fun initialize(context: Context, surface: Surface, width: Int, height: Int): Boolean {
+        requireGlThread("initialize")
         if (isInitialized) return true
         Log.i(TAG, "Initialising Lumiya renderer ($width x $height)")
 
         val initStartedAt = System.currentTimeMillis()
         try {
-            ctx = LumiyaRenderContext()
+            ctx = LumiyaRenderContext { apiName -> requireGlThread("LumiyaRenderContext.$apiName") }
             if (!ctx.initialize()) {
                 Log.e(TAG, "Render context initialisation failed")
                 RenderDiagnostics.glInitFailed(
@@ -136,6 +140,7 @@ class LumiyaRenderer : RenderEngineProvider {
     }
 
     override fun onSurfaceChanged(width: Int, height: Int) {
+        requireGlThread("onSurfaceChanged")
         viewportWidth = width
         viewportHeight = height
         ctx.aspectRatio = width.toFloat() / height.toFloat()
@@ -146,6 +151,7 @@ class LumiyaRenderer : RenderEngineProvider {
     }
 
     override fun onSurfaceDestroyed() {
+        requireGlThread("onSurfaceDestroyed")
         // Surface lost but engine not destroyed – resources remain valid
         Log.w(TAG, "Surface destroyed")
         RenderDiagnostics.glSurfaceDestroyed()
@@ -156,6 +162,7 @@ class LumiyaRenderer : RenderEngineProvider {
     // =====================================================================
 
     override fun renderFrame() {
+        requireGlThread("renderFrame")
         if (!isInitialized) return
 
         // ── 1. Preparation ───────────────────────────────────────────────
@@ -266,7 +273,15 @@ class LumiyaRenderer : RenderEngineProvider {
     // Shutdown
     // =====================================================================
 
+
+    override fun waitForGpuIdle(reason: String) {
+        requireGlThread("waitForGpuIdle")
+        GLES32.glFinish()
+        Log.d(TAG, "GL queue drained before backend transition: $reason")
+    }
+
     override fun shutdown() {
+        requireGlThread("shutdown")
         if (!isInitialized) return
         Log.i(TAG, "Shutting down Lumiya renderer")
         RenderDiagnostics.glShutdown(
@@ -282,6 +297,22 @@ class LumiyaRenderer : RenderEngineProvider {
         destroyFullScreenQuad()
         ctx.shutdown()
         isInitialized = false
+    }
+
+
+    private fun requireGlThread(apiName: String) {
+        val current = Thread.currentThread()
+        if (glThreadId == Long.MIN_VALUE) {
+            glThreadId = current.id
+            glThreadName = current.name
+            Log.i(TAG, "Bound GL thread affinity to ${current.name} (${current.id})")
+            return
+        }
+        if (current.id != glThreadId) {
+            val message = "LumiyaRenderer.$apiName must run on GL thread $glThreadName ($glThreadId); current=${current.name} (${current.id})"
+            Log.e(TAG, message)
+            throw IllegalStateException(message)
+        }
     }
 
     // =====================================================================

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineProvider.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineProvider.kt
@@ -42,6 +42,12 @@ interface RenderEngineProvider {
     /** Render a single frame.  Must be called on the render thread. */
     fun renderFrame()
 
+    /**
+     * Block until outstanding GPU work completes for this backend.
+     * Must be called on the backend render thread.
+     */
+    fun waitForGpuIdle(reason: String = "unspecified") {}
+
     /** Release all GPU resources.  Must be called on the render thread. */
     fun shutdown()
 

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineSwitcher.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineSwitcher.kt
@@ -136,6 +136,9 @@ class RenderEngineSwitcher(private val context: Context) {
         val previousType = activeType
         Log.i(TAG, "Performing engine switch: ${activeType.name} → ${newType.name}")
 
+        // Drain backend GPU queues before tearing down contexts/surfaces.
+        active?.waitForGpuIdle("switch ${activeType.name} -> ${newType.name}")
+
         // Shutdown old engine
         active?.shutdown()
         active = null

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLBufferManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLBufferManager.kt
@@ -45,6 +45,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
      * @return GL buffer handle.
      */
     fun uploadVertexBuffer(data: FloatArray, usage: Int = GLES32.GL_STATIC_DRAW): Int {
+        resourceManager.assertGlThread("GLBufferManager.uploadVertexBuffer")
         val handle = resourceManager.createBuffer()
         val fb = createFloatBuffer(data)
         GLES32.glBindBuffer(GLES32.GL_ARRAY_BUFFER, handle)
@@ -59,6 +60,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
      * @return GL buffer handle.
      */
     fun uploadIndexBuffer(data: ShortArray, usage: Int = GLES32.GL_STATIC_DRAW): Int {
+        resourceManager.assertGlThread("GLBufferManager.uploadIndexBuffer(short)")
         val handle = resourceManager.createBuffer()
         val sb = createShortBuffer(data)
         GLES32.glBindBuffer(GLES32.GL_ELEMENT_ARRAY_BUFFER, handle)
@@ -69,6 +71,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
     }
 
     fun uploadIndexBuffer(data: IntArray, usage: Int = GLES32.GL_STATIC_DRAW): Int {
+        resourceManager.assertGlThread("GLBufferManager.uploadIndexBuffer(int)")
         val handle = resourceManager.createBuffer()
         val ib = createIntBuffer(data)
         GLES32.glBindBuffer(GLES32.GL_ELEMENT_ARRAY_BUFFER, handle)
@@ -81,6 +84,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
     // ── UBO creation ─────────────────────────────────────────────────────
 
     fun createUniformBuffer(sizeBytes: Int, usage: Int = GLES32.GL_DYNAMIC_DRAW): Int {
+        resourceManager.assertGlThread("GLBufferManager.createUniformBuffer")
         val handle = resourceManager.createBuffer()
         GLES32.glBindBuffer(GLES32.GL_UNIFORM_BUFFER, handle)
         GLES32.glBufferData(GLES32.GL_UNIFORM_BUFFER, sizeBytes, null, usage)
@@ -105,6 +109,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
         indexData: ShortArray,
         attributes: List<Pair<Int, Int>>  // (location, size)
     ): MeshVAO {
+        resourceManager.assertGlThread("GLBufferManager.buildVAO")
         val vao = resourceManager.createVAO()
         val vbo = uploadVertexBuffer(vertexData)
         val ebo = uploadIndexBuffer(indexData)
@@ -131,6 +136,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
         indexData: IntArray,
         attributes: List<Pair<Int, Int>>
     ): MeshVAO {
+        resourceManager.assertGlThread("GLBufferManager.buildVAOInt")
         val vao = resourceManager.createVAO()
         val vbo = uploadVertexBuffer(vertexData)
         val ebo = uploadIndexBuffer(indexData)
@@ -155,6 +161,7 @@ class GLBufferManager(private val resourceManager: GLResourceManager) {
     // ── Cleanup ──────────────────────────────────────────────────────────
 
     fun destroyVAO(mesh: MeshVAO) {
+        resourceManager.assertGlThread("GLBufferManager.destroyVAO")
         resourceManager.deleteVAO(mesh.vao)
         resourceManager.deleteBuffer(mesh.vbo)
         resourceManager.deleteBuffer(mesh.ebo)

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLResourceManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLResourceManager.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
  * cleaned up even if the owner is garbage-collected without an explicit
  * `destroy()` call.  Deferred cleanup runs once per frame on the GL thread.
  */
-class GLResourceManager {
+class GLResourceManager(private val glThreadGuard: ((String) -> Unit)? = null) {
 
     companion object {
         private const val TAG = "GLResourceManager"
@@ -39,30 +39,35 @@ class GLResourceManager {
     // ── Allocation helpers ───────────────────────────────────────────────
 
     fun createTexture(): Int {
+        requireGlThread("createTexture")
         val buf = IntArray(1)
         GLES32.glGenTextures(1, buf, 0)
         return buf[0]
     }
 
     fun createBuffer(): Int {
+        requireGlThread("createBuffer")
         val buf = IntArray(1)
         GLES32.glGenBuffers(1, buf, 0)
         return buf[0]
     }
 
     fun createVAO(): Int {
+        requireGlThread("createVAO")
         val buf = IntArray(1)
         GLES32.glGenVertexArrays(1, buf, 0)
         return buf[0]
     }
 
     fun createFramebuffer(): Int {
+        requireGlThread("createFramebuffer")
         val buf = IntArray(1)
         GLES32.glGenFramebuffers(1, buf, 0)
         return buf[0]
     }
 
     fun createRenderbuffer(): Int {
+        requireGlThread("createRenderbuffer")
         val buf = IntArray(1)
         GLES32.glGenRenderbuffers(1, buf, 0)
         return buf[0]
@@ -89,6 +94,7 @@ class GLResourceManager {
     // ── Per-frame cleanup (call on GL thread) ────────────────────────────
 
     fun cleanup() {
+        requireGlThread("cleanup")
         drainQueue(pendingTextureDeletes) { GLES32.glDeleteTextures(1, intArrayOf(it), 0) }
         drainQueue(pendingBufferDeletes)  { GLES32.glDeleteBuffers(1, intArrayOf(it), 0) }
         drainQueue(pendingVAODeletes)     { GLES32.glDeleteVertexArrays(1, intArrayOf(it), 0) }
@@ -101,12 +107,21 @@ class GLResourceManager {
 
     /** Full flush – destroy everything pending. */
     fun flush() {
+        requireGlThread("flush")
         cleanup()
         synchronized(trackedRefs) { trackedRefs.clear() }
         Log.i(TAG, "Resource manager flushed (allocated ≈ ${allocatedBytes / 1024} KB)")
     }
 
     // ── Internals ────────────────────────────────────────────────────────
+
+    fun assertGlThread(apiName: String) {
+        requireGlThread(apiName)
+    }
+
+    private fun requireGlThread(apiName: String) {
+        glThreadGuard?.invoke("GLResourceManager.$apiName")
+    }
 
     private inline fun drainQueue(queue: ConcurrentLinkedQueue<Int>, delete: (Int) -> Unit) {
         var handle = queue.poll()

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLTextureCache.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLTextureCache.kt
@@ -41,6 +41,7 @@ class GLTextureCache(
 
     /** Upload a bitmap and cache the resulting texture. */
     fun put(id: UUID, bitmap: Bitmap): Int {
+        resourceManager.assertGlThread("GLTextureCache.put")
         // If already cached, return existing
         cache.get(id)?.let { return it.handle }
 
@@ -81,10 +82,12 @@ class GLTextureCache(
     }
 
     fun remove(id: UUID) {
+        resourceManager.assertGlThread("GLTextureCache.remove")
         cache.remove(id)
     }
 
     fun clear() {
+        resourceManager.assertGlThread("GLTextureCache.clear")
         cache.evictAll()
     }
 


### PR DESCRIPTION
### Motivation
- Skills used: `skill-creator` — followed guidance for introducing targeted, reusable thread-guard helpers and wiring them into backend hotspots.
- Prevent undefined cross-thread Filament/GLES calls and hard-to-reproduce crashes by ensuring Filament APIs are only called on the render dispatcher thread and GL ES APIs on the GLSurfaceView GL thread.
- Ensure safe backend transitions by waiting for in-flight GPU work to complete before destroying SwapChains/contexts to avoid driver/engine races and use-after-destroy errors.

### Description
- Added `requireFilamentThread(...)` checks to `RenderManager` entry points (initialize, frame/render, swapchain recreation, texture upload, attach/teardown paths, shutdown) and implemented `waitForGpuIdle(...)` that calls `Engine.flushAndWait()` before destroying SwapChains/contexts. 
- Introduced GL-thread affinity in the Lumiya backend via `requireGlThread(...)` in `LumiyaRenderer`, binding the GL thread on first use and enforcing it in lifecycle/render/shutdown/idle methods.
- Propagated GL-thread guards into Lumiya resource hot paths by wiring a guard into `LumiyaRenderContext` and using it from `GLResourceManager` (allocation/cleanup/flush), `GLBufferManager` (VBO/IBO/VAO/UBO creation & destruction), and `GLTextureCache` (texture upload/remove/clear) to assert GL-thread usage.
- Added `waitForGpuIdle(...)` to `RenderEngineProvider` and invoked it from `RenderEngineSwitcher.performSwitch(...)` so backend switching drains GPU queues before shutting down the previous backend.

### Testing
- Attempted an automated Kotlin compilation with `./gradlew :Linkpoint:compileDebugKotlin`; the build failed due to environment configuration (Android SDK not found via `ANDROID_HOME` / `local.properties`) so compile could not be validated in this CI environment. 
- Verified code-level changes with static inspections and project grep/sed checks to confirm new guards and wait calls are wired into the intended call sites (no runtime tests executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1061c92c8323833e576c10a563d5)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces thread-safety guardrails for dual rendering backends (Filament and Lumiya/OpenGL ES) by enforcing strict thread affinity checks and ensuring GPU work completes before backend teardown. The changes add `requireFilamentThread` guards to all `RenderManager` entry points, introduce GL thread affinity in `LumiyaRenderer` via `requireGlThread`, and propagate these guards into GPU resource management classes (`GLResourceManager`, `GLBufferManager`, `GLTextureCache`). Additionally, `waitForGpuIdle` methods now drain GPU queues (via `Engine.flushAndWait()` for Filament and `glFinish()` for GL) before destroying swap chains or switching backends to prevent race conditions and use-after-destroy errors.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineProvider.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/RenderEngineSwitcher.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLResourceManager.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLBufferManager.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/glres/GLTextureCache.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->