### PR TITLE
UI migration: add LegacyFeatureBridge, UiMigrationFlags and RouteArgs

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt
@@ -8,6 +8,11 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -16,6 +21,9 @@ import com.google.android.material.tabs.TabLayout
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.network.ChatType
+import com.linkpoint.ui.navigation.RouteArgs
+import com.linkpoint.ui.navigation.finishOrPopBackStack
+import com.linkpoint.ui.theme.LinkpointTheme
 import com.linkpoint.chat.SessionType
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -29,7 +37,6 @@ class ChatActivity : AppCompatActivity() {
     
     companion object {
         private const val TAG = "ChatActivity"
-        const val EXTRA_IM_SESSION_ID = "extra_im_session_id"
     }
     
     private lateinit var tabLayout: TabLayout
@@ -47,6 +54,11 @@ class ChatActivity : AppCompatActivity() {
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (intent.getBooleanExtra(RouteArgs.EXTRA_USE_COMPOSE, false)) {
+            renderCompose()
+            return
+        }
+
         setContentView(R.layout.activity_chat)
 
         supportActionBar?.apply {
@@ -115,7 +127,7 @@ class ChatActivity : AppCompatActivity() {
     }
 
     private fun handleIntent() {
-        val sessionId = intent.getStringExtra(EXTRA_IM_SESSION_ID)
+        val sessionId = RouteArgs.chatFromIntent(intent).sessionId
             ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
         if (sessionId != null) {
             val session = app.imManager.activeSessions.value.firstOrNull { it.sessionId == sessionId }
@@ -127,6 +139,23 @@ class ChatActivity : AppCompatActivity() {
                 else -> {
                     activeImSessionId = sessionId
                     tabLayout.getTabAt(ActivityChatChannel.IM.ordinal)?.select()
+                }
+            }
+        }
+    }
+
+    private fun renderCompose() {
+        setContent {
+            LinkpointTheme(darkTheme = true) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    ChatScreen(
+                        messages = emptyList(),
+                        onSendMessage = { _, _ -> },
+                        onNavigateBack = { finishOrPopBackStack(navController = null, finish = ::finish) }
+                    )
                 }
             }
         }
@@ -313,7 +342,7 @@ class ChatActivity : AppCompatActivity() {
     
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            finish()
+            finishOrPopBackStack(navController = null, finish = ::finish)
             return true
         }
         return super.onOptionsItemSelected(item)

--- a/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendActionsDialog.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendActionsDialog.kt
@@ -11,7 +11,8 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
-import com.linkpoint.ui.chat.ChatActivity
+import com.linkpoint.ui.navigation.LegacyFeatureBridge
+import com.linkpoint.ui.navigation.RouteArgs
 import com.linkpoint.ui.profile.ProfileActivity
 import com.linkpoint.world.Friend
 import kotlinx.coroutines.launch
@@ -53,10 +54,7 @@ class FriendActionsDialog : DialogFragment() {
         val sessionId = app.imManager.startP2PSession(friend.agentId, friend.name)
         app.imManager.markAsRead(sessionId)
 
-        val intent = Intent(requireContext(), ChatActivity::class.java).apply {
-            putExtra(ChatActivity.EXTRA_IM_SESSION_ID, sessionId.toString())
-        }
-        startActivity(intent)
+        startActivity(LegacyFeatureBridge.chatIntent(requireContext(), RouteArgs.Chat(sessionId.toString())))
     }
 
     private fun viewProfile() {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/groups/GroupDialogs.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/groups/GroupDialogs.kt
@@ -14,7 +14,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.groups.Group
-import com.linkpoint.ui.chat.ChatActivity
+import com.linkpoint.ui.navigation.LegacyFeatureBridge
+import com.linkpoint.ui.navigation.RouteArgs
 import kotlinx.coroutines.launch
 
 /**
@@ -79,10 +80,7 @@ private fun DialogFragment.openGroupChat(group: Group) {
         } catch (e: Exception) {
             group.groupId
         }
-        val intent = Intent(ctx, ChatActivity::class.java).apply {
-            putExtra(ChatActivity.EXTRA_IM_SESSION_ID, sessionId.toString())
-        }
-        ctx.startActivity(intent)
+        ctx.startActivity(LegacyFeatureBridge.chatIntent(ctx, RouteArgs.Chat(sessionId.toString())))
     }
 }
 

--- a/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryActivity.kt
@@ -8,6 +8,11 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -19,6 +24,9 @@ import com.linkpoint.teleport.TeleportResult
 import java.util.UUID
 import android.content.Intent
 import com.linkpoint.ui.notecard.NotecardEditorActivity
+import com.linkpoint.ui.navigation.RouteArgs
+import com.linkpoint.ui.navigation.finishOrPopBackStack
+import com.linkpoint.ui.theme.LinkpointTheme
 
 /**
  * Inventory Activity - Browse and manage inventory
@@ -42,6 +50,11 @@ class InventoryActivity : AppCompatActivity() {
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (intent.getBooleanExtra(RouteArgs.EXTRA_USE_COMPOSE, false)) {
+            renderCompose()
+            return
+        }
+
         setContentView(R.layout.activity_inventory)
         
         supportActionBar?.apply {
@@ -53,6 +66,22 @@ class InventoryActivity : AppCompatActivity() {
         loadRootInventory()
     }
     
+    private fun renderCompose() {
+        setContent {
+            LinkpointTheme(darkTheme = true) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    InventoryScreen(
+                        items = emptyList(),
+                        breadcrumb = listOf("My Inventory"),
+                        onItemClick = { },
+                        onNavigateBack = { finishOrPopBackStack(navController = null, finish = ::finish) },
+                        onNavigateUp = { }
+                    )
+                }
+            }
+        }
+    }
+
     private fun initViews() {
         recyclerView = findViewById(R.id.inventoryRecyclerView)
         breadcrumbText = findViewById(R.id.breadcrumbText)

--- a/Linkpoint/src/main/java/com/linkpoint/ui/login/LoginActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/login/LoginActivity.kt
@@ -28,7 +28,8 @@ import com.linkpoint.network.NetworkDiagnostics
 import com.linkpoint.network.NetworkExceptionUtils.ErrorCategory
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.network.SSLHelper
-import com.linkpoint.ui.settings.SettingsActivity
+import com.linkpoint.ui.navigation.LegacyFeatureBridge
+import com.linkpoint.ui.navigation.RouteArgs
 import com.linkpoint.ui.tos.TosActivity
 import com.linkpoint.ui.world.WorldViewActivity
 import com.linkpoint.utils.PermissionManager
@@ -170,6 +171,11 @@ class LoginActivity : AppCompatActivity(), StartLocationDialog.StartLocationList
         
         setupGridSpinner()
         setupListeners()
+
+        val slurlArgs = pendingSlurlArgs()
+        if (slurlArgs.slurlRegion != null) {
+            statusText.text = "SLURL queued: ${slurlArgs.slurlRegion} (${slurlArgs.x.toInt()}, ${slurlArgs.y.toInt()}, ${slurlArgs.z.toInt()})"
+        }
         
         // Request all essential permissions on startup after UI is fully initialized
         requestAllStartupPermissions()
@@ -316,7 +322,7 @@ class LoginActivity : AppCompatActivity(), StartLocationDialog.StartLocationList
      * Open Settings activity. Can be accessed before login.
      */
     private fun openSettings() {
-        startActivity(Intent(this, SettingsActivity::class.java))
+        startActivity(LegacyFeatureBridge.settingsIntent(this))
     }
     
     private fun loadSavedCredentials() {
@@ -830,6 +836,20 @@ class LoginActivity : AppCompatActivity(), StartLocationDialog.StartLocationList
         }
     }
     
+
+    private fun pendingSlurlArgs(): RouteArgs.Login {
+        val routeArgs = RouteArgs.loginFromIntent(intent)
+        if (routeArgs.slurlRegion == null) {
+            return RouteArgs.Login(
+                slurlRegion = intent.getStringExtra("slurl_region"),
+                x = intent.getFloatExtra("slurl_x", 128f),
+                y = intent.getFloatExtra("slurl_y", 128f),
+                z = intent.getFloatExtra("slurl_z", 0f)
+            )
+        }
+        return routeArgs
+    }
+
     private fun handleLoginResult(result: LoginResult, shouldSaveCredentials: Boolean = true) {
         setLoginInProgress(false)
         
@@ -847,8 +867,7 @@ class LoginActivity : AppCompatActivity(), StartLocationDialog.StartLocationList
                 }
                 
                 // Navigate to world view
-                val intent = Intent(this, WorldViewActivity::class.java)
-                startActivity(intent)
+                startActivity(Intent(this, WorldViewActivity::class.java))
                 finish()
             }
             is LoginResult.MFARequired -> {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/migration/UiMigrationFlags.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/migration/UiMigrationFlags.kt
@@ -1,0 +1,48 @@
+package com.linkpoint.ui.migration
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+
+/**
+ * Feature flags for staged Compose migration.
+ *
+ * Provider indirection makes this remote-config friendly: a remote layer can
+ * replace [UiMigrationFlagsProvider.provider] at runtime.
+ */
+interface UiMigrationFlags {
+    fun useComposeLogin(): Boolean
+    fun useComposeChat(): Boolean
+    fun useComposeInventory(): Boolean
+    fun useComposeSettings(): Boolean
+}
+
+class SharedPrefsUiMigrationFlags(
+    context: Context,
+    private val remoteOverrides: () -> Map<String, Boolean> = { emptyMap() }
+) : UiMigrationFlags {
+
+    private val prefs = PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
+
+    override fun useComposeLogin(): Boolean = flag(KEY_LOGIN)
+    override fun useComposeChat(): Boolean = flag(KEY_CHAT)
+    override fun useComposeInventory(): Boolean = flag(KEY_INVENTORY)
+    override fun useComposeSettings(): Boolean = flag(KEY_SETTINGS)
+
+    private fun flag(key: String): Boolean {
+        return remoteOverrides().getOrElse(key) { prefs.getBoolean(key, false) }
+    }
+
+    companion object {
+        const val KEY_LOGIN = "ui_migration_compose_login"
+        const val KEY_CHAT = "ui_migration_compose_chat"
+        const val KEY_INVENTORY = "ui_migration_compose_inventory"
+        const val KEY_SETTINGS = "ui_migration_compose_settings"
+    }
+}
+
+object UiMigrationFlagsProvider {
+    @Volatile
+    var providerFactory: (Context) -> UiMigrationFlags = { ctx -> SharedPrefsUiMigrationFlags(ctx) }
+
+    fun get(context: Context): UiMigrationFlags = providerFactory(context)
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LegacyFeatureBridge.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LegacyFeatureBridge.kt
@@ -1,0 +1,39 @@
+package com.linkpoint.ui.navigation
+
+import android.content.Context
+import android.content.Intent
+import com.linkpoint.ui.chat.ChatActivity
+import com.linkpoint.ui.inventory.InventoryActivity
+import com.linkpoint.ui.login.LoginActivity
+import com.linkpoint.ui.migration.UiMigrationFlagsProvider
+import com.linkpoint.ui.settings.SettingsActivity
+
+/**
+ * Bridge launcher: route to Compose-enabled destination (same activity + args)
+ * or fallback legacy view based on migration flags.
+ */
+object LegacyFeatureBridge {
+    fun loginIntent(context: Context, args: RouteArgs.Login = RouteArgs.Login()): Intent {
+        val useCompose = UiMigrationFlagsProvider.get(context).useComposeLogin()
+        return RouteArgs.putLogin(Intent(context, LoginActivity::class.java), args)
+            .putExtra(RouteArgs.EXTRA_USE_COMPOSE, useCompose)
+    }
+
+    fun chatIntent(context: Context, args: RouteArgs.Chat = RouteArgs.Chat()): Intent {
+        val useCompose = UiMigrationFlagsProvider.get(context).useComposeChat()
+        return RouteArgs.putChat(Intent(context, ChatActivity::class.java), args)
+            .putExtra(RouteArgs.EXTRA_USE_COMPOSE, useCompose)
+    }
+
+    fun inventoryIntent(context: Context): Intent {
+        val useCompose = UiMigrationFlagsProvider.get(context).useComposeInventory()
+        return Intent(context, InventoryActivity::class.java)
+            .putExtra(RouteArgs.EXTRA_USE_COMPOSE, useCompose)
+    }
+
+    fun settingsIntent(context: Context): Intent {
+        val useCompose = UiMigrationFlagsProvider.get(context).useComposeSettings()
+        return Intent(context, SettingsActivity::class.java)
+            .putExtra(RouteArgs.EXTRA_USE_COMPOSE, useCompose)
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteArgs.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteArgs.kt
@@ -1,0 +1,47 @@
+package com.linkpoint.ui.navigation
+
+import android.content.Intent
+import androidx.navigation.NavHostController
+
+/** Standard conversion between legacy activity intent extras and nav route args. */
+object RouteArgs {
+    const val EXTRA_IM_SESSION_ID = "route_im_session_id"
+    const val EXTRA_SLURL_REGION = "route_slurl_region"
+    const val EXTRA_SLURL_X = "route_slurl_x"
+    const val EXTRA_SLURL_Y = "route_slurl_y"
+    const val EXTRA_SLURL_Z = "route_slurl_z"
+    const val EXTRA_USE_COMPOSE = "route_use_compose"
+
+    data class Chat(val sessionId: String? = null)
+    data class Login(val slurlRegion: String? = null, val x: Float = 128f, val y: Float = 128f, val z: Float = 0f)
+
+    fun chatFromIntent(intent: Intent?): Chat {
+        val sessionId = intent?.getStringExtra(EXTRA_IM_SESSION_ID)
+        return Chat(sessionId = sessionId)
+    }
+
+    fun putChat(intent: Intent, args: Chat): Intent = intent.apply {
+        args.sessionId?.let { putExtra(EXTRA_IM_SESSION_ID, it) }
+    }
+
+    fun loginFromIntent(intent: Intent?): Login {
+        return Login(
+            slurlRegion = intent?.getStringExtra(EXTRA_SLURL_REGION),
+            x = intent?.getFloatExtra(EXTRA_SLURL_X, 128f) ?: 128f,
+            y = intent?.getFloatExtra(EXTRA_SLURL_Y, 128f) ?: 128f,
+            z = intent?.getFloatExtra(EXTRA_SLURL_Z, 0f) ?: 0f
+        )
+    }
+
+    fun putLogin(intent: Intent, args: Login): Intent = intent.apply {
+        args.slurlRegion?.let { putExtra(EXTRA_SLURL_REGION, it) }
+        putExtra(EXTRA_SLURL_X, args.x)
+        putExtra(EXTRA_SLURL_Y, args.y)
+        putExtra(EXTRA_SLURL_Z, args.z)
+    }
+}
+
+fun finishOrPopBackStack(navController: NavHostController?, finish: () -> Unit) {
+    val popped = navController?.popBackStack() ?: false
+    if (!popped) finish()
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/people/UserActionsDialog.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/people/UserActionsDialog.kt
@@ -8,7 +8,8 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
-import com.linkpoint.ui.chat.ChatActivity
+import com.linkpoint.ui.navigation.LegacyFeatureBridge
+import com.linkpoint.ui.navigation.RouteArgs
 import com.linkpoint.ui.profile.ProfileActivity
 import kotlinx.coroutines.launch
 import java.util.UUID
@@ -62,10 +63,7 @@ class UserActionsDialog : DialogFragment() {
         val sessionId = app.imManager.startP2PSession(agentId, userName)
         app.imManager.markAsRead(sessionId)
 
-        val intent = Intent(requireContext(), ChatActivity::class.java).apply {
-            putExtra(ChatActivity.EXTRA_IM_SESSION_ID, sessionId.toString())
-        }
-        startActivity(intent)
+        startActivity(LegacyFeatureBridge.chatIntent(requireContext(), RouteArgs.Chat(sessionId.toString())))
     }
 
     private fun viewProfile() {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt
@@ -11,6 +11,11 @@ import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -27,6 +32,9 @@ import com.linkpoint.R
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.service.BackgroundResumeScheduler
 import com.linkpoint.ui.theme.ThemeManager
+import com.linkpoint.ui.navigation.RouteArgs
+import com.linkpoint.ui.navigation.finishOrPopBackStack
+import com.linkpoint.ui.theme.LinkpointTheme
 import com.linkpoint.ui.tos.TosActivity
 import com.linkpoint.ui.world.WorldViewActivity
 import com.linkpoint.utils.CodexUploadService
@@ -67,6 +75,11 @@ class SettingsActivity : AppCompatActivity() {
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (intent.getBooleanExtra(RouteArgs.EXTRA_USE_COMPOSE, false)) {
+            renderCompose()
+            return
+        }
+
         setContentView(R.layout.activity_settings)
         
         supportActionBar?.apply {
@@ -84,12 +97,34 @@ class SettingsActivity : AppCompatActivity() {
     
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            finish()
+            finishOrPopBackStack(navController = null, finish = ::finish)
             return true
         }
         return super.onOptionsItemSelected(item)
     }
     
+    private fun renderCompose() {
+        setContent {
+            LinkpointTheme(darkTheme = true) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    SettingsScreen(
+                        settings = SettingsState(),
+                        appVersion = BuildConfig.VERSION_NAME,
+                        onSettingsChange = { },
+                        onNavigateBack = { finishOrPopBackStack(navController = null, finish = ::finish) },
+                        onOpenThemePicker = { },
+                        onOpenAccount = { },
+                        onOpenPrivacy = { },
+                        onOpenAbout = { },
+                        onOpenLayoutEditor = {
+                            startActivity(WorldViewActivity.createLayoutEditorIntent(this@SettingsActivity))
+                        }
+                    )
+                }
+            }
+        }
+    }
+
     class SettingsFragment : PreferenceFragmentCompat() {
         override fun onResume() {
             super.onResume()

--- a/Linkpoint/src/main/java/com/linkpoint/ui/slurl/SLURLActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/slurl/SLURLActivity.kt
@@ -10,7 +10,8 @@ import androidx.lifecycle.lifecycleScope
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.network.TeleportResult
-import com.linkpoint.ui.login.LoginActivity
+import com.linkpoint.ui.navigation.LegacyFeatureBridge
+import com.linkpoint.ui.navigation.RouteArgs
 import kotlinx.coroutines.launch
 
 /**
@@ -112,13 +113,12 @@ class SLURLActivity : AppCompatActivity() {
     private fun performTeleport(slurl: SLURLData) {
         if (!app.isConnected()) {
             // Not logged in - go to login first
-            val loginIntent = Intent(this, LoginActivity::class.java).apply {
-                putExtra("slurl_region", slurl.regionName)
-                putExtra("slurl_x", slurl.x)
-                putExtra("slurl_y", slurl.y)
-                putExtra("slurl_z", slurl.z)
-            }
-            startActivity(loginIntent)
+            startActivity(
+                LegacyFeatureBridge.loginIntent(
+                    context = this,
+                    args = RouteArgs.Login(slurl.regionName, slurl.x, slurl.y, slurl.z)
+                )
+            )
             finish()
             return
         }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
@@ -30,14 +30,12 @@ import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.core.ConnectionState
-import com.linkpoint.ui.chat.ChatActivity
 import com.linkpoint.ui.friends.FriendsActivity
-import com.linkpoint.ui.inventory.InventoryActivity
 import com.linkpoint.ui.minimap.MinimapActivity
 import com.linkpoint.ui.avatar.MyAvatarActivity
+import com.linkpoint.ui.navigation.LegacyFeatureBridge
 import com.linkpoint.ui.people.NearbyPeopleActivity
 import com.linkpoint.render.lumiya.core.LumiyaGLSurfaceView
-import com.linkpoint.ui.settings.SettingsActivity
 import com.linkpoint.ui.xr.XRWorldActivity
 import com.linkpoint.utils.DebugReportService
 import kotlinx.coroutines.flow.collectLatest
@@ -235,7 +233,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         
         // Setup quick action buttons
         btnChat.setOnClickListener {
-            startActivity(Intent(this, ChatActivity::class.java))
+            startActivity(LegacyFeatureBridge.chatIntent(this))
         }
         
         btnMinimap.setOnClickListener {
@@ -243,7 +241,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         }
         
         btnInventory.setOnClickListener {
-            startActivity(Intent(this, InventoryActivity::class.java))
+            startActivity(LegacyFeatureBridge.inventoryIntent(this))
         }
         
         btnXR.setOnClickListener {
@@ -991,8 +989,8 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
     
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.nav_chat -> startActivity(Intent(this, ChatActivity::class.java))
-            R.id.nav_inventory -> startActivity(Intent(this, InventoryActivity::class.java))
+            R.id.nav_chat -> startActivity(LegacyFeatureBridge.chatIntent(this))
+            R.id.nav_inventory -> startActivity(LegacyFeatureBridge.inventoryIntent(this))
             R.id.nav_minimap -> startActivity(Intent(this, MinimapActivity::class.java))
             R.id.nav_avatar -> startActivity(Intent(this, MyAvatarActivity::class.java))
             R.id.nav_friends -> startActivity(Intent(this, FriendsActivity::class.java))
@@ -1002,7 +1000,7 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
             R.id.nav_search -> startActivity(Intent(this, com.linkpoint.ui.search.SearchActivity::class.java))
             R.id.nav_world_map -> startActivity(Intent(this, com.linkpoint.ui.map.MapActivity::class.java))
             R.id.nav_teleport_home -> teleportHome()
-            R.id.nav_settings -> startActivity(Intent(this, SettingsActivity::class.java))
+            R.id.nav_settings -> startActivity(LegacyFeatureBridge.settingsIntent(this))
             R.id.nav_xr_mode -> {
                 if (app.isXREntryAvailable()) {
                     startActivity(Intent(this, XRWorldActivity::class.java))

--- a/docs/ui-refactor/screen-migration-matrix.md
+++ b/docs/ui-refactor/screen-migration-matrix.md
@@ -1,0 +1,16 @@
+# Screen Migration Matrix
+
+_Last updated: 2026-04-27._
+
+| Legacy entry point | Compose destination wiring | Feature flag key | Current default path | Bridge status |
+|---|---|---|---|---|
+| `LoginActivity` | `LoginActivity` can be launched via `LegacyFeatureBridge.loginIntent(...)` with route args (`RouteArgs.Login`) and compose toggle extra | `ui_migration_compose_login` | Legacy XML login layout | Bridged (launch-time decision) |
+| `ChatActivity` | `ChatActivity` reads `RouteArgs.EXTRA_USE_COMPOSE` and renders `ChatScreen` when enabled; route args normalized via `RouteArgs.Chat` | `ui_migration_compose_chat` | Legacy RecyclerView chat UI | Bridged (launch-time decision) |
+| `InventoryActivity` | `InventoryActivity` reads `RouteArgs.EXTRA_USE_COMPOSE` and renders `InventoryScreen` when enabled | `ui_migration_compose_inventory` | Legacy RecyclerView inventory UI | Bridged (launch-time decision) |
+| `SettingsActivity` | `SettingsActivity` reads `RouteArgs.EXTRA_USE_COMPOSE` and renders `SettingsScreen` when enabled | `ui_migration_compose_settings` | Legacy preference-fragment UI | Bridged (launch-time decision) |
+
+## Fallback tracking
+
+- Launchers now route through `LegacyFeatureBridge`, which selects compose/fallback using `UiMigrationFlagsProvider`.
+- Route argument conversion for launch intents is centralized in `Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteArgs.kt`.
+- Back navigation parity is handled by `finishOrPopBackStack(...)`, mapping legacy `finish()` semantics to `navController.popBackStack()` when a Compose nav controller is present.


### PR DESCRIPTION
### Motivation
- Introduce a runtime-safe migration path so specific legacy Activities can be switched to Compose screens via feature flags instead of large rewrites.
- Centralize intent-extra ↔ navigation route-arg conversion to avoid ad-hoc parsing at call sites and make SLURL/login/chat handoffs consistent.
- Preserve legacy semantics for back navigation and activity launches while enabling a feature-flagged Compose rollout strategy.

### Description
- Added a remote-config-friendly flags abstraction in `UiMigrationFlags`, `SharedPrefsUiMigrationFlags`, and `UiMigrationFlagsProvider` with keys for login/chat/inventory/settings to control Compose rollout. (`src/main/java/com/linkpoint/ui/migration/UiMigrationFlags.kt`)
- Introduced `RouteArgs` to normalize conversion of legacy `Intent` extras to route-like typed args (chat and SLURL/login args) and added `finishOrPopBackStack(...)` to map legacy `finish()` behavior to Compose nav back when available. (`src/main/java/com/linkpoint/ui/navigation/RouteArgs.kt`)
- Implemented `LegacyFeatureBridge` helper launchers that encapsulate the compose-vs-legacy decision at call sites and attach the `EXTRA_USE_COMPOSE` marker and normalized route args. (`src/main/java/com/linkpoint/ui/navigation/LegacyFeatureBridge.kt`)
- Updated callers to use the bridge and standardized args: quick-actions and drawer entries in `WorldViewActivity`, SLURL -> login handoff in `SLURLActivity`, settings launcher in `LoginActivity`, and IM/group chat entry points in `UserActionsDialog`, `FriendActionsDialog`, and `GroupDialogs`. (`src/main/java/com/linkpoint/ui/...`)
- Added per-Activity checks and lightweight Compose render fallbacks in `ChatActivity`, `InventoryActivity`, and `SettingsActivity` so these Activities render the Compose replacement when `RouteArgs.EXTRA_USE_COMPOSE` is set; back navigation in those flows uses the parity helper. (`src/main/java/com/linkpoint/ui/chat/ChatActivity.kt`, `.../inventory/InventoryActivity.kt`, `.../settings/SettingsActivity.kt`)
- Documented the migration/fallback status in `docs/ui-refactor/screen-migration-matrix.md`.

### Testing
- Attempted to run Kotlin compilation with `./gradlew -p Linkpoint compileDebugKotlin`, which failed in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties`).
- No other automated tests were executed in this environment; code changes were applied and basic smoke edits were validated by local file inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef64677b448323b1c427fca513c35e)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a feature-flagged infrastructure to gradually migrate legacy Android Activities to Jetpack Compose screens without requiring a full rewrite. It adds `UiMigrationFlags` for remote-config-friendly rollout control, `RouteArgs` to normalize intent extras and navigation arguments across legacy and Compose flows, and `LegacyFeatureBridge` launcher helpers that route to either the legacy XML views or new Compose screens based on feature flags. Four activities (`ChatActivity`, `InventoryActivity`, `SettingsActivity`, and `LoginActivity`) now check for a compose toggle flag at launch and render lightweight Compose fallbacks when enabled. All existing call sites that launch these screens have been updated to use the bridge, centralizing the migration decision and standardizing back navigation behavior between legacy `finish()` and `NavController.popBackStack()`.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/ui-refactor/screen-migration-matrix.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/migration/UiMigrationFlags.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteArgs.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/LegacyFeatureBridge.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/slurl/SLURLActivity.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/login/LoginActivity.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/inventory/InventoryActivity.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt` |
| 10 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt` |
| 11 | `Linkpoint/src/main/java/com/linkpoint/ui/people/UserActionsDialog.kt` |
| 12 | `Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendActionsDialog.kt` |
| 13 | `Linkpoint/src/main/java/com/linkpoint/ui/groups/GroupDialogs.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->