### PR TITLE
Add shared UI state composables and integrate into Chat/Inventory/Friends/Map

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatScreen.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatScreen.kt
@@ -39,6 +39,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
+import com.linkpoint.ui.components.state.EmptyState
+import com.linkpoint.ui.components.state.ErrorState
+import com.linkpoint.ui.components.state.LoadingState
+import com.linkpoint.ui.components.state.LowBandwidthOverlay
+import com.linkpoint.ui.components.state.ReconnectingBanner
+import com.linkpoint.ui.components.state.ScreenState
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -94,6 +100,11 @@ fun ChatScreen(
     currentAvatarName: String = "You",
     onSendMessage: (String, ChatChannel) -> Unit,
     onNavigateBack: () -> Unit,
+    state: ScreenState<List<ChatMessage>> = if (messages.isEmpty()) ScreenState.Empty else ScreenState.Content(messages),
+    onRetry: () -> Unit = {},
+    onTelemetry: (eventName: String, metadata: Map<String, String>) -> Unit = { _, _ -> },
+    isLowBandwidth: Boolean = false,
+    isReconnecting: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     var selectedChannel by remember { mutableIntStateOf(0) }
@@ -144,17 +155,50 @@ fun ChatScreen(
                 }
             }
             
-            // Message list
-            LazyColumn(
+            if (isReconnecting) {
+                ReconnectingBanner()
+            }
+
+            Box(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth(),
-                state = listState,
-                contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                    .fillMaxWidth()
             ) {
-                items(filteredMessages, key = { it.id }) { message ->
-                    ChatMessageItem(message = message)
+                when (state) {
+                    ScreenState.Loading -> LoadingState(message = "Loading chat...")
+                    ScreenState.Empty -> EmptyState(
+                        title = "No messages yet",
+                        message = "Start the conversation in this channel."
+                    )
+                    is ScreenState.Error -> ErrorState(
+                        message = state.message,
+                        onRetry = onRetry,
+                        telemetryContext = state.telemetryContext,
+                        onTelemetry = onTelemetry
+                    )
+                    is ScreenState.Content -> {
+                        if (filteredMessages.isEmpty()) {
+                            EmptyState(
+                                title = "No messages yet",
+                                message = "Start the conversation in this channel."
+                            )
+                        } else {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                state = listState,
+                                contentPadding = PaddingValues(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                items(filteredMessages, key = { it.id }) { message ->
+                                    ChatMessageItem(message = message)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (isLowBandwidth) {
+                    LowBandwidthOverlay()
                 }
             }
             

--- a/Linkpoint/src/main/java/com/linkpoint/ui/components/state/EmptyState.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/components/state/EmptyState.kt
@@ -1,0 +1,43 @@
+package com.linkpoint.ui.components.state
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Composable
+fun EmptyState(
+    title: String,
+    message: String,
+    icon: ImageVector? = null,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        icon?.let {
+            Icon(
+                imageVector = it,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium
+        )
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/components/state/ErrorState.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/components/state/ErrorState.kt
@@ -1,0 +1,65 @@
+package com.linkpoint.ui.components.state
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ErrorState(
+    message: String,
+    onRetry: (() -> Unit)? = null,
+    telemetryContext: String = "unknown",
+    onTelemetry: (eventName: String, metadata: Map<String, String>) -> Unit = { _, _ -> },
+    modifier: Modifier = Modifier
+) {
+    LaunchedEffect(message, telemetryContext) {
+        onTelemetry(
+            "error_state_shown",
+            mapOf(
+                "context" to telemetryContext,
+                "message" to message
+            )
+        )
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Something went wrong",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.error
+        )
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        if (onRetry != null) {
+            Button(
+                onClick = {
+                    onTelemetry(
+                        "error_state_retry_tapped",
+                        mapOf(
+                            "context" to telemetryContext,
+                            "message" to message
+                        )
+                    )
+                    onRetry()
+                }
+            ) {
+                Text("Retry")
+            }
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/components/state/LoadingState.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/components/state/LoadingState.kt
@@ -1,0 +1,29 @@
+package com.linkpoint.ui.components.state
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LoadingState(
+    message: String = "Loading...",
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        CircularProgressIndicator()
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/components/state/LowBandwidthOverlay.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/components/state/LowBandwidthOverlay.kt
@@ -1,0 +1,37 @@
+package com.linkpoint.ui.components.state
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LowBandwidthOverlay(
+    message: String = "Low bandwidth mode enabled",
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.35f)),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.9f))
+                .padding(horizontal = 16.dp, vertical = 10.dp)
+        )
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/components/state/ReconnectingBanner.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/components/state/ReconnectingBanner.kt
@@ -1,0 +1,26 @@
+package com.linkpoint.ui.components.state
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ReconnectingBanner(
+    message: String = "Connection unstable. Reconnecting...",
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onTertiary,
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.tertiary)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/components/state/ScreenState.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/components/state/ScreenState.kt
@@ -1,0 +1,15 @@
+package com.linkpoint.ui.components.state
+
+/**
+ * Shared UI state contract for list/detail style screens.
+ */
+sealed interface ScreenState<out T> {
+    data object Loading : ScreenState<Nothing>
+    data class Content<T>(val data: T) : ScreenState<T>
+    data object Empty : ScreenState<Nothing>
+    data class Error(
+        val message: String,
+        val throwable: Throwable? = null,
+        val telemetryContext: String = "unknown"
+    ) : ScreenState<Nothing>
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsScreen.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsScreen.kt
@@ -47,6 +47,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.linkpoint.ui.components.state.EmptyState
+import com.linkpoint.ui.components.state.ErrorState
+import com.linkpoint.ui.components.state.LoadingState
+import com.linkpoint.ui.components.state.ReconnectingBanner
+import com.linkpoint.ui.components.state.ScreenState
 import java.util.UUID
 
 /**
@@ -91,6 +96,10 @@ fun FriendsScreen(
     onViewProfile: (FriendData) -> Unit,
     onRemoveFriend: (FriendData) -> Unit,
     onAddFriend: (String) -> Unit,
+    state: ScreenState<List<FriendData>> = if (friends.isEmpty()) ScreenState.Empty else ScreenState.Content(friends),
+    onRetry: () -> Unit = {},
+    onTelemetry: (eventName: String, metadata: Map<String, String>) -> Unit = { _, _ -> },
+    isReconnecting: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     var showAddDialog by remember { mutableStateOf(false) }
@@ -123,43 +132,41 @@ fun FriendsScreen(
             }
         }
     ) { paddingValues ->
-        if (sortedFriends.isEmpty()) {
-            Box(
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        imageVector = Icons.Default.Person,
-                        contentDescription = null,
-                        modifier = Modifier.size(64.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = "No friends yet",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            if (isReconnecting) {
+                ReconnectingBanner()
             }
-        } else {
-            LazyColumn(
-                modifier = modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(sortedFriends, key = { it.id }) { friend ->
-                    FriendCard(
-                        friend = friend,
-                        onOpenIM = { onOpenIM(friend) },
-                        onTeleportTo = { onTeleportTo(friend) },
-                        onViewProfile = { onViewProfile(friend) },
-                        onRemove = { onRemoveFriend(friend) }
-                    )
+            when (state) {
+                ScreenState.Loading -> LoadingState(message = "Loading friends...")
+                ScreenState.Empty -> EmptyState(
+                    title = "No friends yet",
+                    message = "Use the add button to send your first friend request.",
+                    icon = Icons.Default.Person
+                )
+                is ScreenState.Error -> ErrorState(
+                    message = state.message,
+                    onRetry = onRetry,
+                    telemetryContext = state.telemetryContext,
+                    onTelemetry = onTelemetry
+                )
+                is ScreenState.Content -> LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(sortedFriends, key = { it.id }) { friend ->
+                        FriendCard(
+                            friend = friend,
+                            onOpenIM = { onOpenIM(friend) },
+                            onTeleportTo = { onTeleportTo(friend) },
+                            onViewProfile = { onViewProfile(friend) },
+                            onRemove = { onRemoveFriend(friend) }
+                        )
+                    }
                 }
             }
         }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryScreen.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryScreen.kt
@@ -2,7 +2,6 @@ package com.linkpoint.ui.inventory
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -38,6 +37,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.linkpoint.ui.components.state.EmptyState
+import com.linkpoint.ui.components.state.ErrorState
+import com.linkpoint.ui.components.state.LoadingState
+import com.linkpoint.ui.components.state.ScreenState
 import java.util.UUID
 
 /**
@@ -88,6 +91,9 @@ fun InventoryScreen(
     onItemClick: (InventoryItemData) -> Unit,
     onNavigateBack: () -> Unit,
     onNavigateUp: () -> Unit,
+    state: ScreenState<List<InventoryItemData>> = if (items.isEmpty()) ScreenState.Empty else ScreenState.Content(items),
+    onRetry: () -> Unit = {},
+    onTelemetry: (eventName: String, metadata: Map<String, String>) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     Scaffold(
@@ -120,29 +126,30 @@ fun InventoryScreen(
                 )
             }
             
-            // Items list
-            if (items.isEmpty()) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "This folder is empty",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            } else {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    items(items, key = { it.id }) { item ->
-                        InventoryItemCard(
-                            item = item,
-                            onClick = { onItemClick(item) }
-                        )
+            when (state) {
+                ScreenState.Loading -> LoadingState(message = "Loading inventory...")
+                ScreenState.Empty -> EmptyState(
+                    title = "Inventory is empty",
+                    message = "This folder has no items yet."
+                )
+                is ScreenState.Error -> ErrorState(
+                    message = state.message,
+                    onRetry = onRetry,
+                    telemetryContext = state.telemetryContext,
+                    onTelemetry = onTelemetry
+                )
+                is ScreenState.Content -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(items, key = { it.id }) { item ->
+                            InventoryItemCard(
+                                item = item,
+                                onClick = { onItemClick(item) }
+                            )
+                        }
                     }
                 }
             }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/map/MapScreen.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/map/MapScreen.kt
@@ -1,7 +1,6 @@
 package com.linkpoint.ui.map
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
@@ -45,6 +44,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
+import com.linkpoint.ui.components.state.EmptyState
+import com.linkpoint.ui.components.state.ErrorState
+import com.linkpoint.ui.components.state.LoadingState
+import com.linkpoint.ui.components.state.LowBandwidthOverlay
+import com.linkpoint.ui.components.state.ReconnectingBanner
+import com.linkpoint.ui.components.state.ScreenState
 
 /**
  * Region data for map display
@@ -102,6 +107,11 @@ fun MapScreen(
     onTeleportTo: (MapRegion) -> Unit,
     onTeleportHome: () -> Unit,
     onSearch: (String) -> Unit,
+    state: ScreenState<List<MapRegion>> = if (regions.isEmpty()) ScreenState.Empty else ScreenState.Content(regions),
+    onRetry: () -> Unit = {},
+    onTelemetry: (eventName: String, metadata: Map<String, String>) -> Unit = { _, _ -> },
+    isLowBandwidth: Boolean = false,
+    isReconnecting: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     var searchQuery by remember { mutableStateOf("") }
@@ -126,68 +136,86 @@ fun MapScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            // Map canvas
-            Canvas(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .pointerInput(Unit) {
-                        detectTransformGestures { _, pan, gestureZoom, _ ->
-                            zoom = (zoom * gestureZoom).coerceIn(0.5f, 4f)
-                            offset += pan
-                        }
-                    }
-                    .pointerInput(Unit) {
-                        detectTapGestures { tapOffset ->
-                            // Convert tap to world coordinates
-                            val worldX = ((tapOffset.x - offset.x) / zoom / 256f).toInt()
-                            val worldY = ((tapOffset.y - offset.y) / zoom / 256f).toInt()
-                            
-                            selectedRegion = regions.find { it.x == worldX && it.y == worldY }
-                        }
-                    }
-            ) {
-                val gridSize = 256f * zoom
-                
-                translate(offset.x, offset.y) {
-                    // Draw grid
-                    val startX = (-offset.x / gridSize).toInt() - 1
-                    val endX = ((size.width - offset.x) / gridSize).toInt() + 1
-                    val startY = (-offset.y / gridSize).toInt() - 1
-                    val endY = ((size.height - offset.y) / gridSize).toInt() + 1
-                    
-                    for (x in startX..endX) {
-                        for (y in startY..endY) {
-                            val region = regions.find { it.x == x && it.y == y }
-                            val color = when {
-                                region == null -> Color(0xFF1A1A1A)  // No region
-                                !region.isOnline -> Color(0xFF333333)  // Offline
-                                region.access == RegionAccess.ADULT -> Color(0xFF442222)
-                                region.access == RegionAccess.MODERATE -> Color(0xFF334422)
-                                else -> Color(0xFF224444)  // General
+            Column(modifier = Modifier.fillMaxSize()) {
+                if (isReconnecting) {
+                    ReconnectingBanner()
+                }
+
+                when (state) {
+                    ScreenState.Loading -> LoadingState(message = "Loading world map...")
+                    ScreenState.Empty -> EmptyState(
+                        title = "Map data unavailable",
+                        message = "No regions are currently loaded."
+                    )
+                    is ScreenState.Error -> ErrorState(
+                        message = state.message,
+                        onRetry = onRetry,
+                        telemetryContext = state.telemetryContext,
+                        onTelemetry = onTelemetry
+                    )
+                    is ScreenState.Content -> Canvas(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .pointerInput(Unit) {
+                                detectTransformGestures { _, pan, gestureZoom, _ ->
+                                    zoom = (zoom * gestureZoom).coerceIn(0.5f, 4f)
+                                    offset += pan
+                                }
                             }
-                            
-                            drawRect(
-                                color = color,
-                                topLeft = Offset(x * gridSize, y * gridSize),
-                                size = androidx.compose.ui.geometry.Size(gridSize - 1, gridSize - 1)
-                            )
+                            .pointerInput(Unit) {
+                                detectTapGestures { tapOffset ->
+                                    // Convert tap to world coordinates
+                                    val worldX = ((tapOffset.x - offset.x) / zoom / 256f).toInt()
+                                    val worldY = ((tapOffset.y - offset.y) / zoom / 256f).toInt()
+
+                                    selectedRegion = regions.find { it.x == worldX && it.y == worldY }
+                                }
+                            }
+                    ) {
+                        val gridSize = 256f * zoom
+
+                        translate(offset.x, offset.y) {
+                            // Draw grid
+                            val startX = (-offset.x / gridSize).toInt() - 1
+                            val endX = ((size.width - offset.x) / gridSize).toInt() + 1
+                            val startY = (-offset.y / gridSize).toInt() - 1
+                            val endY = ((size.height - offset.y) / gridSize).toInt() + 1
+
+                            for (x in startX..endX) {
+                                for (y in startY..endY) {
+                                    val region = regions.find { it.x == x && it.y == y }
+                                    val color = when {
+                                        region == null -> Color(0xFF1A1A1A)  // No region
+                                        !region.isOnline -> Color(0xFF333333)  // Offline
+                                        region.access == RegionAccess.ADULT -> Color(0xFF442222)
+                                        region.access == RegionAccess.MODERATE -> Color(0xFF334422)
+                                        else -> Color(0xFF224444)  // General
+                                    }
+
+                                    drawRect(
+                                        color = color,
+                                        topLeft = Offset(x * gridSize, y * gridSize),
+                                        size = androidx.compose.ui.geometry.Size(gridSize - 1, gridSize - 1)
+                                    )
+                                }
+                            }
+
+                            // Draw markers
+                            markers.forEach { marker ->
+                                val markerColor = when (marker.type) {
+                                    MarkerType.SELF -> Color.Green
+                                    MarkerType.FRIEND -> Color.Yellow
+                                    MarkerType.LANDMARK -> Color.Cyan
+                                    MarkerType.TELEPORT_HISTORY -> Color.Magenta
+                                }
+
+                                drawCircle(
+                                    color = markerColor,
+                                    radius = 8f * zoom,
+                                    center = Offset(marker.x * gridSize, marker.y * gridSize)
+                                )
+                            }
                         }
-                    }
-                    
-                    // Draw markers
-                    markers.forEach { marker ->
-                        val markerColor = when (marker.type) {
-                            MarkerType.SELF -> Color.Green
-                            MarkerType.FRIEND -> Color.Yellow
-                            MarkerType.LANDMARK -> Color.Cyan
-                            MarkerType.TELEPORT_HISTORY -> Color.Magenta
-                        }
-                        
-                        drawCircle(
-                            color = markerColor,
-                            radius = 8f * zoom,
-                            center = Offset(marker.x * gridSize, marker.y * gridSize)
-                        )
                     }
                 }
             }
@@ -307,6 +335,10 @@ fun MapScreen(
                         }
                     }
                 }
+            }
+
+            if (isLowBandwidth) {
+                LowBandwidthOverlay(message = "Low bandwidth mode: map updates are throttled.")
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Unify list/detail screens around a single, reusable UI state contract to reduce duplication and standardize `Loading`/`Content`/`Empty`/`Error` rendering semantics.
- Provide canonical empty/error/loading patterns and surface simple network signals (`low-bandwidth`, `reconnecting`) so screens can show consistent UX and telemetry hooks.

### Description
- Add a sealed UI state contract `ScreenState<T>` with `Loading`, `Content`, `Empty`, and `Error` variants in `ui/components/state/ScreenState.kt`.
- Add reusable composables `LoadingState`, `ErrorState` (with `onRetry` + `onTelemetry` hooks), `EmptyState`, `LowBandwidthOverlay`, and `ReconnectingBanner` under `ui/components/state/`.
- Update `ChatScreen`, `InventoryScreen`, `FriendsScreen`, and `MapScreen` to accept `state: ScreenState<...>`, `onRetry`, and `onTelemetry` where appropriate, and to render using the new shared components (also added `isLowBandwidth`/`isReconnecting` flags where requested).
- Implemented error telemetry reporting in `ErrorState` and wired retry telemetry events to the retry button before invoking `onRetry`.

### Testing
- Ran `git diff --check` to validate diffs and whitespace, which succeeded.
- Attempted to run `./gradlew compileDebugKotlin` to compile Kotlin sources but the task failed in this environment due to a missing Android SDK (`ANDROID_HOME`/`sdk.dir` not configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef54554da48323a5a90406def6b1f7)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a unified UI state management pattern across multiple screens in the app. It adds a reusable `ScreenState<T>` sealed interface with variants for **Loading**, **Content**, **Empty**, and **Error** states, along with corresponding composable components (`LoadingState`, `EmptyState`, `ErrorState`, `ReconnectingBanner`, `LowBandwidthOverlay`). The **ChatScreen**, **InventoryScreen**, **FriendsScreen**, and **MapScreen** have been refactored to accept a `state` parameter and render the appropriate UI based on the state value. Additionally, telemetry hooks (`onTelemetry`) and retry callbacks (`onRetry`) are integrated into the error handling flow, and network status indicators (`isLowBandwidth`, `isReconnecting`) are displayed where applicable.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/components/state/ScreenState.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/components/state/LoadingState.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/components/state/EmptyState.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/components/state/ErrorState.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/components/state/ReconnectingBanner.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/components/state/LowBandwidthOverlay.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryScreen.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsScreen.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatScreen.kt` |
| 10 | `Linkpoint/src/main/java/com/linkpoint/ui/map/MapScreen.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->