### PR TITLE
Extend render diagnostics with backend/frame/entity/restart metrics and add parity checklist

### DIFF
--- a/Linkpoint/docs/backend-parity-checklist.md
+++ b/Linkpoint/docs/backend-parity-checklist.md
@@ -1,0 +1,40 @@
+# Backend Parity Checklist
+
+This checklist defines **must-pass scenarios** for render backend parity validation (Filament and Lumiya).
+
+## Pass Criteria
+
+- Each scenario is executed on both backends.
+- No crash, ANR, or frozen frame loop.
+- World remains responsive to camera/movement input after scenario completion.
+- Diagnostics show stable frame progression and no unbounded restart loops.
+
+## Must-Pass Scenarios
+
+- [ ] **Login spawn**
+  - Fresh login, initial region handshake, world appears with terrain + nearby content.
+
+- [ ] **Teleport**
+  - Teleport between regions (different simulator), verify scene teardown/reload and resumed rendering.
+
+- [ ] **Crowded region**
+  - Enter a high-avatar/high-prim region and verify avatar + object rendering continuity.
+
+- [ ] **Mesh-heavy region**
+  - Visit a mesh-dense location and validate geometry/material streaming without renderer instability.
+
+- [ ] **HUD overlay**
+  - Enable visible HUD elements, verify overlay rendering and interaction while world continues updating.
+
+- [ ] **Panel open/close**
+  - Repeatedly open/close in-world panels (inventory/chat/settings overlays) and confirm draw pause/resume behavior is correct.
+
+- [ ] **Background/foreground cycle**
+  - Send app to background, return to foreground, verify swapchain/context recovery and continuous rendering.
+
+## Suggested Evidence to Capture Per Scenario
+
+- Active backend and frame-time percentiles from diagnostics.
+- Visible entity counts (avatars/prims/terrain patches).
+- Texture success/failure rates.
+- Swapchain/context restart counters before/after scenario.

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import java.util.ArrayDeque
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
@@ -47,6 +48,7 @@ object RenderDiagnostics {
 
     private const val HEARTBEAT_INTERVAL_MS = 5_000L
     private const val STALL_THRESHOLD_MS = 2_000L
+    private const val FRAME_INTERVAL_HISTORY_LIMIT = 512
 
     /**
      * Last frame-rendered timestamp per subsystem ("Filament", "Lumiya").
@@ -57,6 +59,7 @@ object RenderDiagnostics {
     private val frameCounters = mutableMapOf<String, AtomicLong>()
     private val lastReportedFrameCount = mutableMapOf<String, AtomicLong>()
     private val activeSubsystems = mutableSetOf<String>()
+    private val frameIntervalHistoryMs = mutableMapOf<String, ArrayDeque<Long>>()
 
     private val heartbeatStarted = AtomicBoolean(false)
     private val heartbeatScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -64,6 +67,10 @@ object RenderDiagnostics {
     private val lumiyaUboUploadTimeNsTotal = AtomicLong(0L)
     private val lumiyaUboUploadSamples = AtomicLong(0L)
     private val lumiyaFrameAllocations = AtomicLong(0L)
+    private val filamentSwapChainCreateCount = AtomicLong(0L)
+    private val filamentSwapChainDestroyCount = AtomicLong(0L)
+    private val filamentSwapChainFailureCount = AtomicLong(0L)
+    private val lumiyaContextCreateCount = AtomicLong(0L)
 
     /**
      * Mark a render subsystem as active and ensure the heartbeat ticker
@@ -75,8 +82,24 @@ object RenderDiagnostics {
         lastFrameWallClock.getOrPut(subsystem) { AtomicLong(0) }
         frameCounters.getOrPut(subsystem) { AtomicLong(0) }
         lastReportedFrameCount.getOrPut(subsystem) { AtomicLong(0) }
+        frameIntervalHistoryMs.getOrPut(subsystem) { ArrayDeque() }
         if (heartbeatStarted.compareAndSet(false, true)) {
             startHeartbeat()
+        }
+    }
+
+    @Synchronized
+    private fun recordFrame(subsystem: String) {
+        trackSubsystem(subsystem)
+        val now = System.currentTimeMillis()
+        val previous = lastFrameWallClock[subsystem]?.getAndSet(now) ?: 0L
+        frameCounters[subsystem]?.incrementAndGet()
+        if (previous <= 0L) return
+        val deltaMs = (now - previous).coerceAtLeast(0L)
+        val history = frameIntervalHistoryMs.getOrPut(subsystem) { ArrayDeque() }
+        history.addLast(deltaMs)
+        while (history.size > FRAME_INTERVAL_HISTORY_LIMIT) {
+            history.removeFirst()
         }
     }
 
@@ -176,6 +199,7 @@ object RenderDiagnostics {
     }
 
     fun filamentSwapChainCreated(width: Int, height: Int) {
+        filamentSwapChainCreateCount.incrementAndGet()
         SessionLogRecorder.logRender(
             "Filament",
             "swapchain_created",
@@ -186,11 +210,13 @@ object RenderDiagnostics {
     }
 
     fun filamentSwapChainDestroyed(reason: String) {
+        filamentSwapChainDestroyCount.incrementAndGet()
         SessionLogRecorder.logRender("Filament", "swapchain_destroyed", reason)
         logLifecycle(NetworkLogger.Level.WARN, "🖼️ Filament SwapChain destroyed: $reason")
     }
 
     fun filamentSwapChainFailed(reason: String) {
+        filamentSwapChainFailureCount.incrementAndGet()
         SessionLogRecorder.logRender("Filament", "swapchain_failed", reason)
         logLifecycle(NetworkLogger.Level.ERROR, "🖼️ Filament SwapChain FAILED: $reason")
     }
@@ -214,12 +240,8 @@ object RenderDiagnostics {
     }
 
     fun filamentFrame() {
-        val counter = frameCounters["Filament"]
-            ?: AtomicLong(0).also {
-                trackSubsystem("Filament")
-            }
-        val total = (frameCounters["Filament"] ?: counter).incrementAndGet()
-        lastFrameWallClock["Filament"]?.set(System.currentTimeMillis())
+        recordFrame("Filament")
+        val total = frameCounters["Filament"]?.get() ?: 0L
         if (total == 1L) {
             SessionLogRecorder.logRender("Filament", "first_frame", "frameCount=1")
         }
@@ -267,6 +289,7 @@ object RenderDiagnostics {
     // ────────────────────────────────────────────────────────────────────
 
     fun glSurfaceCreated() {
+        lumiyaContextCreateCount.incrementAndGet()
         trackSubsystem("Lumiya")
         SessionLogRecorder.logRender("Lumiya", "surface_created")
     }
@@ -299,12 +322,8 @@ object RenderDiagnostics {
     }
 
     fun glFrame() {
-        val counter = frameCounters["Lumiya"]
-            ?: AtomicLong(0).also {
-                trackSubsystem("Lumiya")
-            }
-        val total = (frameCounters["Lumiya"] ?: counter).incrementAndGet()
-        lastFrameWallClock["Lumiya"]?.set(System.currentTimeMillis())
+        recordFrame("Lumiya")
+        val total = frameCounters["Lumiya"]?.get() ?: 0L
         if (total == 1L) {
             SessionLogRecorder.logRender("Lumiya", "first_frame", "frameCount=1")
         }
@@ -351,6 +370,60 @@ object RenderDiagnostics {
         }
     }
 
+    data class Percentiles(val p50Ms: Long?, val p90Ms: Long?, val p99Ms: Long?)
+    data class DiagnosticsSnapshot(
+        val activeBackend: String,
+        val frameTimePercentiles: Map<String, Percentiles>,
+        val swapChainCreateCount: Long,
+        val swapChainDestroyCount: Long,
+        val swapChainFailureCount: Long,
+        val swapChainRestartCount: Long,
+        val glContextCreateCount: Long,
+        val glContextRestartCount: Long
+    )
+
+    @Synchronized
+    fun diagnosticsSnapshot(): DiagnosticsSnapshot {
+        val now = System.currentTimeMillis()
+        val activeBackends = activeSubsystems.filter { subsystem ->
+            val lastFrame = lastFrameWallClock[subsystem]?.get() ?: 0L
+            lastFrame > 0L && (now - lastFrame) <= (STALL_THRESHOLD_MS * 2)
+        }
+        val activeBackend = when (activeBackends.size) {
+            0 -> "none"
+            1 -> activeBackends.first()
+            else -> activeBackends.joinToString("+")
+        }
+
+        val percentiles = frameIntervalHistoryMs.mapValues { (_, values) ->
+            val sorted = values.toList().sorted()
+            Percentiles(
+                p50Ms = percentile(sorted, 0.50),
+                p90Ms = percentile(sorted, 0.90),
+                p99Ms = percentile(sorted, 0.99)
+            )
+        }
+
+        val swapCreates = filamentSwapChainCreateCount.get()
+        val contextCreates = lumiyaContextCreateCount.get()
+        return DiagnosticsSnapshot(
+            activeBackend = activeBackend,
+            frameTimePercentiles = percentiles,
+            swapChainCreateCount = swapCreates,
+            swapChainDestroyCount = filamentSwapChainDestroyCount.get(),
+            swapChainFailureCount = filamentSwapChainFailureCount.get(),
+            swapChainRestartCount = (swapCreates - 1L).coerceAtLeast(0L),
+            glContextCreateCount = contextCreates,
+            glContextRestartCount = (contextCreates - 1L).coerceAtLeast(0L)
+        )
+    }
+
+    private fun percentile(sortedValues: List<Long>, q: Double): Long? {
+        if (sortedValues.isEmpty()) return null
+        val idx = ((sortedValues.size - 1) * q).toInt().coerceIn(0, sortedValues.lastIndex)
+        return sortedValues[idx]
+    }
+
     /**
      * Test hook: stop the heartbeat ticker. Production callers should
      * not need this — the ticker lives for the app's lifetime.
@@ -369,6 +442,11 @@ object RenderDiagnostics {
         lumiyaUboUploadTimeNsTotal.set(0L)
         lumiyaUboUploadSamples.set(0L)
         lumiyaFrameAllocations.set(0L)
+        frameIntervalHistoryMs.clear()
+        filamentSwapChainCreateCount.set(0L)
+        filamentSwapChainDestroyCount.set(0L)
+        filamentSwapChainFailureCount.set(0L)
+        lumiyaContextCreateCount.set(0L)
         Log.d(TAG, "Render diagnostics reset (test hook)")
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -1191,6 +1191,9 @@ class RenderManager(private val context: Context) {
             timeSinceLastFrame = if (lastFrameTime > 0) System.currentTimeMillis() - lastFrameTime else null,
             initializationTime = initializationTime,
             lastInitializationError = lastInitializationError,
+            visiblePrimCount = sceneManager?.getVisibleObjects()?.size ?: 0,
+            visibleAvatarCount = sceneManager?.getVisibleAvatars()?.size ?: 0,
+            visibleTerrainPatchCount = terrainRenderer?.getDiagnostics()?.visiblePatchCount ?: 0,
             scenePopulationSnapshot = ScenePopulationDiagnostics.snapshot()
         )
     }
@@ -1215,6 +1218,9 @@ class RenderManager(private val context: Context) {
         val timeSinceLastFrame: Long?,
         val initializationTime: Long,
         val lastInitializationError: String?,
+        val visiblePrimCount: Int,
+        val visibleAvatarCount: Int,
+        val visibleTerrainPatchCount: Int,
         val scenePopulationSnapshot: ScenePopulationDiagnostics.Snapshot
     )
     

--- a/Linkpoint/src/main/java/com/linkpoint/render/terrain/TerrainRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/terrain/TerrainRenderer.kt
@@ -17,6 +17,11 @@ class TerrainRenderer(
     private val engine: Engine,
     private val scene: Scene
 ) {
+    data class Diagnostics(
+        val visiblePatchCount: Int,
+        val dirtyPatchCount: Int
+    )
+
     companion object {
         private const val TAG = "TerrainRenderer"
         
@@ -359,6 +364,15 @@ class TerrainRenderer(
         vertexBuffer?.let { engine.destroyVertexBuffer(it) }
         indexBuffer?.let { engine.destroyIndexBuffer(it) }
         materialInstance?.let { engine.destroyMaterialInstance(it) }
+    }
+
+    fun getDiagnostics(): Diagnostics {
+        val dirty = patches.count { it.dirty }
+        val visible = if (terrainEntity != 0) PATCHES_PER_SIDE * PATCHES_PER_SIDE else 0
+        return Diagnostics(
+            visiblePatchCount = visible,
+            dirtyPatchCount = dirty
+        )
     }
 }
 

--- a/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
@@ -10,6 +10,7 @@ import com.linkpoint.network.core.ConnectionQualityManager
 import com.linkpoint.network.core.NetworkStateManager
 import com.linkpoint.protocol.messages.EnhancedPacketLogger
 import com.linkpoint.protocol.messages.UDPConnectionFixed
+import com.linkpoint.render.RenderDiagnostics
 import kotlinx.coroutines.*
 import java.io.File
 import java.text.SimpleDateFormat
@@ -1018,6 +1019,12 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine("  Attempts: ${texDiag.j2kDecodeAttempts}")
                         appendLine("  Successes: ${texDiag.j2kDecodeSuccesses}")
                         appendLine("  Error States: ${texDiag.textureErrorStateCount}")
+                        val decodeFailureCount = (texDiag.j2kDecodeAttempts - texDiag.j2kDecodeSuccesses).coerceAtLeast(0)
+                        appendLine("  Success Rate: ${formatRate(texDiag.j2kDecodeSuccesses, texDiag.j2kDecodeAttempts)}")
+                        appendLine("  Failure Rate: ${formatRate(decodeFailureCount, texDiag.j2kDecodeAttempts)}")
+                        val transferAttempts = texDiag.downloadedCount + texDiag.failedCount
+                        appendLine("  Transfer Success Rate: ${formatRate(texDiag.downloadedCount, transferAttempts)}")
+                        appendLine("  Transfer Failure Rate: ${formatRate(texDiag.failedCount, transferAttempts)}")
                         val decoderStatus = com.linkpoint.assets.JPEG2000Decoder.getStartupStatus()
                         appendLine("  Backend: ${decoderStatus.activeBackend}")
                         appendLine("  Native Loaded: ${if (decoderStatus.nativeLoaded) "✓" else "✗"}")
@@ -1080,6 +1087,8 @@ class DebugReportService private constructor(private val context: Context) {
                         renderDiag.timeSinceLastFrame?.let {
                             appendLine("Time Since Last Frame: ${formatDuration(it)}")
                         }
+                        val renderTimeline = RenderDiagnostics.diagnosticsSnapshot()
+                        appendLine("Active Backend: ${renderTimeline.activeBackend}")
                         appendLine()
                         appendLine("Filament Components:")
                         appendLine("  Engine: ${if (renderDiag.hasEngine) "✓" else "✗"}")
@@ -1090,6 +1099,30 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine("  SwapChain: ${if (renderDiag.hasSwapChain) "✓" else "✗"}")
                         appendLine("  Surface Ready: ${if (renderDiag.isSurfaceReady) "✓" else "✗ (e.g. on Settings, app backgrounded)"}")
                         appendLine("  Drawing Enabled: ${if (renderDiag.isDrawingEnabled) "✓" else "✗ (paused — panel open / activity backgrounded)"}")
+                        appendLine()
+                        appendLine("Visible Entity Counts:")
+                        appendLine("  Avatars: ${renderDiag.visibleAvatarCount}")
+                        appendLine("  Prims: ${renderDiag.visiblePrimCount}")
+                        appendLine("  Terrain Patches: ${renderDiag.visibleTerrainPatchCount}")
+                        appendLine()
+                        appendLine("Frame Time Percentiles (ms):")
+                        if (renderTimeline.frameTimePercentiles.isEmpty()) {
+                            appendLine("  (insufficient frame history)")
+                        } else {
+                            renderTimeline.frameTimePercentiles.forEach { (backend, p) ->
+                                appendLine(
+                                    "  $backend: p50=${p.p50Ms ?: "-"} p90=${p.p90Ms ?: "-"} p99=${p.p99Ms ?: "-"}"
+                                )
+                            }
+                        }
+                        appendLine()
+                        appendLine("Swapchain / Context Restarts:")
+                        appendLine("  Filament SwapChain Creates: ${renderTimeline.swapChainCreateCount}")
+                        appendLine("  Filament SwapChain Destroys: ${renderTimeline.swapChainDestroyCount}")
+                        appendLine("  Filament SwapChain Failures: ${renderTimeline.swapChainFailureCount}")
+                        appendLine("  Filament SwapChain Restarts: ${renderTimeline.swapChainRestartCount}")
+                        appendLine("  Lumiya Context Creates: ${renderTimeline.glContextCreateCount}")
+                        appendLine("  Lumiya Context Restarts: ${renderTimeline.glContextRestartCount}")
 
                         if (renderDiag.initializationTime > 0) {
                             appendLine()
@@ -1726,6 +1759,12 @@ class DebugReportService private constructor(private val context: Context) {
             ms < 3600000 -> String.format(Locale.US, "%.1fm", ms / 60000.0)
             else -> String.format(Locale.US, "%.1fh", ms / 3600000.0)
         }
+    }
+
+    private fun formatRate(successes: Int, attempts: Int): String {
+        if (attempts <= 0) return "n/a (0/0)"
+        val pct = (successes.toDouble() * 100.0) / attempts.toDouble()
+        return String.format(Locale.US, "%.1f%% (%d/%d)", pct, successes, attempts)
     }
     
     fun shutdown() {


### PR DESCRIPTION
### Motivation

- Improve render subsystem observability so debug reports can show the active backend, frame-time distributions, visible entity counts, texture success/failure rates, and swapchain/context restart counters to help diagnose parity and stability issues between Filament and Lumiya.
- Surface these metrics in the existing debug report output so QA and crash reports include the evidence required to validate must-pass backend scenarios.

### Description

- Added a structured snapshot API in `RenderDiagnostics` (`diagnosticsSnapshot()`) and per-frame bookkeeping (`recordFrame`) to collect frame-interval histories and compute `p50/p90/p99` percentiles, plus counters for Filament swapchain create/destroy/fail and Lumiya GL context creates/restarts (`Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt`).
- Extended `RenderManager` diagnostics to include visible entity counts (`visiblePrimCount`, `visibleAvatarCount`, `visibleTerrainPatchCount`) and wired them into `getDiagnostics()` (`Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt`).
- Added terrain diagnostics to `TerrainRenderer` (`getDiagnostics()`) to report visible and dirty terrain patch counts (`Linkpoint/src/main/java/com/linkpoint/render/terrain/TerrainRenderer.kt`).
- Updated `DebugReportService` to surface the new data in the generated report including active backend, frame-time percentiles, visible entity counts, texture success/failure rates, and swapchain/context restart counters, and added a small helper `formatRate` for percentage output (`Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt`).
- Added a new checklist document `Linkpoint/docs/backend-parity-checklist.md` listing must-pass scenarios and evidence to capture for backend parity testing.

### Testing

- Attempted an automated Kotlin compilation with `./gradlew :Linkpoint:compileDebugKotlin`, which did not complete due to the environment lacking Android SDK configuration (`sdk.dir` / `ANDROID_HOME`), so no successful build artifacts were produced.
- No other automated tests were executed in this environment; all changes were limited to diagnostics/logging and a documentation file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef106a5b948323a7b5cf2bd1aa6814)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances render subsystem observability by adding comprehensive metrics tracking to diagnose parity and stability issues between the Filament and Lumiya rendering backends. The changes introduce frame-time percentile calculations (p50/p90/p99), visible entity counters (avatars, prims, terrain patches), swapchain and GL context restart tracking, and texture success/failure rates, all surfaced through an expanded debug report. A backend parity testing checklist document is also added to define must-pass scenarios for validation across both rendering backends.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/docs/backend-parity-checklist.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/render/terrain/TerrainRenderer.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added backend parity validation checklist defining test scenarios and pass criteria for render backend compatibility.

* **New Features**
  * Enhanced diagnostic reporting with frame-time percentiles (p50/p90/p99) and frame interval tracking per subsystem.
  * Added visible entity and terrain patch count tracking to diagnostics.
  * Expanded debug reports with active backend identification, render performance metrics, and swapchain/context restart counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->