### PR TITLE
Add Compose routing & theme tests, ThemeCatalog, and migration test plan

### DIFF
--- a/Linkpoint/build.gradle.kts
+++ b/Linkpoint/build.gradle.kts
@@ -380,6 +380,8 @@ dependencies {
     testImplementation("org.json:json:20240303")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test:core-ktx:1.5.0")
 }
 
 // Helper function to get git commit hash

--- a/Linkpoint/src/androidTest/java/com/linkpoint/ui/tests/NavigationAndThemeComposeTest.kt
+++ b/Linkpoint/src/androidTest/java/com/linkpoint/ui/tests/NavigationAndThemeComposeTest.kt
@@ -1,0 +1,178 @@
+package com.linkpoint.ui.tests
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.linkpoint.ui.theme.BuiltInThemes
+import com.linkpoint.ui.theme.LinkpointTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationAndThemeComposeTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun bottom_tab_routing_updates_selected_route() {
+        composeRule.setContent { BottomTabHarness() }
+
+        composeRule.onNodeWithText("Route: home").assertIsDisplayed()
+        composeRule.onNodeWithText("Chat").performClick()
+        composeRule.onNodeWithText("Route: chat").assertIsDisplayed()
+        composeRule.onNodeWithText("Map").performClick()
+        composeRule.onNodeWithText("Route: map").assertIsDisplayed()
+    }
+
+    @Test
+    fun drawer_section_routing_updates_selected_route() {
+        composeRule.setContent { DrawerHarness() }
+
+        composeRule.onNodeWithContentDescription("Open drawer").performClick()
+        composeRule.onNodeWithText("Inventory").performClick()
+        composeRule.onNodeWithText("Section: inventory").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("Open drawer").performClick()
+        composeRule.onNodeWithText("Groups").performClick()
+        composeRule.onNodeWithText("Section: groups").assertIsDisplayed()
+    }
+
+    @Test
+    fun primary_controls_apply_theme_primary_color() {
+        composeRule.setContent {
+            LinkpointTheme(themePack = BuiltInThemes.FIRESTORM) {
+                androidx.compose.material3.Button(
+                    onClick = {},
+                    modifier = Modifier.testTag("primary_button")
+                ) {
+                    Text("Primary")
+                }
+            }
+        }
+
+        val image = composeRule.onNodeWithTag("primary_button").captureToImage()
+        val primaryArgb = BuiltInThemes.FIRESTORM.parseColor(BuiltInThemes.FIRESTORM.colorPrimary)
+        val pixelMap = image.toPixelMap()
+
+        var foundPrimary = false
+        for (x in 0 until image.width) {
+            for (y in 0 until image.height) {
+                if (pixelMap[x, y].toArgb() == primaryArgb) {
+                    foundPrimary = true
+                    break
+                }
+            }
+            if (foundPrimary) break
+        }
+
+        assertTrue("Expected primary button to render FIRESTORM primary color", foundPrimary)
+    }
+}
+
+@Composable
+private fun BottomTabHarness() {
+    var selectedRoute by remember { mutableStateOf("home") }
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                listOf(
+                    "home" to ("Home" to Icons.Default.Home),
+                    "chat" to ("Chat" to Icons.Default.Chat),
+                    "map" to ("Map" to Icons.Default.Map)
+                ).forEach { (route, meta) ->
+                    NavigationBarItem(
+                        selected = selectedRoute == route,
+                        onClick = { selectedRoute = route },
+                        label = { Text(meta.first) },
+                        icon = { Icon(meta.second, contentDescription = meta.first) }
+                    )
+                }
+            }
+        }
+    ) {
+        Text(
+            text = "Route: $selectedRoute",
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Composable
+private fun DrawerHarness() {
+    var selectedSection by remember { mutableStateOf("home") }
+    var openDrawer by remember { mutableStateOf(false) }
+
+    ModalNavigationDrawer(
+        drawerContent = {
+            if (openDrawer) {
+                ModalDrawerSheet {
+                    NavigationDrawerItem(
+                        label = { Text("Inventory") },
+                        selected = selectedSection == "inventory",
+                        onClick = {
+                            selectedSection = "inventory"
+                            openDrawer = false
+                        }
+                    )
+                    NavigationDrawerItem(
+                        label = { Text("Groups") },
+                        selected = selectedSection == "groups",
+                        onClick = {
+                            selectedSection = "groups"
+                            openDrawer = false
+                        }
+                    )
+                }
+            }
+        }
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Drawer test") },
+                    navigationIcon = {
+                        IconButton(onClick = { openDrawer = true }) {
+                            Icon(Icons.Default.Menu, contentDescription = "Open drawer")
+                        }
+                    }
+                )
+            }
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Text("Section: $selectedSection")
+            }
+        }
+    }
+}

