### PR TITLE
Add UI cluster destination stubs and screen migration matrix

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/auth/AuthDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/auth/AuthDestinations.kt
@@ -1,0 +1,39 @@
+package com.linkpoint.ui.auth
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class LoginScreenState(
+    val title: String = "Login",
+    val description: String = "Authentication destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginDestination(
+    state: LoginScreenState = LoginScreenState(),
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(state.title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = state.description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/communication/CommunicationDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/communication/CommunicationDestinations.kt
@@ -1,0 +1,39 @@
+package com.linkpoint.ui.communication
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class ChatScreenState(
+    val title: String = "Chat",
+    val description: String = "Communication destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatDestination(
+    state: ChatScreenState = ChatScreenState(),
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(state.title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = state.description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/discovery/DiscoveryDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/discovery/DiscoveryDestinations.kt
@@ -1,0 +1,77 @@
+package com.linkpoint.ui.discovery
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class SearchScreenState(
+    val title: String = "Search",
+    val description: String = "Search destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchDestination(
+    state: SearchScreenState = SearchScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class TeleportHistoryScreenState(
+    val title: String = "Teleport History",
+    val description: String = "Teleport history destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TeleportHistoryDestination(
+    state: TeleportHistoryScreenState = TeleportHistoryScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class SlurlScreenState(
+    val title: String = "SLURL",
+    val description: String = "SLURL destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SlurlDestination(
+    state: SlurlScreenState = SlurlScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DestinationScaffold(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryDestinations.kt
@@ -1,0 +1,39 @@
+package com.linkpoint.ui.inventory
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class InventoryScreenState(
+    val title: String = "Inventory",
+    val description: String = "Inventory destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InventoryDestination(
+    state: InventoryScreenState = InventoryScreenState(),
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(state.title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = state.description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt
@@ -1,0 +1,66 @@
+package com.linkpoint.ui.onboarding
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class OnboardingEntryScreenState(
+    val title: String = "Onboarding",
+    val description: String = "Onboarding handoff destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OnboardingEntryDestination(
+    state: OnboardingEntryScreenState = OnboardingEntryScreenState(),
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(state.title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = state.description)
+        }
+    }
+}
+
+data class StartLocationScreenState(
+    val title: String = "Start Location",
+    val description: String = "Start location selection destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StartLocationDestination(
+    state: StartLocationScreenState = StartLocationScreenState(),
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(state.title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = state.description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/social/SocialDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/social/SocialDestinations.kt
@@ -1,0 +1,119 @@
+package com.linkpoint.ui.social
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class FriendsScreenState(
+    val title: String = "Friends",
+    val description: String = "Friends destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FriendsDestination(
+    state: FriendsScreenState = FriendsScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class GroupsScreenState(
+    val title: String = "Groups",
+    val description: String = "Groups destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupsDestination(
+    state: GroupsScreenState = GroupsScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class ProfileScreenState(
+    val title: String = "Profile",
+    val description: String = "Profile destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileDestination(
+    state: ProfileScreenState = ProfileScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class MyProfileScreenState(
+    val title: String = "My Profile",
+    val description: String = "My profile destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyProfileDestination(
+    state: MyProfileScreenState = MyProfileScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class NearbyPeopleScreenState(
+    val title: String = "Nearby People",
+    val description: String = "Nearby people destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NearbyPeopleDestination(
+    state: NearbyPeopleScreenState = NearbyPeopleScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class MyAvatarScreenState(
+    val title: String = "My Avatar",
+    val description: String = "My avatar destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyAvatarDestination(
+    state: MyAvatarScreenState = MyAvatarScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DestinationScaffold(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt
@@ -1,0 +1,77 @@
+package com.linkpoint.ui.system
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class SettingsScreenState(
+    val title: String = "Settings",
+    val description: String = "Settings destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsDestination(
+    state: SettingsScreenState = SettingsScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class TosScreenState(
+    val title: String = "Terms of Service",
+    val description: String = "Terms of service destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TosDestination(
+    state: TosScreenState = TosScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class ThemePickerScreenState(
+    val title: String = "Theme Picker",
+    val description: String = "Theme picker destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ThemePickerDestination(
+    state: ThemePickerScreenState = ThemePickerScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DestinationScaffold(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = description)
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldDestinations.kt
@@ -1,0 +1,91 @@
+package com.linkpoint.ui.world
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+data class WorldShellScreenState(
+    val title: String = "World",
+    val description: String = "World shell destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorldShellDestination(
+    state: WorldShellScreenState = WorldShellScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class MapScreenState(
+    val title: String = "Map",
+    val description: String = "Map destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MapDestination(
+    state: MapScreenState = MapScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class MinimapScreenState(
+    val title: String = "Minimap",
+    val description: String = "Minimap destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MinimapDestination(
+    state: MinimapScreenState = MinimapScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+data class XrWorldScreenState(
+    val title: String = "XR World",
+    val description: String = "XR world destination placeholder."
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun XrWorldDestination(
+    state: XrWorldScreenState = XrWorldScreenState(),
+    modifier: Modifier = Modifier
+) {
+    DestinationScaffold(state.title, state.description, modifier)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DestinationScaffold(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(title) })
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = description)
+        }
+    }
+}

--- a/docs/ui-refactor/screen-migration-matrix.md
+++ b/docs/ui-refactor/screen-migration-matrix.md
@@ -1,0 +1,33 @@
+# Screen Migration Matrix
+
+This matrix tracks activity-to-destination handoff work for the UI cluster refactor.
+
+## Priority Order
+
+1. **Phase 1 (first):** auth + world shell + chat + inventory + settings
+2. **Phase 2 (next):** social/discovery/system advanced surfaces
+
+## Matrix
+
+| Handoff screen name | Current implementation file | Target destination | Status |
+| --- | --- | --- | --- |
+| Login | `ui/login/LoginScreen.kt` | `ui/auth/LoginDestination` | in progress |
+| Start Location | `ui/login/StartLocationDialog.kt` | `ui/onboarding/StartLocationDestination` | not started |
+| World Shell | `ui/world/WorldViewActivity.kt` | `ui/world/WorldShellDestination` | in progress |
+| Chat | `ui/chat/ChatScreen.kt` | `ui/communication/ChatDestination` | in progress |
+| Inventory | `ui/inventory/InventoryScreen.kt` | `ui/inventory/InventoryDestination` | in progress |
+| Settings | `ui/settings/SettingsScreen.kt` | `ui/system/SettingsDestination` | in progress |
+| Friends | `ui/friends/FriendsScreen.kt` | `ui/social/FriendsDestination` | not started |
+| Groups | `ui/groups/GroupsScreen.kt` | `ui/social/GroupsDestination` | not started |
+| Profile | `ui/profile/ProfileScreen.kt` | `ui/social/ProfileDestination` | not started |
+| My Profile | `ui/profile/ProfileScreen.kt` | `ui/social/MyProfileDestination` | not started |
+| Nearby People | `ui/people/NearbyPeopleScreen.kt` | `ui/social/NearbyPeopleDestination` | not started |
+| My Avatar | `ui/avatar/MyAvatarScreen.kt` | `ui/social/MyAvatarDestination` | not started |
+| Search | `ui/search/SearchScreen.kt` | `ui/discovery/SearchDestination` | not started |
+| Teleport History | `ui/teleport/TeleportHistoryScreen.kt` | `ui/discovery/TeleportHistoryDestination` | not started |
+| SLURL | `ui/slurl/SLURLScreen.kt` | `ui/discovery/SlurlDestination` | not started |
+| Map | `ui/map/MapScreen.kt` | `ui/world/MapDestination` | not started |
+| Minimap | `ui/minimap/MinimapScreen.kt` | `ui/world/MinimapDestination` | not started |
+| XR World | `ui/xr/XRWorldActivity.kt` | `ui/world/XrWorldDestination` | not started |
+| Terms of Service | `ui/tos/TosScreen.kt` | `ui/system/TosDestination` | not started |
+| Theme Picker | `ui/theme/ThemePickerScreen.kt` | `ui/system/ThemePickerDestination` | not started |


### PR DESCRIPTION
### Motivation
- Provide a clean set of destination/feature module stubs to enable incremental migration from Activity-based screens to Compose navigation destinations. 
- Ship a lightweight, TODO-free baseline for each handoff screen so engineers can implement real UI and ViewModel wiring iteratively and in a prioritized order.

### Description
- Added new UI cluster packages under `com.linkpoint.ui`: `onboarding`, `auth`, `world`, `communication`, `social`, `inventory`, `discovery`, and `system`, each containing destination composables and simple screen state models. 
- Implemented destination stubs that use `Scaffold` + `TopAppBar`, provide a `data class ...ScreenState` model, and render a centered placeholder body with no TODOs. 
- Introduced `docs/ui-refactor/screen-migration-matrix.md` documenting each handoff screen, the current implementation file, the target destination, and migration status, and encoded the requested Phase 1/Phase 2 priority ordering. 

### Testing
- Attempted Gradle task discovery/build validation (`./gradlew -q tasks --all`) but the run was blocked by missing Android SDK configuration (`sdk.dir` / `ANDROID_HOME`) in this environment. 
- No automated unit/UI tests were added as part of this change; the created stubs are compile-time Kotlin/Compose sources ready for downstream integration and testing once the Android SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef544484a48323bcb96875bd783c21)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR establishes a foundational scaffold for migrating from Activity-based screens to Compose navigation destinations. It introduces eight UI cluster packages (`auth`, `onboarding`, `world`, `communication`, `social`, `inventory`, `discovery`, and `system`) with placeholder destination composables and screen state models. Each stub uses a consistent `Scaffold` + `TopAppBar` pattern with centered placeholder text. A comprehensive migration matrix document maps 22 existing screens to their target destinations, organized by Phase 1 (priority) and Phase 2 implementation order.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/ui-refactor/screen-migration-matrix.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/auth/AuthDestinations.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldDestinations.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/communication/CommunicationDestinations.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryDestinations.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/social/SocialDestinations.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/ui/discovery/DiscoveryDestinations.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->