### PR TITLE
Derive Material3 tokens from ThemePack and add theme token previews

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/BuiltInThemes.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/BuiltInThemes.kt
@@ -24,7 +24,10 @@ object BuiltInThemes {
         colorBackground = "#1A1A1A",
         colorSurface = "#2D2D2D",
         colorOnSurface = "#FFFFFF",
-        colorOnSurfaceVariant = "#B0B0B0"
+        colorOnSurfaceVariant = "#B0B0B0",
+        densityProfile = DensityProfile.STANDARD,
+        cornerProfile = CornerProfile.ROUNDED,
+        motionProfile = MotionProfile.STANDARD
     )
     
     /**
@@ -217,7 +220,10 @@ object BuiltInThemes {
         colorBackground = "#121212",
         colorSurface = "#1E1E1E",
         colorOnSurface = "#F5F5F5",
-        colorOnSurfaceVariant = "#BDBDBD"
+        colorOnSurfaceVariant = "#BDBDBD",
+        densityProfile = DensityProfile.COMPACT,
+        cornerProfile = CornerProfile.SHARP,
+        motionProfile = MotionProfile.EXPRESSIVE
     )
 
     /**

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/KthemeAdapters.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/KthemeAdapters.kt
@@ -8,6 +8,16 @@ import com.ktheme.models.ThemeMetadata
  * Map a Ktheme theme into Linkpoint's ThemePack format.
  */
 fun Theme.toThemePack(): ThemePack {
+    val densityProfile = metadata.tags.firstNotNullOfOrNull { tag ->
+        tag.removePrefix("density:").takeIf { it != tag }?.let { runCatching { DensityProfile.valueOf(it.uppercase()) }.getOrNull() }
+    }
+    val cornerProfile = metadata.tags.firstNotNullOfOrNull { tag ->
+        tag.removePrefix("corner:").takeIf { it != tag }?.let { runCatching { CornerProfile.valueOf(it.uppercase()) }.getOrNull() }
+    }
+    val motionProfile = metadata.tags.firstNotNullOfOrNull { tag ->
+        tag.removePrefix("motion:").takeIf { it != tag }?.let { runCatching { MotionProfile.valueOf(it.uppercase()) }.getOrNull() }
+    }
+
     return ThemePack(
         id = metadata.id,
         name = metadata.name,
@@ -25,7 +35,10 @@ fun Theme.toThemePack(): ThemePack {
         colorOnSurface = colorScheme.onSurface,
         colorOnSurfaceVariant = colorScheme.onSurfaceVariant,
         colorSurfaceVariant = colorScheme.surfaceVariant,
-        colorError = colorScheme.error
+        colorError = colorScheme.error,
+        densityProfile = densityProfile,
+        cornerProfile = cornerProfile,
+        motionProfile = motionProfile
     )
 }
 
@@ -41,7 +54,12 @@ fun ThemePack.toKthemeTheme(): Theme {
             description = description.ifBlank { "Linkpoint theme" },
             author = author,
             version = version,
-            tags = listOf("linkpoint"),
+            tags = buildList {
+                add("linkpoint")
+                densityProfile?.let { add("density:${it.name.lowercase()}") }
+                cornerProfile?.let { add("corner:${it.name.lowercase()}") }
+                motionProfile?.let { add("motion:${it.name.lowercase()}") }
+            },
             createdAt = now,
             updatedAt = now
         ),

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointMotion.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointMotion.kt
@@ -1,0 +1,43 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+@Immutable
+data class LinkpointMotion(
+    val fastMillis: Int,
+    val normalMillis: Int,
+    val slowMillis: Int
+)
+
+enum class MotionProfile {
+    REDUCED,
+    STANDARD,
+    EXPRESSIVE
+}
+
+fun ThemePack.resolvedMotionProfile(): MotionProfile = motionProfile ?: MotionProfile.STANDARD
+
+fun ThemePack.toMotion(): LinkpointMotion {
+    return when (resolvedMotionProfile()) {
+        MotionProfile.REDUCED -> LinkpointMotion(
+            fastMillis = 80,
+            normalMillis = 140,
+            slowMillis = 200
+        )
+
+        MotionProfile.STANDARD -> LinkpointMotion(
+            fastMillis = 120,
+            normalMillis = 220,
+            slowMillis = 320
+        )
+
+        MotionProfile.EXPRESSIVE -> LinkpointMotion(
+            fastMillis = 180,
+            normalMillis = 300,
+            slowMillis = 420
+        )
+    }
+}
+
+val LocalLinkpointMotion = staticCompositionLocalOf { BuiltInThemes.LINKPOINT_DEFAULT.toMotion() }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointShapes.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointShapes.kt
@@ -1,0 +1,44 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.dp
+
+enum class CornerProfile {
+    SHARP,
+    ROUNDED,
+    PILLED
+}
+
+fun ThemePack.resolvedCornerProfile(): CornerProfile = cornerProfile ?: CornerProfile.ROUNDED
+
+fun ThemePack.toMaterialShapes(): Shapes {
+    return when (resolvedCornerProfile()) {
+        CornerProfile.SHARP -> Shapes(
+            extraSmall = RoundedCornerShape(0.dp),
+            small = RoundedCornerShape(2.dp),
+            medium = RoundedCornerShape(4.dp),
+            large = RoundedCornerShape(6.dp),
+            extraLarge = RoundedCornerShape(8.dp)
+        )
+
+        CornerProfile.ROUNDED -> Shapes(
+            extraSmall = RoundedCornerShape(4.dp),
+            small = RoundedCornerShape(8.dp),
+            medium = RoundedCornerShape(12.dp),
+            large = RoundedCornerShape(16.dp),
+            extraLarge = RoundedCornerShape(20.dp)
+        )
+
+        CornerProfile.PILLED -> Shapes(
+            extraSmall = RoundedCornerShape(8.dp),
+            small = RoundedCornerShape(14.dp),
+            medium = RoundedCornerShape(20.dp),
+            large = RoundedCornerShape(28.dp),
+            extraLarge = RoundedCornerShape(36.dp)
+        )
+    }
+}
+
+val LocalLinkpointShapes = staticCompositionLocalOf { BuiltInThemes.LINKPOINT_DEFAULT.toMaterialShapes() }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointSpacing.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointSpacing.kt
@@ -1,0 +1,61 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class LinkpointSpacing(
+    val xxs: Dp,
+    val xs: Dp,
+    val sm: Dp,
+    val md: Dp,
+    val lg: Dp,
+    val xl: Dp,
+    val xxl: Dp
+)
+
+enum class DensityProfile {
+    COMPACT,
+    STANDARD,
+    COMFORTABLE
+}
+
+fun ThemePack.resolvedDensityProfile(): DensityProfile = densityProfile ?: DensityProfile.STANDARD
+
+fun ThemePack.toSpacing(): LinkpointSpacing {
+    return when (resolvedDensityProfile()) {
+        DensityProfile.COMPACT -> LinkpointSpacing(
+            xxs = 2.dp,
+            xs = 4.dp,
+            sm = 6.dp,
+            md = 10.dp,
+            lg = 14.dp,
+            xl = 18.dp,
+            xxl = 24.dp
+        )
+
+        DensityProfile.STANDARD -> LinkpointSpacing(
+            xxs = 4.dp,
+            xs = 8.dp,
+            sm = 12.dp,
+            md = 16.dp,
+            lg = 20.dp,
+            xl = 24.dp,
+            xxl = 32.dp
+        )
+
+        DensityProfile.COMFORTABLE -> LinkpointSpacing(
+            xxs = 6.dp,
+            xs = 10.dp,
+            sm = 14.dp,
+            md = 18.dp,
+            lg = 24.dp,
+            xl = 30.dp,
+            xxl = 40.dp
+        )
+    }
+}
+
+val LocalLinkpointSpacing = staticCompositionLocalOf { BuiltInThemes.LINKPOINT_DEFAULT.toSpacing() }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTheme.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTheme.kt
@@ -49,59 +49,74 @@ fun LinkpointTheme(
     val activeTheme by themeManager.activeTheme.collectAsState()
     val resolvedThemePack = themePack ?: activeTheme
     val linkpointColors = resolvedThemePack.toComposeColors()
-    
-    // Create Material 3 color scheme from ThemePack colors
-    // Support both dark and light themes based on system preference
-    val colorScheme = if (darkTheme) {
-        darkColorScheme(
-            primary = linkpointColors.primary,
-            onPrimary = linkpointColors.onPrimary,
-            primaryContainer = linkpointColors.primaryVariant,
-            onPrimaryContainer = linkpointColors.onPrimary,
-            secondary = linkpointColors.secondary,
-            onSecondary = linkpointColors.onSecondary,
-            secondaryContainer = linkpointColors.secondary,
-            onSecondaryContainer = linkpointColors.onSecondary,
-            background = linkpointColors.background,
-            onBackground = linkpointColors.onSurface,
-            surface = linkpointColors.surface,
-            onSurface = linkpointColors.onSurface,
-            surfaceVariant = linkpointColors.surfaceVariant,
-            onSurfaceVariant = linkpointColors.onSurfaceVariant,
-            error = linkpointColors.error,
-            onError = linkpointColors.onError
-        )
-    } else {
-        // Light theme - invert some colors for better contrast
-        lightColorScheme(
-            primary = linkpointColors.primary,
-            onPrimary = linkpointColors.onPrimary,
-            primaryContainer = linkpointColors.primaryVariant,
-            onPrimaryContainer = linkpointColors.onPrimary,
-            secondary = linkpointColors.secondary,
-            onSecondary = linkpointColors.onSecondary,
-            secondaryContainer = linkpointColors.secondary,
-            onSecondaryContainer = linkpointColors.onSecondary,
-            background = linkpointColors.onSurface,  // Inverted for light
-            onBackground = linkpointColors.background,
-            surface = linkpointColors.onSurface,  // Inverted for light
-            onSurface = linkpointColors.background,
-            surfaceVariant = linkpointColors.onSurfaceVariant,
-            onSurfaceVariant = linkpointColors.surface,
-            error = linkpointColors.error,
-            onError = linkpointColors.onError
-        )
-    }
-    
+
+    val colorScheme = resolvedThemePack.toMaterialColorScheme(
+        linkpointColors = linkpointColors,
+        darkTheme = darkTheme
+    )
+    val typography = resolvedThemePack.toMaterialTypography()
+    val shapes = resolvedThemePack.toMaterialShapes()
+    val spacing = resolvedThemePack.toSpacing()
+    val motion = resolvedThemePack.toMotion()
+
     CompositionLocalProvider(
         LocalLinkpointColors provides linkpointColors,
-        LocalThemePack provides resolvedThemePack
+        LocalThemePack provides resolvedThemePack,
+        LocalLinkpointTypography provides typography,
+        LocalLinkpointShapes provides shapes,
+        LocalLinkpointSpacing provides spacing,
+        LocalLinkpointMotion provides motion
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
+            typography = typography,
+            shapes = shapes,
             content = content
         )
     }
+}
+
+private fun ThemePack.toMaterialColorScheme(
+    linkpointColors: LinkpointColors,
+    darkTheme: Boolean
+) = if (darkTheme) {
+    darkColorScheme(
+        primary = linkpointColors.primary,
+        onPrimary = linkpointColors.onPrimary,
+        primaryContainer = linkpointColors.primaryVariant,
+        onPrimaryContainer = linkpointColors.onPrimary,
+        secondary = linkpointColors.secondary,
+        onSecondary = linkpointColors.onSecondary,
+        secondaryContainer = linkpointColors.secondary,
+        onSecondaryContainer = linkpointColors.onSecondary,
+        background = linkpointColors.background,
+        onBackground = linkpointColors.onSurface,
+        surface = linkpointColors.surface,
+        onSurface = linkpointColors.onSurface,
+        surfaceVariant = linkpointColors.surfaceVariant,
+        onSurfaceVariant = linkpointColors.onSurfaceVariant,
+        error = linkpointColors.error,
+        onError = linkpointColors.onError
+    )
+} else {
+    lightColorScheme(
+        primary = linkpointColors.primary,
+        onPrimary = linkpointColors.onPrimary,
+        primaryContainer = linkpointColors.primaryVariant,
+        onPrimaryContainer = linkpointColors.onPrimary,
+        secondary = linkpointColors.secondary,
+        onSecondary = linkpointColors.onSecondary,
+        secondaryContainer = linkpointColors.secondary,
+        onSecondaryContainer = linkpointColors.onSecondary,
+        background = linkpointColors.onSurface,
+        onBackground = linkpointColors.background,
+        surface = linkpointColors.onSurface,
+        onSurface = linkpointColors.background,
+        surfaceVariant = linkpointColors.onSurfaceVariant,
+        onSurfaceVariant = linkpointColors.surface,
+        error = linkpointColors.error,
+        onError = linkpointColors.onError
+    )
 }
 
 /**
@@ -129,4 +144,24 @@ object LinkpointTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalThemePack.current
+
+    val spacing: LinkpointSpacing
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalLinkpointSpacing.current
+
+    val motion: LinkpointMotion
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalLinkpointMotion.current
+
+    val typography: androidx.compose.material3.Typography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalLinkpointTypography.current
+
+    val shapes: androidx.compose.material3.Shapes
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalLinkpointShapes.current
 }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTypography.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTypography.kt
@@ -1,0 +1,36 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
+
+fun ThemePack.toMaterialTypography(): Typography {
+    val scale = when (resolvedDensityProfile()) {
+        DensityProfile.COMPACT -> 0.95f
+        DensityProfile.STANDARD -> 1f
+        DensityProfile.COMFORTABLE -> 1.08f
+    }
+
+    fun scaled(size: Int) = (size * scale).sp
+
+    return Typography(
+        displayLarge = TextStyle(fontSize = scaled(57), lineHeight = scaled(64)),
+        displayMedium = TextStyle(fontSize = scaled(45), lineHeight = scaled(52)),
+        displaySmall = TextStyle(fontSize = scaled(36), lineHeight = scaled(44)),
+        headlineLarge = TextStyle(fontSize = scaled(32), lineHeight = scaled(40)),
+        headlineMedium = TextStyle(fontSize = scaled(28), lineHeight = scaled(36)),
+        headlineSmall = TextStyle(fontSize = scaled(24), lineHeight = scaled(32)),
+        titleLarge = TextStyle(fontSize = scaled(22), lineHeight = scaled(28)),
+        titleMedium = TextStyle(fontSize = scaled(16), lineHeight = scaled(24)),
+        titleSmall = TextStyle(fontSize = scaled(14), lineHeight = scaled(20)),
+        bodyLarge = TextStyle(fontSize = scaled(16), lineHeight = scaled(24)),
+        bodyMedium = TextStyle(fontSize = scaled(14), lineHeight = scaled(20)),
+        bodySmall = TextStyle(fontSize = scaled(12), lineHeight = scaled(16)),
+        labelLarge = TextStyle(fontSize = scaled(14), lineHeight = scaled(20)),
+        labelMedium = TextStyle(fontSize = scaled(12), lineHeight = scaled(16)),
+        labelSmall = TextStyle(fontSize = scaled(11), lineHeight = scaled(16))
+    )
+}
+
+val LocalLinkpointTypography = staticCompositionLocalOf { BuiltInThemes.LINKPOINT_DEFAULT.toMaterialTypography() }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePack.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePack.kt
@@ -72,7 +72,16 @@ data class ThemePack(
     val colorSuccess: String = "#4CAF50",
     
     /** Optional: Warning color */
