### PR TITLE
Add Compose app shell, route metadata and auth guards; introduce WorldHomeHostActivity

### DIFF
--- a/Linkpoint/src/main/AndroidManifest.xml
+++ b/Linkpoint/src/main/AndroidManifest.xml
@@ -70,6 +70,14 @@
             </intent-filter>
         </activity>
 
+
+        <!-- Compose migration host entry (world/home) -->
+        <activity
+            android:name=".ui.navigation.WorldHomeHostActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Linkpoint.NoActionBar"/>
+
         <!-- Main World View Activity with Filament Rendering -->
         <activity
             android:name=".ui.world.WorldViewActivity"

--- a/Linkpoint/src/main/java/com/linkpoint/ui/login/LoginActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/login/LoginActivity.kt
@@ -30,7 +30,7 @@ import com.linkpoint.network.NetworkLogger
 import com.linkpoint.network.SSLHelper
 import com.linkpoint.ui.settings.SettingsActivity
 import com.linkpoint.ui.tos.TosActivity
-import com.linkpoint.ui.world.WorldViewActivity
+import com.linkpoint.ui.navigation.WorldHomeHostActivity
 import com.linkpoint.utils.PermissionManager
 import com.linkpoint.utils.SecurePreferences
 import kotlinx.coroutines.Dispatchers
@@ -847,7 +847,7 @@ class LoginActivity : AppCompatActivity(), StartLocationDialog.StartLocationList
                 }
                 
                 // Navigate to world view
-                val intent = Intent(this, WorldViewActivity::class.java)
+                val intent = Intent(this, WorldHomeHostActivity::class.java)
                 startActivity(intent)
                 finish()
             }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointAppShell.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointAppShell.kt
