### PR TITLE
Add Compose app shell and route migration scaffolding

### DIFF
--- a/Linkpoint/src/main/AndroidManifest.xml
+++ b/Linkpoint/src/main/AndroidManifest.xml
@@ -210,6 +210,13 @@
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".ui.world.WorldViewActivity" />
 
+
+        <!-- Compose migration host for Nav + AppShell rollout -->
+        <activity
+            android:name=".ui.navigation.NavigationMigrationActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Linkpoint.NoActionBar" />
+
         <!-- Grid Connection Service -->
         <service
             android:name=".services.GridConnectionService"

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointAppShell.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointAppShell.kt
@@ -1,0 +1,132 @@
+package com.linkpoint.ui.navigation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LinkpointAppShell(
+    navController: NavHostController,
+    content: @Composable (Modifier) -> Unit
+) {
+    val drawerState = rememberDrawerState(initialValue = androidx.compose.material3.DrawerValue.Closed)
+    val coroutineScope = rememberCoroutineScope()
+    val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+    val routeSpec = RouteSpecs.forRoute(currentRoute)
+    var overflowExpanded by remember { mutableStateOf(false) }
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        gesturesEnabled = routeSpec.showDrawerMenu,
+        drawerContent = {
+            ModalDrawerSheet {
+                LinkpointMenus.drawerSections.forEach { section ->
+                    Text(
+                        text = section.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                    section.items.forEach { item ->
+                        DropdownMenuItem(
+                            text = { Text(item.label) },
+                            onClick = {
+                                coroutineScope.launch { drawerState.close() }
+                                navController.navigateTo(item.route)
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text(routeSpec.title) },
+                    navigationIcon = {
+                        when (routeSpec.backBehavior) {
+                            BackBehavior.NAVIGATE_UP -> IconButton(onClick = { navController.navigateUp() }) {
+                                Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                            }
+
+                            BackBehavior.EXIT_APP,
+                            BackBehavior.NONE -> if (routeSpec.showDrawerMenu) {
+                                IconButton(onClick = { coroutineScope.launch { drawerState.open() } }) {
+                                    Icon(Icons.Filled.Menu, contentDescription = "Menu")
+                                }
+                            }
+                        }
+                    },
+                    actions = {
+                        if (routeSpec.showDrawerMenu) {
+                            IconButton(onClick = { overflowExpanded = !overflowExpanded }) {
+                                Icon(Icons.Filled.MoreVert, contentDescription = "More")
+                            }
+                            DropdownMenu(
+                                expanded = overflowExpanded,
+                                onDismissRequest = { overflowExpanded = false }
+                            ) {
+                                LinkpointMenus.drawerSections.forEach { section ->
+                                    section.items.forEach { item ->
+                                        DropdownMenuItem(
+                                            text = { Text(item.label) },
+                                            onClick = {
+                                                overflowExpanded = false
+                                                navController.navigateTo(item.route)
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            },
+            bottomBar = {
+                if (routeSpec.showBottomMenu) {
+                    NavigationBar {
+                        LinkpointMenus.bottomTabs.forEach { tab ->
+                            val selected = currentRoute == tab.route
+                            NavigationBarItem(
+                                selected = selected,
+                                onClick = { navController.navigateTo(tab.route) },
+                                icon = {},
+                                label = { Text(tab.label) }
+                            )
+                        }
+                    }
+                }
+            }
+        ) { innerPadding ->
+            content(Modifier.padding(innerPadding))
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointMenus.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointMenus.kt
@@ -1,0 +1,56 @@
+package com.linkpoint.ui.navigation
+
+/**
+ * Menu model used by the app shell while we migrate from legacy Activity navigation.
+ */
+data class MenuDestination(
+    val label: String,
+    val route: String
+)
+
+data class DrawerSection(
+    val title: String,
+    val items: List<MenuDestination>
+)
+
+object LinkpointMenus {
+    val bottomTabs: List<MenuDestination> = listOf(
+        MenuDestination("World", Routes.WORLD),
+        MenuDestination("Chat", Routes.CHAT),
+        MenuDestination("People", Routes.FRIENDS),
+        MenuDestination("Inventory", Routes.INVENTORY),
+        MenuDestination("Map", Routes.MAP)
+    )
+
+    val drawerSections: List<DrawerSection> = listOf(
+        DrawerSection(
+            title = "Me",
+            items = listOf(
+                MenuDestination("My Profile", Routes.MY_PROFILE),
+                MenuDestination("My Avatar", Routes.MY_AVATAR),
+                MenuDestination("Wallet", Routes.WALLET),
+                MenuDestination("Notifications", Routes.NOTIFICATIONS_FEED)
+            )
+        ),
+        DrawerSection(
+            title = "Explore",
+            items = listOf(
+                MenuDestination("Search", Routes.SEARCH),
+                MenuDestination("Nearby", Routes.NEARBY_PEOPLE),
+                MenuDestination("Teleport History", Routes.TELEPORT_HISTORY),
+                MenuDestination("Build Tools", Routes.BUILD_TOOLS),
+                MenuDestination("Voice", Routes.VOICE_DEEP)
+            )
+        ),
+        DrawerSection(
+            title = "System",
+            items = listOf(
+                MenuDestination("Settings", Routes.SETTINGS),
+                MenuDestination("Permissions", Routes.PERMISSIONS_OVERVIEW),
+                MenuDestination("Onboarding", Routes.ONBOARDING_WELCOME),
+                MenuDestination("Terms", Routes.TOS),
+                MenuDestination("XR World", Routes.XR_WORLD)
+            )
+        )
+    )
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/Navigation.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/Navigation.kt
@@ -1,10 +1,38 @@
 package com.linkpoint.ui.navigation
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.linkpoint.ui.avatar.MyAvatarActivity
+import com.linkpoint.ui.build.BuildActivity
+import com.linkpoint.ui.chat.ChatActivity
+import com.linkpoint.ui.friends.FriendsActivity
+import com.linkpoint.ui.groups.GroupsActivity
+import com.linkpoint.ui.inventory.InventoryActivity
+import com.linkpoint.ui.login.LoginActivity
+import com.linkpoint.ui.map.MapActivity
+import com.linkpoint.ui.minimap.MinimapActivity
+import com.linkpoint.ui.people.NearbyPeopleActivity
+import com.linkpoint.ui.profile.ProfileActivity
+import com.linkpoint.ui.search.SearchActivity
+import com.linkpoint.ui.settings.SettingsActivity
+import com.linkpoint.ui.slurl.SLURLActivity
+import com.linkpoint.ui.teleport.TeleportHistoryActivity
+import com.linkpoint.ui.tos.TosActivity
+import com.linkpoint.ui.world.WorldViewActivity
+import com.linkpoint.ui.xr.XRWorldActivity
 
 /**
  * Navigation routes for the Linkpoint app.
@@ -29,152 +57,118 @@ object Routes {
     const val THEME_PICKER = "theme_picker"
     const val SLURL = "slurl/{slurl}"
     const val XR_WORLD = "xr_world"
-    
+
+    // Planned destinations
+    const val WALLET = "wallet"
+    const val NOTIFICATIONS_FEED = "notifications_feed"
+    const val VOICE_DEEP = "voice_deep"
+    const val PLACE_DETAIL = "place/{region}/{x}/{y}/{z}"
+    const val PLACE_EVENTS = "place/{region}/{x}/{y}/{z}/events"
+    const val BUILD_TOOLS = "build_tools"
+
+    // Onboarding steps
+    const val ONBOARDING_WELCOME = "onboarding/welcome"
+    const val ONBOARDING_AVATAR_SETUP = "onboarding/avatar_setup"
+    const val ONBOARDING_VOICE_SETUP = "onboarding/voice_setup"
+    const val ONBOARDING_FINISH = "onboarding/finish"
+
+    // Permission flow
+    const val PERMISSIONS_OVERVIEW = "permissions/overview"
+    const val PERMISSIONS_MICROPHONE = "permissions/microphone"
+    const val PERMISSIONS_NOTIFICATIONS = "permissions/notifications"
+
     fun profile(userId: String) = "profile/$userId"
-    fun slurl(slurl: String) = "slurl/$slurl"
+    fun slurl(slurl: String) = "slurl/${android.net.Uri.encode(slurl)}"
+    fun placeDetail(region: String, x: String, y: String, z: String) = "place/$region/$x/$y/$z"
+    fun placeEvents(region: String, x: String, y: String, z: String) = "place/$region/$x/$y/$z/events"
 }
 
-/**
- * Extension function to navigate with animation
- */
 fun NavHostController.navigateTo(route: String) {
     navigate(route) {
-        // Pop up to the start destination to avoid building up a large stack
         launchSingleTop = true
         restoreState = true
     }
 }
 
-/**
- * Extension function to navigate back
- */
 fun NavHostController.navigateBack() {
     popBackStack()
 }
 
-/**
- * Main navigation composable that can be used as the app's navigation structure.
- * 
- * Note: This is a framework that can be used when migrating from Activities to 
- * single-Activity + Compose Navigation architecture. Currently the app still uses
- * Activity-based navigation, but these routes and NavHost setup can be adopted
- * incrementally.
- * 
- * Usage in MainActivity:
- * ```kotlin
- * setContent {
- *     LinkpointTheme {
- *         val navController = rememberNavController()
- *         LinkpointNavHost(navController = navController)
- *     }
- * }
- * ```
- */
 @Composable
 fun LinkpointNavHost(
     navController: NavHostController = rememberNavController(),
     startDestination: String = Routes.LOGIN
 ) {
-    NavHost(
-        navController = navController,
-        startDestination = startDestination
-    ) {
-        // Login screen - entry point
-        composable(Routes.LOGIN) {
-            // LoginScreen would be called here with proper ViewModel integration
-            // For now, this serves as the navigation structure
-        }
-        
-        // Main world view
-        composable(Routes.WORLD) {
-            // WorldScreen composable
-        }
-        
-        // Chat screen
-        composable(Routes.CHAT) {
-            // ChatScreen composable
-        }
-        
-        // Inventory screen
-        composable(Routes.INVENTORY) {
-            // InventoryScreen composable
-        }
-        
-        // Friends screen
-        composable(Routes.FRIENDS) {
-            // FriendsScreen composable
-        }
-        
-        // Groups screen
-        composable(Routes.GROUPS) {
-            // GroupsScreen composable
-        }
-        
-        // Profile screen (other users)
-        composable(Routes.PROFILE) { backStackEntry ->
-            val userId = backStackEntry.arguments?.getString("userId") ?: return@composable
-            // ProfileScreen with userId
-        }
-        
-        // My profile screen
-        composable(Routes.MY_PROFILE) {
-            // ProfileScreen for current user
-        }
-        
-        // Settings screen
-        composable(Routes.SETTINGS) {
-            // SettingsScreen composable
-        }
-        
-        // World map screen
-        composable(Routes.MAP) {
-            // MapScreen composable
-        }
-        
-        // Minimap screen
-        composable(Routes.MINIMAP) {
-            // MinimapScreen composable
-        }
-        
-        // Search screen
-        composable(Routes.SEARCH) {
-            // SearchScreen composable
-        }
-        
-        // Teleport history screen
-        composable(Routes.TELEPORT_HISTORY) {
-            // TeleportHistoryScreen composable
-        }
-        
-        // Nearby people screen
-        composable(Routes.NEARBY_PEOPLE) {
-            // NearbyPeopleScreen composable
-        }
-        
-        // My avatar screen
-        composable(Routes.MY_AVATAR) {
-            // MyAvatarScreen composable
-        }
-        
-        // Terms of Service screen
-        composable(Routes.TOS) {
-            // TosScreen composable
-        }
-        
-        // Theme picker screen
-        composable(Routes.THEME_PICKER) {
-            // ThemePickerScreen composable
-        }
-        
-        // SLURL handler
-        composable(Routes.SLURL) { backStackEntry ->
-            val slurl = backStackEntry.arguments?.getString("slurl") ?: return@composable
-            // Handle SLURL navigation
-        }
-        
-        // XR World (VR/AR mode)
-        composable(Routes.XR_WORLD) {
-            // XRWorldScreen composable
+    LinkpointAppShell(navController = navController) { shellModifier ->
+        NavHost(
+            navController = navController,
+            startDestination = startDestination,
+            modifier = shellModifier
+        ) {
+            composable(Routes.LOGIN) { LegacyRouteBridge(LoginActivity::class.java) }
+            composable(Routes.WORLD) { LegacyRouteBridge(WorldViewActivity::class.java) }
+            composable(Routes.CHAT) { LegacyRouteBridge(ChatActivity::class.java) }
+            composable(Routes.INVENTORY) { LegacyRouteBridge(InventoryActivity::class.java) }
+            composable(Routes.FRIENDS) { LegacyRouteBridge(FriendsActivity::class.java) }
+            composable(Routes.GROUPS) { LegacyRouteBridge(GroupsActivity::class.java) }
+            composable(Routes.PROFILE) { backStackEntry ->
+                val userId = backStackEntry.arguments?.getString("userId") ?: return@composable
+                LegacyRouteBridge(ProfileActivity::class.java) { putExtra("userId", userId) }
+            }
+            composable(Routes.MY_PROFILE) { LegacyRouteBridge(ProfileActivity::class.java) { putExtra("isMe", true) } }
+            composable(Routes.SETTINGS) { LegacyRouteBridge(SettingsActivity::class.java) }
+            composable(Routes.MAP) { LegacyRouteBridge(MapActivity::class.java) }
+            composable(Routes.MINIMAP) { LegacyRouteBridge(MinimapActivity::class.java) }
+            composable(Routes.SEARCH) { LegacyRouteBridge(SearchActivity::class.java) }
+            composable(Routes.TELEPORT_HISTORY) { LegacyRouteBridge(TeleportHistoryActivity::class.java) }
+            composable(Routes.NEARBY_PEOPLE) { LegacyRouteBridge(NearbyPeopleActivity::class.java) }
+            composable(Routes.MY_AVATAR) { LegacyRouteBridge(MyAvatarActivity::class.java) }
+            composable(Routes.TOS) { LegacyRouteBridge(TosActivity::class.java) }
+            composable(Routes.THEME_PICKER) { PlaceholderRoute("Theme Picker") }
+            composable(Routes.SLURL) { backStackEntry ->
+                val slurl = backStackEntry.arguments?.getString("slurl") ?: return@composable
+                LegacyRouteBridge(SLURLActivity::class.java) {
+                    data = android.net.Uri.parse(android.net.Uri.decode(slurl))
+                }
+            }
+            composable(Routes.XR_WORLD) { LegacyRouteBridge(XRWorldActivity::class.java) }
+
+            composable(Routes.WALLET) { PlaceholderRoute("Wallet") }
+            composable(Routes.NOTIFICATIONS_FEED) { PlaceholderRoute("Notifications Feed") }
+            composable(Routes.VOICE_DEEP) { PlaceholderRoute("Voice (Deep)") }
+            composable(Routes.PLACE_DETAIL) { PlaceholderRoute("Place Detail") }
+            composable(Routes.PLACE_EVENTS) { PlaceholderRoute("Place Events") }
+            composable(Routes.BUILD_TOOLS) { LegacyRouteBridge(BuildActivity::class.java) }
+
+            composable(Routes.ONBOARDING_WELCOME) { PlaceholderRoute("Onboarding Welcome") }
+            composable(Routes.ONBOARDING_AVATAR_SETUP) { PlaceholderRoute("Onboarding Avatar Setup") }
+            composable(Routes.ONBOARDING_VOICE_SETUP) { PlaceholderRoute("Onboarding Voice Setup") }
+            composable(Routes.ONBOARDING_FINISH) { PlaceholderRoute("Onboarding Finish") }
+
+            composable(Routes.PERMISSIONS_OVERVIEW) { PlaceholderRoute("Permissions Overview") }
+            composable(Routes.PERMISSIONS_MICROPHONE) { PlaceholderRoute("Permissions: Microphone") }
+            composable(Routes.PERMISSIONS_NOTIFICATIONS) { PlaceholderRoute("Permissions: Notifications") }
         }
     }
 }
+
+@Composable
+private fun PlaceholderRoute(label: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = label)
+    }
+}
+
+@Composable
+private fun LegacyRouteBridge(
+    activityClass: Class<out Activity>,
+    configureIntent: Intent.() -> Unit = {}
+) {
+    val context = LocalContext.current
+    LaunchedEffect(activityClass) {
+        context.startActivity(Intent(context, activityClass).apply(configureIntent))
+    }
+    PlaceholderRoute("Opening ${activityClass.simpleName}")
+}
+
+fun Context.resolveRouteFromIntent(intent: Intent?): String? = RouteResolver.resolve(intent)

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/NavigationMigrationActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/NavigationMigrationActivity.kt
@@ -1,0 +1,23 @@
+package com.linkpoint.ui.navigation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.linkpoint.ui.theme.LinkpointTheme
+
+/**
+ * Temporary single-Activity Compose host used during navigation migration.
+ */
+class NavigationMigrationActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val resolvedRoute = RouteResolver.resolve(intent) ?: Routes.WORLD
+
+        setContent {
+            LinkpointTheme {
+                LinkpointNavHost(startDestination = resolvedRoute)
+            }
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteResolver.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteResolver.kt
@@ -1,0 +1,62 @@
+package com.linkpoint.ui.navigation
+
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * Resolves incoming intents and external links into internal Compose routes.
+ */
+object RouteResolver {
+
+    fun resolve(intent: Intent?): String? {
+        val data = intent?.data ?: return null
+        return resolve(data)
+    }
+
+    fun resolve(uri: Uri): String? {
+        val host = uri.host.orEmpty().lowercase()
+        val segments = uri.pathSegments
+
+        if (uri.scheme.equals("secondlife", ignoreCase = true)) {
+            // secondlife://Region/128/128/20
+            if (segments.isNotEmpty()) {
+                return Routes.slurl(uri.toString())
+            }
+        }
+
+        if (host == "maps.secondlife.com") {
+            // https://maps.secondlife.com/secondlife/Region/128/128/20
+            if (segments.size >= 5 && segments[0] == "secondlife") {
+                val region = segments[1]
+                val x = segments[2]
+                val y = segments[3]
+                val z = segments[4]
+                return Routes.placeDetail(region, x, y, z)
+            }
+        }
+
+        // profile links: /profile/{id} or /app/profile/{id}
+        val profileIndex = segments.indexOf("profile")
+        if (profileIndex >= 0 && profileIndex + 1 < segments.size) {
+            val profileId = segments[profileIndex + 1]
+            return if (profileId == "me") Routes.MY_PROFILE else Routes.profile(profileId)
+        }
+
+        // place links: /place/{region}/{x}/{y}/{z} and optional /events
+        val placeIndex = segments.indexOf("place")
+        if (placeIndex >= 0 && placeIndex + 4 < segments.size) {
+            val region = segments[placeIndex + 1]
+            val x = segments[placeIndex + 2]
+            val y = segments[placeIndex + 3]
+            val z = segments[placeIndex + 4]
+            val hasEventsSuffix = placeIndex + 5 < segments.size && segments[placeIndex + 5] == "events"
+            return if (hasEventsSuffix) {
+                Routes.placeEvents(region, x, y, z)
+            } else {
+                Routes.placeDetail(region, x, y, z)
+            }
+        }
+
+        return null
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteSpec.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteSpec.kt
@@ -1,0 +1,67 @@
+package com.linkpoint.ui.navigation
+
+/**
+ * Metadata for routes rendered by [LinkpointAppShell].
+ */
+data class RouteSpec(
+    val title: String,
+    val backBehavior: BackBehavior = BackBehavior.NAVIGATE_UP,
+    val showBottomMenu: Boolean = false,
+    val showDrawerMenu: Boolean = false
+)
+
+enum class BackBehavior {
+    NONE,
+    NAVIGATE_UP,
+    EXIT_APP
+}
+
+object RouteSpecs {
+    private val specs: Map<String, RouteSpec> = mapOf(
+        Routes.LOGIN to RouteSpec("Login", backBehavior = BackBehavior.NONE),
+        Routes.WORLD to RouteSpec("World", backBehavior = BackBehavior.EXIT_APP, showBottomMenu = true, showDrawerMenu = true),
+        Routes.CHAT to RouteSpec("Chat", showBottomMenu = true, showDrawerMenu = true),
+        Routes.INVENTORY to RouteSpec("Inventory", showBottomMenu = true, showDrawerMenu = true),
+        Routes.FRIENDS to RouteSpec("Friends", showBottomMenu = true, showDrawerMenu = true),
+        Routes.GROUPS to RouteSpec("Groups", showDrawerMenu = true),
+        Routes.PROFILE to RouteSpec("Profile", showDrawerMenu = true),
+        Routes.MY_PROFILE to RouteSpec("My Profile", showDrawerMenu = true),
+        Routes.SETTINGS to RouteSpec("Settings", showDrawerMenu = true),
+        Routes.MAP to RouteSpec("Map", showBottomMenu = true, showDrawerMenu = true),
+        Routes.MINIMAP to RouteSpec("Minimap", showDrawerMenu = true),
+        Routes.SEARCH to RouteSpec("Search", showDrawerMenu = true),
+        Routes.TELEPORT_HISTORY to RouteSpec("Teleport History", showDrawerMenu = true),
+        Routes.NEARBY_PEOPLE to RouteSpec("Nearby People", showDrawerMenu = true),
+        Routes.MY_AVATAR to RouteSpec("My Avatar", showDrawerMenu = true),
+        Routes.TOS to RouteSpec("Terms of Service"),
+        Routes.THEME_PICKER to RouteSpec("Theme Picker"),
+        Routes.SLURL to RouteSpec("SLURL"),
+        Routes.XR_WORLD to RouteSpec("XR World"),
+        Routes.WALLET to RouteSpec("Wallet", showDrawerMenu = true),
+        Routes.NOTIFICATIONS_FEED to RouteSpec("Notifications", showDrawerMenu = true),
+        Routes.VOICE_DEEP to RouteSpec("Voice", showDrawerMenu = true),
+        Routes.PLACE_DETAIL to RouteSpec("Place Details", showDrawerMenu = true),
+        Routes.PLACE_EVENTS to RouteSpec("Place Events", showDrawerMenu = true),
+        Routes.BUILD_TOOLS to RouteSpec("Build Tools", showDrawerMenu = true),
+        Routes.ONBOARDING_WELCOME to RouteSpec("Onboarding", backBehavior = BackBehavior.NONE),
+        Routes.ONBOARDING_AVATAR_SETUP to RouteSpec("Avatar Setup", backBehavior = BackBehavior.NONE),
+        Routes.ONBOARDING_VOICE_SETUP to RouteSpec("Voice Setup", backBehavior = BackBehavior.NONE),
+        Routes.ONBOARDING_FINISH to RouteSpec("You're ready", backBehavior = BackBehavior.NONE),
+        Routes.PERMISSIONS_OVERVIEW to RouteSpec("Permissions", backBehavior = BackBehavior.NONE),
+        Routes.PERMISSIONS_MICROPHONE to RouteSpec("Microphone Permission", backBehavior = BackBehavior.NONE),
+        Routes.PERMISSIONS_NOTIFICATIONS to RouteSpec("Notification Permission", backBehavior = BackBehavior.NONE)
+    )
+
+    fun forRoute(route: String?): RouteSpec {
+        if (route == null) return RouteSpec("Linkpoint")
+        return specs[normalizeRoute(route)] ?: RouteSpec("Linkpoint")
+    }
+
+    private fun normalizeRoute(route: String): String = when {
+        route.startsWith("profile/") && route != Routes.MY_PROFILE -> Routes.PROFILE
+        route.startsWith("slurl/") -> Routes.SLURL
+        route.startsWith("place/") && route.endsWith("/events") -> Routes.PLACE_EVENTS
+        route.startsWith("place/") -> Routes.PLACE_DETAIL
+        else -> route
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a Compose-based app shell and centralized routing model to migrate from an activity-per-screen architecture to a single-activity + Compose navigation host.
- Surface a small set of common UI chrome (top app bar, bottom tabs, drawer/overflow) driven by centralized menu data so routes can be migrated incrementally.
- Ensure incoming deep links and legacy Activities can be handled during the migration by resolving routes centrally and bridging to existing Activities when needed.

### Description
- Added a Compose app shell `LinkpointAppShell.kt` that renders a top app bar, bottom navigation using `LinkpointMenus.bottomTabs`, and drawer/overflow menus using `LinkpointMenus.drawerSections`.
- Introduced `LinkpointMenus.kt` to model bottom tabs and drawer sections, and `RouteSpec.kt` (with `RouteSpec`, `BackBehavior`, `RouteSpecs`) to store per-route metadata such as title, back behavior, and menu visibility.
- Expanded `Routes` and helper builders in `Navigation.kt` to include planned destinations (wallet, notifications feed, voice deep, place detail/events, build tools), onboarding steps, and permission flows, and integrated the app shell into `LinkpointNavHost`.
- Added `LegacyRouteBridge` behavior in `LinkpointNavHost` to launch legacy `Activity`-based screens as interim handlers while Compose destinations are migrated.
- Implemented `RouteResolver.kt` to resolve incoming intents/URIs (SLURL, profile links, place links and `/events`) into internal Compose routes and added `NavigationMigrationActivity` as a temporary single-activity Compose host wired into `AndroidManifest.xml`.

### Testing
- Attempted to build Kotlin sources with `./gradlew compileDebugKotlin` but the Gradle build failed in this environment due to missing Android SDK location (`SDK location not found`).
- Ran `git diff --check` and committed the changes; the repository diff shows the new files and modifications and there were no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef64612a848323b4e9055ce737a2b5)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a **Compose-based single-activity navigation architecture** to replace the existing activity-per-screen model. It adds an app shell with top app bar, bottom tabs, and drawer menus, a centralized routing model with metadata for each destination, a route resolver to handle deep links and external URIs (including SLURL and place links), and a legacy activity bridge mechanism to enable incremental migration from the old Activity-based screens to new Compose destinations. The changes lay the foundation for gradually moving all screens to Compose while maintaining compatibility with existing Activities during the transition.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteSpec.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointMenus.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/RouteResolver.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/LinkpointAppShell.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/Navigation.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/navigation/NavigationMigrationActivity.kt` |
| 7 | `Linkpoint/src/main/AndroidManifest.xml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->