### PR TITLE
Add UI module boundaries and Gradle checks to enforce one-way UI dependencies

### DIFF
--- a/Linkpoint/build.gradle.kts
+++ b/Linkpoint/build.gradle.kts
@@ -9,6 +9,63 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "2.2.21"
 }
 
+data class UiBoundaryRule(
+    val moduleName: String,
+    val packagePrefixes: Set<String>,
+    val allowedUiDependencies: Set<String>
+)
+
+val sharedUiModules = setOf("theme", "navigation", "components", "common", "dialogs")
+val uiBoundaryRules = listOf(
+    UiBoundaryRule(
+        moduleName = "ui-theme",
+        packagePrefixes = setOf("com.linkpoint.ui.theme"),
+        allowedUiDependencies = emptySet()
+    ),
+    UiBoundaryRule(
+        moduleName = "ui-common-components",
+        packagePrefixes = setOf(
+            "com.linkpoint.ui.components",
+            "com.linkpoint.ui.common",
+            "com.linkpoint.ui.dialogs"
+        ),
+        allowedUiDependencies = setOf("theme")
+    ),
+    UiBoundaryRule(
+        moduleName = "ui-navigation",
+        packagePrefixes = setOf("com.linkpoint.ui.navigation"),
+        allowedUiDependencies = setOf("theme", "components", "common", "dialogs")
+    ),
+    UiBoundaryRule(
+        moduleName = "ui/chat",
+        packagePrefixes = setOf("com.linkpoint.ui.chat"),
+        allowedUiDependencies = sharedUiModules
+    ),
+    UiBoundaryRule(
+        moduleName = "ui/inventory",
+        packagePrefixes = setOf("com.linkpoint.ui.inventory"),
+        allowedUiDependencies = sharedUiModules
+    ),
+    UiBoundaryRule(
+        moduleName = "ui/world",
+        packagePrefixes = setOf("com.linkpoint.ui.world"),
+        allowedUiDependencies = sharedUiModules
+    )
+)
+
+val runtimePackagesForbiddenInUi = listOf(
+    "com.linkpoint.protocol",
+    "com.linkpoint.network",
+    "com.linkpoint.render"
+)
+val runtimeInterfaceGateSegments = listOf(
+    ".api.",
+    ".interfaces.",
+    ".adapter.",
+    ".adapters.",
+    ".contract."
+)
+
 // Configuration for libGDX native libraries
 val natives by configurations.creating
 