-    val colorWarning: String = "#FFC107"
+    val colorWarning: String = "#FFC107",
+
+    /** Optional profile that tunes UI density/spacing */
+    val densityProfile: DensityProfile? = null,
+
+    /** Optional profile that tunes shape corner radius */
+    val cornerProfile: CornerProfile? = null,
+
+    /** Optional profile that tunes motion/animation duration */
+    val motionProfile: MotionProfile? = null
 ) {
     companion object {
         private val json = Json { 
@@ -111,7 +120,10 @@ data class ThemePack(
                 colorBackground = "#1A1A1A",
                 colorSurface = "#2D2D2D",
                 colorOnSurface = "#FFFFFF",
-                colorOnSurfaceVariant = "#B0B0B0"
+                colorOnSurfaceVariant = "#B0B0B0",
+                densityProfile = DensityProfile.STANDARD,
+                cornerProfile = CornerProfile.ROUNDED,
+                motionProfile = MotionProfile.STANDARD
             )
         }
     }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemeTokenPreviews.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemeTokenPreviews.kt
@@ -1,0 +1,78 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(showBackground = true, name = "Theme Tokens - Default")
+@Composable
+private fun ThemeTokenPreviewDefault() {
+    LinkpointTheme(themePack = BuiltInThemes.LINKPOINT_DEFAULT, darkTheme = true) {
+        ThemeTokenPreviewContent()
+    }
+}
+
+@Preview(showBackground = true, name = "Theme Tokens - Firestorm")
+@Composable
+private fun ThemeTokenPreviewFirestorm() {
+    LinkpointTheme(themePack = BuiltInThemes.FIRESTORM, darkTheme = true) {
+        ThemeTokenPreviewContent()
+    }
+}
+
+@Composable
+private fun ThemeTokenPreviewContent() {
+    val spacing = LinkpointTheme.spacing
+    val motion = LinkpointTheme.motion
+
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.background)
+            .padding(spacing.md),
+        verticalArrangement = Arrangement.spacedBy(spacing.sm)
+    ) {
+        Text("Typography", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onBackground)
+        Text("Body Large", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onBackground)
+        Text("Body Medium", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onBackground)
+
+        Text("Shapes", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onBackground)
+        Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Card(modifier = Modifier.weight(1f)) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(spacing.xxl)
+                        .clip(MaterialTheme.shapes.small)
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                )
+            }
+            Card(modifier = Modifier.weight(1f)) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(spacing.xxl)
+                        .clip(MaterialTheme.shapes.large)
+                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                )
+            }
+        }
+
+        Text(
+            "Motion: fast=${motion.fastMillis}ms, normal=${motion.normalMillis}ms, slow=${motion.slowMillis}ms",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow themes to carry density/shape/motion profiles so UI tokens (spacing, typography, shapes, motion) can be derived from a `ThemePack` rather than hard-coded.
- Ensure switching the active theme recomputes all Compose locals so Material3 tokens update consistently across the UI.
- Provide developer previews to validate tokens for built-in themes during design iteration.

### Description
- Added token files under `ui/theme`: `LinkpointSpacing.kt`, `LinkpointShapes.kt`, `LinkpointTypography.kt`, and `LinkpointMotion.kt` which provide profile enums, conversion helpers (`ThemePack.toSpacing()`, `toMaterialTypography()`, `toMaterialShapes()`, `toMotion()`), and `staticCompositionLocalOf` locals for each token set.
- Extended `ThemePack` with optional metadata fields `densityProfile`, `cornerProfile`, and `motionProfile`, and updated the template and some built-in themes to include sane defaults.
- Updated `LinkpointTheme` to derive a Material3 `ColorScheme` plus `Typography` and `Shapes` from the resolved `ThemePack`, and to provide composition locals for typography, shapes, spacing and motion so token recomputation follows `ThemeManager.activeTheme` changes (via `toMaterialColorScheme`, `toMaterialTypography`, `toMaterialShapes`, `toSpacing`, `toMotion`).
- Extended Ktheme adapters to round-trip profile metadata using theme `tags` (e.g. `density:*`, `corner:*`, `motion:*`) so external themes preserve these profiles.
- Added `ThemeTokenPreviews.kt` dev preview composables that render typography, shapes, spacing and motion metadata for built-in themes.

### Testing
- Attempted to compile Kotlin sources with `./gradlew compileDebugKotlin`; this run failed in the current environment due to missing Android SDK configuration (`sdk.dir` in `local.properties` or `ANDROID_HOME` is not set). 
- No unit or instrumentation tests were run in this environment because the build could not complete due to the SDK configuration issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6457ca58832385e79d24269b84d1)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extends the theme system to support dynamic UI token generation by allowing `ThemePack` to carry density, shape, and motion profiles. Material3 design tokens (typography, shapes, spacing, and motion) are now derived from the active theme rather than being hard-coded, ensuring consistent UI updates when themes switch. The changes add profile enums and conversion helpers, extend the `ThemePack` data model with optional metadata fields, update theme composition locals to recompute tokens based on `ThemeManager.activeTheme`, add round-trip support for profile metadata in Ktheme adapters via tags, and provide developer preview composables to validate tokens for built-in themes.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePack.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointSpacing.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointShapes.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTypography.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointMotion.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTheme.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/BuiltInThemes.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/KthemeAdapters.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemeTokenPreviews.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->