--- a/Linkpoint/src/androidTest/java/com/linkpoint/ui/tests/ThemeScreenshotGoldenTest.kt
+++ b/Linkpoint/src/androidTest/java/com/linkpoint/ui/tests/ThemeScreenshotGoldenTest.kt
@@ -1,0 +1,163 @@
+package com.linkpoint.ui.tests
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.linkpoint.ui.chat.ChatChannel
+import com.linkpoint.ui.chat.ChatMessage
+import com.linkpoint.ui.chat.ChatScreen
+import com.linkpoint.ui.chat.MessageType
+import com.linkpoint.ui.friends.FriendData
+import com.linkpoint.ui.friends.FriendStatus
+import com.linkpoint.ui.friends.FriendsScreen
+import com.linkpoint.ui.login.GridDisplayInfo
+import com.linkpoint.ui.login.LoginScreen
+import com.linkpoint.ui.settings.SettingsScreen
+import com.linkpoint.ui.settings.SettingsState
+import com.linkpoint.ui.teleport.TeleportHistoryEntry
+import com.linkpoint.ui.teleport.TeleportHistoryScreen
+import com.linkpoint.ui.theme.BuiltInThemes
+import com.linkpoint.ui.theme.LinkpointTheme
+import java.security.MessageDigest
+import java.util.UUID
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ThemeScreenshotGoldenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun representative_screens_have_distinct_snapshots_across_three_theme_families() {
+        val families = mapOf(
+            "linkpoint" to BuiltInThemes.LINKPOINT_DEFAULT,
+            "viewer" to BuiltInThemes.SL_CLASSIC,
+            "cleverferret" to BuiltInThemes.CLEVERFERRET_GOLD
+        )
+
+        val screenHashes = linkedMapOf<String, MutableSet<String>>()
+
+        families.forEach { (familyName, theme) ->
+            captureScreenHash("login", familyName, theme) {
+                LoginScreen(
+                    grids = listOf(GridDisplayInfo("sl", "Second Life")),
+                    onLogin = {},
+                    onOpenSettings = {}
+                )
+            }.also { addHash(screenHashes, "login", it) }
+
+            captureScreenHash("chat", familyName, theme) {
+                ChatScreen(
+                    messages = listOf(
+                        ChatMessage(
+                            id = "1",
+                            sender = "Guide",
+                            content = "Welcome to Linkpoint",
+                            timestamp = 1000L,
+                            type = MessageType.NORMAL,
+                            channel = ChatChannel.LOCAL
+                        )
+                    ),
+                    onSendMessage = { _, _ -> },
+                    onNavigateBack = {}
+                )
+            }.also { addHash(screenHashes, "chat", it) }
+
+            captureScreenHash("friends", familyName, theme) {
+                FriendsScreen(
+                    friends = listOf(
+                        FriendData(UUID.fromString("00000000-0000-0000-0000-000000000001"), "Alex", FriendStatus.ONLINE, "Sandbox")
+                    ),
+                    onNavigateBack = {},
+                    onOpenIM = {},
+                    onTeleportTo = {},
+                    onViewProfile = {},
+                    onRemoveFriend = {},
+                    onAddFriend = {}
+                )
+            }.also { addHash(screenHashes, "friends", it) }
+
+            captureScreenHash("settings", familyName, theme) {
+                SettingsScreen(
+                    settings = SettingsState(),
+                    onSettingsChange = {},
+                    onNavigateBack = {},
+                    onOpenThemePicker = {},
+                    onOpenAccount = {},
+                    onOpenPrivacy = {},
+                    onOpenAbout = {},
+                    onOpenLayoutEditor = {}
+                )
+            }.also { addHash(screenHashes, "settings", it) }
+
+            captureScreenHash("teleport_history", familyName, theme) {
+                TeleportHistoryScreen(
+                    history = listOf(
+                        TeleportHistoryEntry("1", "Morris", "128,128,25", 1000L, "secondlife://Morris/128/128/25")
+                    ),
+                    onTeleportTo = {},
+                    onDeleteEntry = {},
+                    onClearHistory = {},
+                    onNavigateBack = {}
+                )
+            }.also { addHash(screenHashes, "teleport_history", it) }
+        }
+
+        assertEquals("Expected 5 representative screens", 5, screenHashes.size)
+        screenHashes.forEach { (screen, hashes) ->
+            assertTrue(
+                "Expected themed visual variation for $screen across 3 families",
+                hashes.size >= 3
+            )
+        }
+    }
+
+    private fun captureScreenHash(
+        screenName: String,
+        familyName: String,
+        theme: com.linkpoint.ui.theme.ThemePack,
+        content: @androidx.compose.runtime.Composable () -> Unit
+    ): String {
+        val tag = "golden_${screenName}_$familyName"
+        composeRule.setContent {
+            LinkpointTheme(themePack = theme) {
+                androidx.compose.foundation.layout.Box(modifier = androidx.compose.ui.Modifier.testTag(tag)) {
+                    content()
+                }
+            }
+        }
+
+        val image = composeRule.onNodeWithTag(tag).captureToImage()
+        val pixelMap = image.toPixelMap()
+        val bytes = ByteArray(image.width * image.height * 4)
+        var index = 0
+        for (y in 0 until image.height) {
+            for (x in 0 until image.width) {
+                val argb = pixelMap[x, y].toArgb()
+                bytes[index++] = ((argb shr 24) and 0xFF).toByte()
+                bytes[index++] = ((argb shr 16) and 0xFF).toByte()
+                bytes[index++] = ((argb shr 8) and 0xFF).toByte()
+                bytes[index++] = (argb and 0xFF).toByte()
+            }
+        }
+
+        return MessageDigest.getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun addHash(
+        screenHashes: MutableMap<String, MutableSet<String>>,
+        screen: String,
+        hash: String
+    ) {
+        screenHashes.getOrPut(screen) { linkedSetOf() }.add(hash)
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemeCatalog.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemeCatalog.kt
@@ -1,0 +1,40 @@
+package com.linkpoint.ui.theme
+
+/**
+ * Catalog of built-in themes grouped by visual family.
+ */
+object ThemeCatalog {
+    enum class ThemeFamily {
+        LINKPOINT,
+        VIEWER_INSPIRED,
+        CLEVERFERRET
+    }
+
+    private val familyToThemes: Map<ThemeFamily, List<ThemePack>> = mapOf(
+        ThemeFamily.LINKPOINT to listOf(BuiltInThemes.LINKPOINT_DEFAULT),
+        ThemeFamily.VIEWER_INSPIRED to listOf(
+            BuiltInThemes.SL_CLASSIC,
+            BuiltInThemes.FIRESTORM
+        ),
+        ThemeFamily.CLEVERFERRET to listOf(
+            BuiltInThemes.CLEVERFERRET_GOLD,
+            BuiltInThemes.NAVY_GOLD,
+            BuiltInThemes.ROYAL_SILVER,
+            BuiltInThemes.FOREST_COPPER,
+            BuiltInThemes.BURGUNDY_ROSEGOLD,
+            BuiltInThemes.CHARCOAL_CHAMPAGNE,
+            BuiltInThemes.SLATE_GUNMETAL
+        )
+    )
+
+    fun allThemes(): List<ThemePack> = familyToThemes.values.flatten()
+
+    fun families(): Set<ThemeFamily> = familyToThemes.keys
+
+    fun themesInFamily(family: ThemeFamily): List<ThemePack> = familyToThemes[family].orEmpty()
+
+    fun familyForTheme(themeId: String): ThemeFamily? =
+        familyToThemes.entries.firstOrNull { (_, themes) -> themes.any { it.id == themeId } }?.key
+
+    fun getById(id: String): ThemePack? = allThemes().firstOrNull { it.id == id }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/ui/theme/BuiltInThemesCompatibilityTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/ui/theme/BuiltInThemesCompatibilityTest.kt
@@ -1,0 +1,27 @@
+package com.linkpoint.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class BuiltInThemesCompatibilityTest {
+
+    @Test
+    fun `linkpoint_default resolves`() {
+        val resolved = BuiltInThemes.getById("linkpoint_default")
+        assertNotNull(resolved)
+        assertEquals(BuiltInThemes.LINKPOINT_DEFAULT.id, resolved?.id)
+    }
+
+    @Test
+    fun `merged built-ins have no duplicate IDs`() {
+        val mergedIds = (BuiltInThemes.getAllBuiltInThemes() + ThemeCatalog.allThemes())
+            .map { it.id }
+
+        assertEquals(
+            "Merged built-in IDs must be unique",
+            mergedIds.size,
+            mergedIds.toSet().size
+        )
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/ui/theme/ThemeCatalogTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/ui/theme/ThemeCatalogTest.kt
@@ -1,0 +1,35 @@
+package com.linkpoint.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThemeCatalogTest {
+
+    @Test
+    fun `all catalog themes have unique IDs`() {
+        val ids = ThemeCatalog.allThemes().map { it.id }
+        assertEquals(ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun `catalog covers every family`() {
+        ThemeCatalog.ThemeFamily.entries.forEach { family ->
+            assertTrue("Expected family $family to have at least one theme", ThemeCatalog.themesInFamily(family).isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `lookup behavior returns expected themes and families`() {
+        val theme = ThemeCatalog.getById(BuiltInThemes.LINKPOINT_DEFAULT.id)
+        assertNotNull(theme)
+        assertEquals(BuiltInThemes.LINKPOINT_DEFAULT.id, theme?.id)
+        assertEquals(
+            ThemeCatalog.ThemeFamily.LINKPOINT,
+            ThemeCatalog.familyForTheme(BuiltInThemes.LINKPOINT_DEFAULT.id)
+        )
+        assertEquals(null, ThemeCatalog.getById("missing_theme"))
+        assertEquals(null, ThemeCatalog.familyForTheme("missing_theme"))
+    }
+}

--- a/docs/ui-refactor/test-plan.md
+++ b/docs/ui-refactor/test-plan.md
@@ -1,0 +1,56 @@
+# UI Refactor Migration Smoke Test Plan
+
+## Scope
+This smoke plan verifies Compose routing, theme integrity, built-in theme compatibility, and screenshot stability after UI refactor milestones.
+
+## Preconditions
+- Build debug + androidTest artifacts for Linkpoint module.
+- Emulator/device available (API 34+ recommended).
+- Theme assets and built-ins bundled in app.
+
+## Smoke Suite
+
+### 1) Compose navigation routing
+- Bottom tab routing: verify selecting each bottom tab updates active route state and visible destination content.
+- Drawer section routing: verify selecting drawer sections updates active destination and closes drawer.
+
+### 2) Theme correctness
+- Primary controls: verify Material primary controls (button/FAB) use active theme `colorPrimary`.
+- Spot-check linkpoint, viewer-inspired, and cleverferret family themes.
+
+### 3) Theme catalog consistency
+- IDs are globally unique.
+- Every declared family has at least one entry.
+- Lookups return expected family and theme by ID.
+
+### 4) Built-in compatibility
+- `linkpoint_default` resolves via built-in lookup.
+- No duplicate IDs in merged built-in/catalog list.
+
+### 5) Screenshot/golden guardrail
+Capture representative screens under three theme families:
+- Login
+- Chat
+- Friends
+- Settings
+- Teleport History
+
+For each screen:
+- capture snapshot hash for all 3 families,
+- ensure expected themed visual variation,
+- archive hashes as migration baseline for future regressions.
+
+## Execution order
+1. Unit tests (`ThemeCatalog*`, `BuiltInThemesCompatibility*`).
+2. Instrumented Compose UI routing/theme tests.
+3. Instrumented screenshot/golden tests.
+
+## Pass criteria
+- All unit tests pass.
+- All Compose routing/theme tests pass.
+- Screenshot/golden tests produce 5x3 snapshots with expected per-screen variation.
+
+## Follow-up on failures
+- Routing failure: inspect test harness nav wiring and destination state updates.
+- Theme failure: inspect `LinkpointTheme`, `ThemeColors`, and built-in pack values.
+- Golden failure: validate intentional UI change; if intentional, regenerate and approve new baselines.


### PR DESCRIPTION
### Motivation
- Provide automated coverage for Compose navigation and theme behavior to guard the UI refactor.
- Group built-in themes into families for clearer testing and compatibility checks across theme variants.
- Add screenshot/golden-style checks for representative screens to detect visual regressions across theme families.

### Description
- Add `ThemeCatalog` to group built-in themes by family and provide lookup helpers (`ThemeCatalog.kt`).
- Add unit tests for the catalog and built-in compatibility (`ThemeCatalogTest.kt`, `BuiltInThemesCompatibilityTest.kt`).
- Add Compose instrumentation tests for bottom tab routing, drawer section routing, and primary control theme application (`NavigationAndThemeComposeTest.kt`).
- Add a screenshot/golden-style instrumentation test that captures 5 representative screens under 3 theme families and compares snapshot hashes (`ThemeScreenshotGoldenTest.kt`).
- Update app module test dependencies to include Compose UI test helpers (`androidTestImplementation("androidx.compose.ui:ui-test-junit4")`, `androidTestImplementation("androidx.test:core-ktx:1.5.0")`) and add a migration smoke test plan at `docs/ui-refactor/test-plan.md`.

### Testing
- Attempted to run unit tests with `./gradlew :Linkpoint:testDebugUnitTest --tests "com.linkpoint.ui.theme.ThemeCatalogTest" --tests "com.linkpoint.ui.theme.BuiltInThemesCompatibilityTest"`, but the build failed because the Android SDK location is not configured (missing `ANDROID_HOME` / `sdk.dir`).
- Instrumented Compose tests and screenshot/golden tests were added but not executed in this environment due to the same Android SDK / emulator prerequisites.
- No test failures in repository-level linting or static edits were observed during file creation; runtime verification requires an Android build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef548659d883239742550247cf1b2c)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds automated test coverage for Compose navigation and theming behavior to guard an ongoing UI refactor. It introduces a `ThemeCatalog` that groups built-in themes into families (Linkpoint, Viewer-Inspired, CleverFerret) with corresponding unit tests for catalog lookup and built-in compatibility. New instrumentation tests verify bottom tab and drawer routing, theme color application, and capture screenshot hashes across representative screens under three theme families to detect visual regressions. The PR also adds necessary Compose test dependencies and documents a migration smoke test plan.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/ui-refactor/test-plan.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemeCatalog.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/ui/theme/ThemeCatalogTest.kt` |
| 4 | `Linkpoint/src/test/kotlin/com/linkpoint/ui/theme/BuiltInThemesCompatibilityTest.kt` |
| 5 | `Linkpoint/src/androidTest/java/com/linkpoint/ui/tests/NavigationAndThemeComposeTest.kt` |
| 6 | `Linkpoint/src/androidTest/java/com/linkpoint/ui/tests/ThemeScreenshotGoldenTest.kt` |
| 7 | `Linkpoint/build.gradle.kts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->