@@ -1,0 +1,104 @@
+package com.linkpoint.ui.navigation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LinkpointAppShell(
+    navController: NavHostController,
+    currentRoute: String?,
+    title: String,
+    subtitle: String?,
+    bottomTabs: List<LinkpointMenuDestination> = LinkpointMenus.bottomTabs,
+    drawerSections: List<LinkpointDrawerSection> = LinkpointMenus.drawerSections,
+    content: @Composable (Modifier) -> Unit
+) {
+    val drawerState = rememberDrawerState(initialValue = androidx.compose.material3.DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            if (drawerSections.isNotEmpty()) {
+                ModalDrawerSheet {
+                    drawerSections.forEach { section ->
+                        Text(
+                            text = section.title,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        section.items.forEach { item ->
+                            androidx.compose.material3.NavigationDrawerItem(
+                                label = { Text(item.label) },
+                                selected = currentRoute == item.route,
+                                onClick = {
+                                    navController.navigateTo(item.route)
+                                    scope.launch { drawerState.close() }
+                                }
+                            )
+                        }
+                        Divider(modifier = Modifier.padding(vertical = 8.dp))
+                    }
+                }
+            }
+        }
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Column {
+                            Text(text = title)
+                            if (!subtitle.isNullOrBlank()) {
+                                Text(
+                                    text = subtitle,
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                            }
+                        }
+                    },
+                    navigationIcon = {
+                        if (drawerSections.isNotEmpty()) {
+                            IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                                Text("≡")
+                            }
+                        }
+                    }
+                )
+            },
+            bottomBar = {
+                NavigationBar {
+                    bottomTabs.forEach { tab ->
+                        NavigationBarItem(
+                            selected = currentRoute == tab.route,
+                            onClick = { navController.navigateTo(tab.route) },
+                            icon = { Text(tab.label.take(1)) },
+                            label = { Text(tab.label) }
+                        )
+                    }
+                }
+            }
+        ) { paddingValues ->
+            content(Modifier.padding(paddingValues))
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/Navigation.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/Navigation.kt
@@ -1,14 +1,46 @@
 package com.linkpoint.ui.navigation
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.linkpoint.LinkpointApp
+import com.linkpoint.ui.avatar.MyAvatarActivity
+import com.linkpoint.ui.build.BuildActivity
+import com.linkpoint.ui.chat.ChatActivity
+import com.linkpoint.ui.friends.FriendsActivity
+import com.linkpoint.ui.groups.GroupsActivity
+import com.linkpoint.ui.inventory.InventoryActivity
+import com.linkpoint.ui.login.LoginActivity
+import com.linkpoint.ui.map.MapActivity
+import com.linkpoint.ui.minimap.MinimapActivity
+import com.linkpoint.ui.people.NearbyPeopleActivity
+import com.linkpoint.ui.profile.ProfileActivity
+import com.linkpoint.ui.search.SearchActivity
+import com.linkpoint.ui.settings.SettingsActivity
+import com.linkpoint.ui.teleport.TeleportHistoryActivity
+import com.linkpoint.ui.tos.TosActivity
+import com.linkpoint.ui.world.WorldViewActivity
+import com.linkpoint.ui.xr.XRWorldActivity
+import kotlin.reflect.KClass
 
-/**
- * Navigation routes for the Linkpoint app.
- */
 object Routes {
     const val LOGIN = "login"
     const val WORLD = "world"
@@ -29,152 +61,216 @@ object Routes {
     const val THEME_PICKER = "theme_picker"
     const val SLURL = "slurl/{slurl}"
     const val XR_WORLD = "xr_world"
-    
+
+    const val WALLET = "wallet"
+    const val BUILD_TOOLS = "build_tools"
+    const val NOTIFICATIONS_FEED = "notifications_feed"
+    const val VOICE_DEEP = "voice_deep"
+    const val PLACES_DETAIL = "places/{placeId}"
+    const val PLACES_EVENTS = "places/events"
+    const val ONBOARDING_WELCOME = "onboarding/welcome"
+    const val ONBOARDING_PERMISSIONS = "onboarding/permissions"
+    const val ONBOARDING_AVATAR = "onboarding/avatar"
+
     fun profile(userId: String) = "profile/$userId"
     fun slurl(slurl: String) = "slurl/$slurl"
+    fun placeDetail(placeId: String) = "places/$placeId"
 }
 
-/**
- * Extension function to navigate with animation
- */
+enum class MenuPlacement { BOTTOM_TAB, DRAWER, OVERFLOW, NONE }
+enum class BackBehavior { DEFAULT, ROOT_LEVEL, ALWAYS_TO_WORLD }
+
+data class RouteMetadata(
+    val menuPlacement: MenuPlacement,
+    val title: String,
+    val subtitle: String? = null,
+    val backBehavior: BackBehavior = BackBehavior.DEFAULT,
+    val requiresAuth: Boolean = true,
+    val legacyActivity: KClass<out Activity>? = null
+)
+
+data class LinkpointMenuDestination(val route: String, val label: String)
+data class LinkpointDrawerSection(val title: String, val items: List<LinkpointMenuDestination>)
+
+object LinkpointMenus {
+    val bottomTabs = listOf(
+        LinkpointMenuDestination(Routes.WORLD, "World"),
+        LinkpointMenuDestination(Routes.CHAT, "Chat"),
+        LinkpointMenuDestination(Routes.INVENTORY, "Inventory"),
+        LinkpointMenuDestination(Routes.FRIENDS, "Friends")
+    )
+
+    val drawerSections = listOf(
+        LinkpointDrawerSection(
+            title = "Explore",
+            items = listOf(
+                LinkpointMenuDestination(Routes.MAP, "Map"),
+                LinkpointMenuDestination(Routes.SEARCH, "Search"),
+                LinkpointMenuDestination(Routes.PLACES_EVENTS, "Events")
+            )
+        ),
+        LinkpointDrawerSection(
+            title = "Tools",
+            items = listOf(
+                LinkpointMenuDestination(Routes.BUILD_TOOLS, "Build Tools"),
+                LinkpointMenuDestination(Routes.NOTIFICATIONS_FEED, "Notifications"),
+                LinkpointMenuDestination(Routes.VOICE_DEEP, "Voice")
+            )
+        ),
+        LinkpointDrawerSection(
+            title = "Account",
+            items = listOf(
+                LinkpointMenuDestination(Routes.MY_PROFILE, "My Profile"),
+                LinkpointMenuDestination(Routes.WALLET, "Wallet"),
+                LinkpointMenuDestination(Routes.SETTINGS, "Settings")
+            )
+        )
+    )
+}
+
+val routeMetadata: Map<String, RouteMetadata> = mapOf(
+    Routes.LOGIN to RouteMetadata(MenuPlacement.NONE, "Sign in", requiresAuth = false, legacyActivity = LoginActivity::class),
+    Routes.WORLD to RouteMetadata(MenuPlacement.BOTTOM_TAB, "World", "3D session", BackBehavior.ROOT_LEVEL, legacyActivity = WorldViewActivity::class),
+    Routes.CHAT to RouteMetadata(MenuPlacement.BOTTOM_TAB, "Chat", "Conversations", legacyActivity = ChatActivity::class),
+    Routes.INVENTORY to RouteMetadata(MenuPlacement.BOTTOM_TAB, "Inventory", "Items and outfits", legacyActivity = InventoryActivity::class),
+    Routes.FRIENDS to RouteMetadata(MenuPlacement.BOTTOM_TAB, "Friends", "People list", legacyActivity = FriendsActivity::class),
+    Routes.GROUPS to RouteMetadata(MenuPlacement.DRAWER, "Groups", legacyActivity = GroupsActivity::class),
+    Routes.PROFILE to RouteMetadata(MenuPlacement.NONE, "Resident profile", backBehavior = BackBehavior.ALWAYS_TO_WORLD, legacyActivity = ProfileActivity::class),
+    Routes.MY_PROFILE to RouteMetadata(MenuPlacement.DRAWER, "My profile", legacyActivity = ProfileActivity::class),
+    Routes.SETTINGS to RouteMetadata(MenuPlacement.DRAWER, "Settings", legacyActivity = SettingsActivity::class),
+    Routes.MAP to RouteMetadata(MenuPlacement.DRAWER, "Map", legacyActivity = MapActivity::class),
+    Routes.MINIMAP to RouteMetadata(MenuPlacement.OVERFLOW, "Minimap", legacyActivity = MinimapActivity::class),
+    Routes.SEARCH to RouteMetadata(MenuPlacement.DRAWER, "Search", legacyActivity = SearchActivity::class),
+    Routes.TELEPORT_HISTORY to RouteMetadata(MenuPlacement.OVERFLOW, "Teleport history", legacyActivity = TeleportHistoryActivity::class),
+    Routes.NEARBY_PEOPLE to RouteMetadata(MenuPlacement.OVERFLOW, "Nearby", legacyActivity = NearbyPeopleActivity::class),
+    Routes.MY_AVATAR to RouteMetadata(MenuPlacement.OVERFLOW, "My avatar", legacyActivity = MyAvatarActivity::class),
+    Routes.TOS to RouteMetadata(MenuPlacement.NONE, "Terms of service", requiresAuth = false, legacyActivity = TosActivity::class),
+    Routes.THEME_PICKER to RouteMetadata(MenuPlacement.OVERFLOW, "Theme picker"),
+    Routes.SLURL to RouteMetadata(MenuPlacement.NONE, "SLURL handoff"),
+    Routes.XR_WORLD to RouteMetadata(MenuPlacement.OVERFLOW, "XR world", legacyActivity = XRWorldActivity::class),
+    Routes.WALLET to RouteMetadata(MenuPlacement.DRAWER, "Wallet", "L$ balance and transactions"),
+    Routes.BUILD_TOOLS to RouteMetadata(MenuPlacement.DRAWER, "Build tools", legacyActivity = BuildActivity::class),
+    Routes.NOTIFICATIONS_FEED to RouteMetadata(MenuPlacement.DRAWER, "Notifications", "Messages and system notices"),
+    Routes.VOICE_DEEP to RouteMetadata(MenuPlacement.DRAWER, "Voice", "Channel and diagnostics"),
+    Routes.PLACES_DETAIL to RouteMetadata(MenuPlacement.NONE, "Place details", backBehavior = BackBehavior.ALWAYS_TO_WORLD),
+    Routes.PLACES_EVENTS to RouteMetadata(MenuPlacement.DRAWER, "Events", "Places and happenings"),
+    Routes.ONBOARDING_WELCOME to RouteMetadata(MenuPlacement.NONE, "Welcome", requiresAuth = false),
+    Routes.ONBOARDING_PERMISSIONS to RouteMetadata(MenuPlacement.NONE, "Permissions", requiresAuth = false),
+    Routes.ONBOARDING_AVATAR to RouteMetadata(MenuPlacement.NONE, "Starter avatar", requiresAuth = false)
+)
+
 fun NavHostController.navigateTo(route: String) {
     navigate(route) {
-        // Pop up to the start destination to avoid building up a large stack
         launchSingleTop = true
         restoreState = true
     }
 }
 
-/**
- * Extension function to navigate back
- */
 fun NavHostController.navigateBack() {
     popBackStack()
 }
 
-/**
- * Main navigation composable that can be used as the app's navigation structure.
- * 
- * Note: This is a framework that can be used when migrating from Activities to 
- * single-Activity + Compose Navigation architecture. Currently the app still uses
- * Activity-based navigation, but these routes and NavHost setup can be adopted
- * incrementally.
- * 
- * Usage in MainActivity:
- * ```kotlin
- * setContent {
- *     LinkpointTheme {
- *         val navController = rememberNavController()
- *         LinkpointNavHost(navController = navController)
- *     }
- * }
- * ```
- */
+fun resolveRouteMetadata(route: String?): RouteMetadata {
+    val normalizedRoute = route ?: Routes.WORLD
+    return routeMetadata[normalizedRoute]
+        ?: when {
+            normalizedRoute.startsWith("profile/") -> routeMetadata.getValue(Routes.PROFILE)
+            normalizedRoute.startsWith("slurl/") -> routeMetadata.getValue(Routes.SLURL)
+            normalizedRoute.startsWith("places/") -> routeMetadata.getValue(Routes.PLACES_DETAIL)
+            else -> routeMetadata.getValue(Routes.WORLD)
+        }
+}
+
 @Composable
 fun LinkpointNavHost(
     navController: NavHostController = rememberNavController(),
     startDestination: String = Routes.LOGIN
 ) {
-    NavHost(
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+    val metadata = resolveRouteMetadata(currentRoute)
+
+    LinkpointAppShell(
         navController = navController,
-        startDestination = startDestination
+        currentRoute = currentRoute,
+        title = metadata.title,
+        subtitle = metadata.subtitle,
+        bottomTabs = LinkpointMenus.bottomTabs,
+        drawerSections = LinkpointMenus.drawerSections
+    ) { paddingModifier ->
+        NavHost(
+            navController = navController,
+            startDestination = startDestination,
+            modifier = paddingModifier
+        ) {
+            routeMetadata.forEach { (routePattern, _) ->
+                composable(routePattern) { entry ->
+                    val resolved = resolveRouteMetadata(entry.destination.route)
+                    GuardedRoute(navController = navController, route = routePattern, metadata = resolved)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GuardedRoute(
+    navController: NavHostController,
+    route: String,
+    metadata: RouteMetadata
+) {
+    val isAuthenticated = LinkpointApp.getInstanceOrNull()?.sessionManager?.isConnected() == true
+
+    if (metadata.requiresAuth && !isAuthenticated) {
+        LaunchedEffect(route) {
+            navController.navigateTo(Routes.LOGIN)
+        }
+        PlaceholderRoute("Authentication required", "Please sign in to continue.")
+        return
+    }
+
+    val legacyActivity = metadata.legacyActivity
+    if (legacyActivity != null && route != Routes.LOGIN) {
+        LegacyActivityRoute(activityClass = legacyActivity, title = metadata.title)
+    } else {
+        PlaceholderRoute(metadata.title, metadata.subtitle ?: "Compose destination ready for migration.")
+    }
+}
+
+@Composable
+private fun LegacyActivityRoute(
+    activityClass: KClass<out Activity>,
+    title: String
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    PlaceholderRoute(title, "Legacy activity opens as leaf destination.") {
+        launchLegacyActivity(context, activityClass)
+    }
+}
+
+private fun launchLegacyActivity(context: Context, activityClass: KClass<out Activity>) {
+    context.startActivity(Intent(context, activityClass.java))
+}
+
+@Composable
+private fun PlaceholderRoute(
+    title: String,
+    subtitle: String,
+    onOpenLegacy: (() -> Unit)? = null
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        // Login screen - entry point
-        composable(Routes.LOGIN) {
-            // LoginScreen would be called here with proper ViewModel integration
-            // For now, this serves as the navigation structure
-        }
-        
-        // Main world view
-        composable(Routes.WORLD) {
-            // WorldScreen composable
-        }
-        
-        // Chat screen
-        composable(Routes.CHAT) {
-            // ChatScreen composable
-        }
-        
-        // Inventory screen
-        composable(Routes.INVENTORY) {
-            // InventoryScreen composable
-        }
-        
-        // Friends screen
-        composable(Routes.FRIENDS) {
-            // FriendsScreen composable
-        }
-        
-        // Groups screen
-        composable(Routes.GROUPS) {
-            // GroupsScreen composable
-        }
-        
-        // Profile screen (other users)
-        composable(Routes.PROFILE) { backStackEntry ->
-            val userId = backStackEntry.arguments?.getString("userId") ?: return@composable
-            // ProfileScreen with userId
-        }
-        
-        // My profile screen
-        composable(Routes.MY_PROFILE) {
-            // ProfileScreen for current user
-        }
-        
-        // Settings screen
-        composable(Routes.SETTINGS) {
-            // SettingsScreen composable
-        }
-        
-        // World map screen
-        composable(Routes.MAP) {
-            // MapScreen composable
-        }
-        
-        // Minimap screen
-        composable(Routes.MINIMAP) {
-            // MinimapScreen composable
-        }
-        
-        // Search screen
-        composable(Routes.SEARCH) {
-            // SearchScreen composable
-        }
-        
-        // Teleport history screen
-        composable(Routes.TELEPORT_HISTORY) {
-            // TeleportHistoryScreen composable
-        }
-        
-        // Nearby people screen
-        composable(Routes.NEARBY_PEOPLE) {
-            // NearbyPeopleScreen composable
-        }
-        
-        // My avatar screen
-        composable(Routes.MY_AVATAR) {
-            // MyAvatarScreen composable
-        }
-        
-        // Terms of Service screen
-        composable(Routes.TOS) {
-            // TosScreen composable
-        }
-        
-        // Theme picker screen
-        composable(Routes.THEME_PICKER) {
-            // ThemePickerScreen composable
-        }
-        
-        // SLURL handler
-        composable(Routes.SLURL) { backStackEntry ->
-            val slurl = backStackEntry.arguments?.getString("slurl") ?: return@composable
-            // Handle SLURL navigation
-        }
-        
-        // XR World (VR/AR mode)
-        composable(Routes.XR_WORLD) {
-            // XRWorldScreen composable
+        Text(text = title, style = MaterialTheme.typography.headlineSmall)
+        Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(top = 8.dp))
+        onOpenLegacy?.let {
+            Button(onClick = it, modifier = Modifier.padding(top = 16.dp)) {
+                Text("Open legacy screen")
+            }
         }
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/WorldHomeHostActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/WorldHomeHostActivity.kt
@@ -1,0 +1,32 @@
+package com.linkpoint.ui.navigation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import com.linkpoint.ui.theme.LinkpointTheme
+
+/**
+ * First migration host activity that adopts the Compose app shell.
+ * Legacy activities remain leaf destinations launched from nav routes.
+ */
+class WorldHomeHostActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            LinkpointTheme(darkTheme = true) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    LinkpointNavHost(startDestination = Routes.WORLD)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a Compose-based app shell to enable an incremental migration from legacy Activities to a single-Activity / Compose navigation host. 
- Surface missing handoff/navigation destinations and attach metadata so UI (top bar / tabs / drawer) can be driven by route information.
- Protect routes that require an authenticated session with a guard so unauthenticated users are redirected to login while keeping legacy Activities usable as leaf destinations.

### Description
- Add a Compose shell at `ui/navigation/LinkpointAppShell.kt` implementing a top app bar, bottom navigation bound to `LinkpointMenus.bottomTabs`, and an optional drawer bound to `drawerSections`.
- Extend `Navigation.kt` to add new routes (`wallet`, `build_tools`, `notifications_feed`, `voice_deep`, `places/{placeId}`, `places/events`, onboarding steps) and introduce `RouteMetadata` carrying `menuPlacement`, `title`/`subtitle`, `backBehavior`, `requiresAuth`, and optional `legacyActivity` reference.
- Add `LinkpointMenus` (bottom tabs + drawer sections) and a `routeMetadata` map, plus `resolveRouteMetadata` logic to normalize dynamic routes (profile, slurl, places).
- Implement guarded routing via `GuardedRoute` which checks session state from `LinkpointApp.sessionManager`, redirects to `Routes.LOGIN` when `requiresAuth` is true and the session is not connected, and renders either a placeholder Compose screen or launches legacy Activities as leaf destinations.
- Add `WorldHomeHostActivity` as the first Compose migration host and wire `LinkpointNavHost`/`LinkpointAppShell` into it.
- Update `LoginActivity` to navigate to `WorldHomeHostActivity` after successful login (instead of directly launching `WorldViewActivity`).
- Register `WorldHomeHostActivity` in `AndroidManifest.xml`.

### Testing
- Attempted a Kotlin build with `./gradlew compileDebugKotlin`; build failed due to environment configuration (`SDK location not found`), so compile could not be validated in this environment.
- No automated unit/instrumentation tests were executed in this environment because Gradle could not complete due to the missing Android SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef543bddd48323b8611006787af0a3)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a **Compose-based navigation architecture** to enable incremental migration from legacy Activity-based navigation to a single-Activity pattern. It adds a `LinkpointAppShell` with top bar, bottom navigation, and drawer, defines route metadata (including auth requirements, menu placement, and legacy Activity references), implements authentication guards to redirect unauthenticated users to login, and creates `WorldHomeHostActivity` as the first Compose migration host. The login flow is updated to navigate to this new host instead of directly to `WorldViewActivity`, while legacy Activities remain as leaf destinations launched from navigation routes.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/Navigation.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointAppShell.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/WorldHomeHostActivity.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/login/LoginActivity.kt` |
| 5 | `Linkpoint/src/main/AndroidManifest.xml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->