@@ -442,3 +499,84 @@ val verifyNoPlaceholderOnlyEntities by tasks.registering {
 
 tasks.matching { it.name == "assembleRelease" || it.name == "bundleRelease" || it.name == "lintVitalRelease" }
     .configureEach { dependsOn(verifyNoPlaceholderOnlyEntities) }
+
+val verifyUiArchitectureBoundaries by tasks.registering {
+    group = "verification"
+    description = "Enforces one-way UI dependencies and runtime/service boundary rules."
+    doLast {
+        val sourceRoot = file("src/main/java")
+        val kotlinFiles = sourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .toList()
+
+        val packageRegex = Regex("""^\s*package\s+([A-Za-z0-9_.]+)""", RegexOption.MULTILINE)
+        val importRegex = Regex("""^\s*import\s+([A-Za-z0-9_.]+)""", RegexOption.MULTILINE)
+
+        fun resolveRule(pkg: String): UiBoundaryRule? = uiBoundaryRules.firstOrNull { rule ->
+            rule.packagePrefixes.any { pkg == it || pkg.startsWith("$it.") }
+        }
+
+        val violations = mutableListOf<String>()
+
+        kotlinFiles.forEach { file ->
+            val relative = file.relativeTo(projectDir).path
+            val text = file.readText()
+            val pkg = packageRegex.find(text)?.groupValues?.get(1) ?: return@forEach
+            val imports = importRegex.findAll(text).map { it.groupValues[1] }.toList()
+
+            val inUiPackage = pkg == "com.linkpoint.ui" || pkg.startsWith("com.linkpoint.ui.")
+
+            if (inUiPackage) {
+                // Rule 1: UI should only touch runtime/service/protocol through interfaces/adapters.
+                imports.filter { imp ->
+                    runtimePackagesForbiddenInUi.any { prefix -> imp == prefix || imp.startsWith("$prefix.") }
+                }.forEach { imp ->
+                    val allowedByInterface = runtimeInterfaceGateSegments.any { segment -> imp.contains(segment) } ||
+                        imp.endsWith(".Api") || imp.endsWith("Api") || imp.endsWith("Adapter") || imp.endsWith("Port")
+                    if (!allowedByInterface) {
+                        violations += "$relative imports forbidden runtime package dependency: $imp"
+                    }
+                }
+
+                // Rule 2: Feature packages are one-way: shared UI modules can be consumed,
+                // but feature-to-feature imports are blocked.
+                val ownerRule = resolveRule(pkg)
+                if (ownerRule != null) {
+                    imports.filter { it.startsWith("com.linkpoint.ui.") }.forEach { imp ->
+                        val segment = imp.removePrefix("com.linkpoint.ui.").substringBefore(".")
+                        val isSameFeature = ownerRule.packagePrefixes.any { own ->
+                            val ownSegment = own.removePrefix("com.linkpoint.ui.").substringBefore(".")
+                            ownSegment == segment
+                        }
+                        val allowed = segment in ownerRule.allowedUiDependencies
+                        if (!isSameFeature && !allowed) {
+                            violations += "$relative has disallowed UI dependency from ${ownerRule.moduleName} -> com.linkpoint.ui.$segment"
+                        }
+                    }
+                }
+            } else {
+                // Rule 3: Domain/service/runtime modules must not depend on UI packages.
+                imports.filter { it == "com.linkpoint.ui" || it.startsWith("com.linkpoint.ui.") }
+                    .forEach { imp ->
+                        violations += "$relative creates reverse dependency on UI package: $imp"
+                    }
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("UI architecture boundary check failed (${violations.size} violation(s)):")
+                    violations.sorted().forEach { appendLine(" - $it") }
+                    appendLine()
+                    appendLine("Fix imports to keep dependency direction one-way:")
+                    appendLine("UI -> domain/service adapters/interfaces, never reverse.")
+                }
+            )
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(verifyUiArchitectureBoundaries)
+}

--- a/Linkpoint/docs/ui-refactor/module-map.md
+++ b/Linkpoint/docs/ui-refactor/module-map.md
@@ -1,0 +1,21 @@
+# UI Refactor Module Map
+
+> Scope: package-level modules inside the current `Linkpoint` Android app module.
+
+| Module | Primary package(s) | Depends on | Owner | Review-required labels |
+|---|---|---|---|---|
+| `ui-theme` | `com.linkpoint.ui.theme` | _none_ | `@ui-foundation` | `area:ui`, `review:design-system` |
+| `ui-common-components` | `com.linkpoint.ui.components`, `com.linkpoint.ui.common`, `com.linkpoint.ui.dialogs` | `ui-theme` | `@ui-foundation` | `area:ui`, `review:component-api` |
+| `ui-navigation` | `com.linkpoint.ui.navigation` | `ui-theme`, `ui-common-components` | `@ui-platform` | `area:ui`, `review:navigation` |
+| `ui/chat` | `com.linkpoint.ui.chat` | `ui-theme`, `ui-common-components`, `ui-navigation`, domain/service adapters | `@feature-chat` | `area:chat`, `review:ui-arch` |
+| `ui/inventory` | `com.linkpoint.ui.inventory` | `ui-theme`, `ui-common-components`, `ui-navigation`, domain/service adapters | `@feature-inventory` | `area:inventory`, `review:ui-arch` |
+| `ui/world` | `com.linkpoint.ui.world` | `ui-theme`, `ui-common-components`, `ui-navigation`, domain/service adapters | `@feature-world` | `area:world`, `review:ui-arch` |
+| Other `ui/*` feature packages (`ui/avatar`, `ui/map`, `ui/people`, etc.) | `com.linkpoint.ui.<feature>` | `ui-theme`, `ui-common-components`, `ui-navigation`, domain/service adapters | Per-feature maintainers | `area:ui`, `review:ui-arch` |
+
+## Boundary rules
+
+1. **One-way direction:** `ui/*` packages may depend on domain/service adapter interfaces, but non-UI packages must not import `com.linkpoint.ui.*`.
+2. **Runtime/protocol isolation:** `com.linkpoint.protocol`, `com.linkpoint.network`, and `com.linkpoint.render` are blocked from direct UI coupling except via explicit API/interface/adapter contracts.
+3. **Feature encapsulation:** `ui/chat`, `ui/inventory`, `ui/world`, and other feature packages should not import each other directly; shared code must live in `ui-theme`, `ui-common-components`, or `ui-navigation`.
+
+Implementation note: enforced by `verifyUiArchitectureBoundaries` in `build.gradle.kts`.

--- a/Linkpoint/settings.gradle.kts
+++ b/Linkpoint/settings.gradle.kts
@@ -20,3 +20,37 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "Linkpoint"
+
+/**
+ * UI feature-module boundaries for the refactor plan.
+ *
+ * These are package-level boundaries inside the current single-module Android app.
+ * They are consumed by build logic and docs to keep dependency direction explicit.
+ */
+val uiFeatureBoundaries = mapOf(
+    "ui-theme" to listOf("com.linkpoint.ui.theme"),
+    "ui-navigation" to listOf("com.linkpoint.ui.navigation"),
+    "ui-common-components" to listOf(
+        "com.linkpoint.ui.components",
+        "com.linkpoint.ui.common",
+        "com.linkpoint.ui.dialogs"
+    ),
+    "ui/chat" to listOf("com.linkpoint.ui.chat"),
+    "ui/inventory" to listOf("com.linkpoint.ui.inventory"),
+    "ui/world" to listOf("com.linkpoint.ui.world")
+)
+
+val uiRuntimeBoundaries = mapOf(
+    "forbiddenRuntimePackages" to listOf(
+        "com.linkpoint.protocol",
+        "com.linkpoint.network",
+        "com.linkpoint.render"
+    ),
+    "allowedInterfaceSegments" to listOf(
+        ".api.",
+        ".interfaces.",
+        ".adapter.",
+        ".adapters.",
+        ".contract."
+    )
+)


### PR DESCRIPTION
### Motivation

- Clarify and enforce package-level UI feature boundaries (theme, navigation, common components, and feature packages) while the app remains a single Gradle module. 
- Prevent accidental coupling of UI code to runtime/service/protocol implementations (`com.linkpoint.protocol`, `com.linkpoint.network`, `com.linkpoint.render`) except via explicit adapter/interface contracts. 
- Ensure UI features depend only on shared UI modules or domain/service adapter interfaces and disallow reverse or feature-to-feature imports.

### Description

- Added package-level UI feature declarations in `Linkpoint/settings.gradle.kts` with entries for `ui-theme`, `ui-navigation`, `ui-common-components`, `ui/chat`, `ui/inventory`, and `ui/world` and runtime boundary metadata (`forbiddenRuntimePackages` and `allowedInterfaceSegments`).
- Implemented `UiBoundaryRule` and boundary rules in `Linkpoint/build.gradle.kts`, including the shared UI allowlist (`theme`, `navigation`, `components`, `common`, `dialogs`) and runtime/interface gate segments.
- Added a verification Gradle task `verifyUiArchitectureBoundaries` that scans Kotlin sources to enforce: (1) UI packages may only import runtime/protocol/render packages via allowed interface/adapter segments or explicit adapter types, (2) non-UI packages must not import `com.linkpoint.ui.*`, and (3) feature-to-feature UI imports are blocked unless allowed by shared modules.
- Added `Linkpoint/docs/ui-refactor/module-map.md` with a concise architecture map listing modules, primary packages, owners, and review-required labels and a short summary of the boundary rules.

### Testing

- Ran a quick automated scan that found UI files importing runtime/protocol/render packages to inform the rules (`python` script scan of `com.linkpoint.ui` sources).
- Executed `./gradlew -p Linkpoint verifyUiArchitectureBoundaries`, which could not complete in this environment because the Android SDK location is not configured (no `ANDROID_HOME` or `local.properties`), so the Gradle verification task was not allowed to run to completion.
- No unit/integration tests were modified; verification is wired into the `check` lifecycle so CI with a configured Android SDK will run the boundary checks automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6455afc0832381eb8f31c3f602e8)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces **package-level UI module boundaries** within the existing single-module Android app to enforce one-way dependencies between UI features and runtime/service layers. It adds Gradle-based architecture enforcement through a custom verification task (`verifyUiArchitectureBoundaries`) that prevents UI code from directly coupling to protocol, network, and render implementations except via explicit adapter/interface contracts, blocks reverse dependencies from non-UI code into UI packages, and prevents feature-to-feature imports while allowing shared UI modules (`theme`, `navigation`, `components`, `common`, `dialogs`) to be consumed by all features. The changes include boundary metadata declarations in `settings.gradle.kts`, enforcement rules and the verification task in `build.gradle.kts`, and comprehensive documentation mapping the module structure, ownership, and rules.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/docs/ui-refactor/module-map.md` |
| 2 | `Linkpoint/settings.gradle.kts` |
| 3 | `Linkpoint/build.gradle.kts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->