### PR TITLE
Introduce design tokens, density-aware theming and density persistence

### DIFF
--- a/Linkpoint/build.gradle.kts
+++ b/Linkpoint/build.gradle.kts
@@ -284,6 +284,7 @@ dependencies {
     
     // Preferences
     implementation("androidx.preference:preference-ktx:1.2.1")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     // Room (inventory cache persistence)
     implementation("androidx.room:room-runtime:2.6.1")

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsScreen.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,15 +37,21 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.linkpoint.ui.theme.DensitySettingsStore
+import com.linkpoint.ui.theme.LinkpointTokens
+import com.linkpoint.ui.theme.ThemePack
+import kotlinx.coroutines.launch
 
 /**
  * Settings state
@@ -91,6 +98,11 @@ fun SettingsScreen(
     modifier: Modifier = Modifier
 ) {
     var currentSettings by remember { mutableStateOf(settings) }
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val densityStore = remember(context) { DensitySettingsStore(context) }
+    val densityMode by densityStore.densityMode.collectAsState(initial = ThemePack.DensityMode.BALANCED)
+    val spacing = LinkpointTokens.design.spacing
     
     Scaffold(
         topBar = {
@@ -109,8 +121,8 @@ fun SettingsScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .padding(spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
         ) {
             // Account Section
             SettingsSection(title = "Account") {
@@ -131,6 +143,17 @@ fun SettingsScreen(
                     onClick = onOpenThemePicker
                 )
                 
+                HorizontalDivider()
+
+                DensityModeSetting(
+                    selectedDensity = densityMode,
+                    onDensitySelected = { selected ->
+                        scope.launch {
+                            densityStore.setDensityMode(selected)
+                        }
+                    }
+                )
+
                 HorizontalDivider()
                 
                 SettingsSliderItem(
@@ -306,6 +329,30 @@ fun SettingsScreen(
                     title = "About Linkpoint",
                     subtitle = "Version $appVersion",
                     onClick = onOpenAbout
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DensityModeSetting(
+    selectedDensity: ThemePack.DensityMode,
+    onDensitySelected: (ThemePack.DensityMode) -> Unit
+) {
+    Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(text = "Density", style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = "Controls global spacing and component compactness",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            ThemePack.DensityMode.entries.forEach { mode ->
+                FilterChip(
+                    selected = selectedDensity == mode,
+                    onClick = { onDensitySelected(mode) },
+                    label = { Text(mode.name.lowercase().replaceFirstChar { it.uppercase() }) }
                 )
             }
         }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointDensitySettings.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointDensitySettings.kt
@@ -1,0 +1,39 @@
+package com.linkpoint.ui.theme
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.densityDataStore by preferencesDataStore(name = "linkpoint_ui_density")
+
+class DensitySettingsStore(private val context: Context) {
+    private val densityKey: Preferences.Key<String> = stringPreferencesKey("density_mode")
+
+    val densityMode: Flow<ThemePack.DensityMode> = context.densityDataStore.data.map { prefs ->
+        prefs[densityKey]
+            ?.let { runCatching { ThemePack.DensityMode.valueOf(it) }.getOrNull() }
+            ?: ThemePack.DensityMode.BALANCED
+    }
+
+    suspend fun setDensityMode(mode: ThemePack.DensityMode) {
+        context.densityDataStore.edit { prefs ->
+            prefs[densityKey] = mode.name
+        }
+    }
+}
+
+val LocalDensityMode = staticCompositionLocalOf { ThemePack.DensityMode.BALANCED }
+
+object LinkpointDensity {
+    val current: ThemePack.DensityMode
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalDensityMode.current
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointDesignTokens.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointDesignTokens.kt
@@ -1,0 +1,80 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class LinkpointSpacing(
+    val xxs: Dp,
+    val xs: Dp,
+    val sm: Dp,
+    val md: Dp,
+    val lg: Dp,
+    val xl: Dp,
+    val xxl: Dp
+)
+
+@Immutable
+data class LinkpointRadii(
+    val sm: Dp,
+    val md: Dp,
+    val lg: Dp,
+    val xl: Dp,
+    val pill: Dp
+)
+
+@Immutable
+data class LinkpointElevation(
+    val low: Dp,
+    val mid: Dp,
+    val high: Dp
+)
+
+@Immutable
+data class LinkpointMotion(
+    val shortMs: Int,
+    val mediumMs: Int,
+    val longMs: Int
+)
+
+@Immutable
+data class LinkpointDesignTokens(
+    val spacing: LinkpointSpacing,
+    val radii: LinkpointRadii,
+    val elevation: LinkpointElevation,
+    val motion: LinkpointMotion
+)
+
+val LocalDesignTokens = staticCompositionLocalOf { linkpointDesignTokensFor(ThemePack.DensityMode.BALANCED) }
+
+fun linkpointDesignTokensFor(density: ThemePack.DensityMode): LinkpointDesignTokens {
+    val spacing = when (density) {
+        ThemePack.DensityMode.COMPACT -> LinkpointSpacing(2.dp, 4.dp, 6.dp, 10.dp, 14.dp, 18.dp, 24.dp)
+        ThemePack.DensityMode.BALANCED -> LinkpointSpacing(4.dp, 8.dp, 12.dp, 16.dp, 20.dp, 24.dp, 32.dp)
+        ThemePack.DensityMode.SPACIOUS -> LinkpointSpacing(6.dp, 10.dp, 14.dp, 20.dp, 26.dp, 32.dp, 40.dp)
+    }
+
+    val radii = when (density) {
+        ThemePack.DensityMode.COMPACT -> LinkpointRadii(4.dp, 8.dp, 12.dp, 16.dp, 999.dp)
+        ThemePack.DensityMode.BALANCED -> LinkpointRadii(6.dp, 12.dp, 16.dp, 20.dp, 999.dp)
+        ThemePack.DensityMode.SPACIOUS -> LinkpointRadii(8.dp, 14.dp, 20.dp, 24.dp, 999.dp)
+    }
+
+    return LinkpointDesignTokens(
+        spacing = spacing,
+        radii = radii,
+        elevation = LinkpointElevation(low = 1.dp, mid = 4.dp, high = 8.dp),
+        motion = LinkpointMotion(shortMs = 120, mediumMs = 220, longMs = 320)
+    )
+}
+
+object LinkpointTokens {
+    val design: LinkpointDesignTokens
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalDesignTokens.current
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointShapes.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointShapes.kt
@@ -1,0 +1,51 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Shape
+
+@Immutable
+data class LinkpointShapeTokens(
+    val materialShapes: Shapes,
+    val chipShape: Shape,
+    val cardShape: Shape
+)
+
+val LocalLinkpointShapes = staticCompositionLocalOf {
+    linkpointShapesFor(
+        cornerStyle = ThemePack.CornerStyleProfile.STANDARD,
+        designTokens = linkpointDesignTokensFor(ThemePack.DensityMode.BALANCED)
+    )
+}
+
+fun linkpointShapesFor(
+    cornerStyle: ThemePack.CornerStyleProfile,
+    designTokens: LinkpointDesignTokens
+): LinkpointShapeTokens {
+    val radii = designTokens.radii
+    val (small, medium, large) = when (cornerStyle) {
+        ThemePack.CornerStyleProfile.SHARP -> Triple(
+            RoundedCornerShape(0),
+            RoundedCornerShape(radii.sm),
+            RoundedCornerShape(radii.md)
+        )
+        ThemePack.CornerStyleProfile.ORGANIC -> Triple(
+            RoundedCornerShape(radii.md),
+            RoundedCornerShape(radii.lg),
+            RoundedCornerShape(radii.xl)
+        )
+        ThemePack.CornerStyleProfile.STANDARD -> Triple(
+            RoundedCornerShape(radii.sm),
+            RoundedCornerShape(radii.md),
+            RoundedCornerShape(radii.lg)
+        )
+    }
+
+    return LinkpointShapeTokens(
+        materialShapes = Shapes(small = small, medium = medium, large = large),
+        chipShape = RoundedCornerShape(radii.pill),
+        cardShape = medium
+    )
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTheme.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTheme.kt
@@ -41,15 +41,32 @@ val LocalThemePack = staticCompositionLocalOf { BuiltInThemes.LINKPOINT_DEFAULT 
 @Composable
 fun LinkpointTheme(
     themePack: ThemePack? = null,
+    densityMode: ThemePack.DensityMode? = null,
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
     val themeManager = remember(context) { ThemeManager.getInstance(context) }
+    val densitySettingsStore = remember(context) { DensitySettingsStore(context) }
     val activeTheme by themeManager.activeTheme.collectAsState()
+    val persistedDensityMode by densitySettingsStore.densityMode.collectAsState(initial = ThemePack.DensityMode.BALANCED)
     val resolvedThemePack = themePack ?: activeTheme
+    val resolvedDensityMode = densityMode
+        ?: persistedDensityMode
+        .takeIf { it != ThemePack.DensityMode.BALANCED }
+        ?: resolvedThemePack.resolvedDensityDefault()
     val linkpointColors = resolvedThemePack.toComposeColors()
-    
+    val designTokens = remember(resolvedDensityMode) { linkpointDesignTokensFor(resolvedDensityMode) }
+    val typographyTokens = remember(resolvedThemePack.id) {
+        linkpointTypographyFor(resolvedThemePack.resolvedThemeFamily())
+    }
+    val shapeTokens = remember(resolvedThemePack.id, resolvedDensityMode) {
+        linkpointShapesFor(
+            cornerStyle = resolvedThemePack.resolvedCornerStyleProfile(),
+            designTokens = designTokens
+        )
+    }
+
     // Create Material 3 color scheme from ThemePack colors
     // Support both dark and light themes based on system preference
     val colorScheme = if (darkTheme) {
@@ -95,10 +112,16 @@ fun LinkpointTheme(
     
     CompositionLocalProvider(
         LocalLinkpointColors provides linkpointColors,
-        LocalThemePack provides resolvedThemePack
+        LocalThemePack provides resolvedThemePack,
+        LocalDensityMode provides resolvedDensityMode,
+        LocalDesignTokens provides designTokens,
+        LocalLinkpointTypography provides typographyTokens,
+        LocalLinkpointShapes provides shapeTokens
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
+            typography = typographyTokens.materialTypography,
+            shapes = shapeTokens.materialShapes,
             content = content
         )
     }
@@ -129,4 +152,9 @@ object LinkpointTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalThemePack.current
+
+    val density: ThemePack.DensityMode
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalDensityMode.current
 }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTypography.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTypography.kt
@@ -1,0 +1,47 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+
+@Immutable
+data class LinkpointTypographyTokens(
+    val materialTypography: Typography,
+    val coordinateText: TextStyle,
+    val lindenDollarText: TextStyle
+)
+
+val LocalLinkpointTypography = staticCompositionLocalOf {
+    linkpointTypographyFor(ThemePack.ThemeFamily.DEFAULT)
+}
+
+fun linkpointTypographyFor(family: ThemePack.ThemeFamily): LinkpointTypographyTokens {
+    val baseFamily = when (family) {
+        ThemePack.ThemeFamily.CLASSIC -> FontFamily.Serif
+        ThemePack.ThemeFamily.ELEGANT -> FontFamily.Serif
+        ThemePack.ThemeFamily.MODERN -> FontFamily.SansSerif
+        ThemePack.ThemeFamily.INDUSTRIAL -> FontFamily.SansSerif
+        ThemePack.ThemeFamily.DEFAULT -> FontFamily.SansSerif
+    }
+
+    val typography = Typography().run {
+        copy(
+            displayLarge = displayLarge.copy(fontFamily = baseFamily),
+            displayMedium = displayMedium.copy(fontFamily = baseFamily),
+            titleLarge = titleLarge.copy(fontFamily = baseFamily),
+            titleMedium = titleMedium.copy(fontFamily = baseFamily),
+            bodyLarge = bodyLarge.copy(fontFamily = baseFamily),
+            bodyMedium = bodyMedium.copy(fontFamily = baseFamily),
+            labelLarge = labelLarge.copy(fontFamily = baseFamily)
+        )
+    }
+
+    val mono = typography.bodyMedium.copy(fontFamily = FontFamily.Monospace)
+    return LinkpointTypographyTokens(
+        materialTypography = typography,
+        coordinateText = mono,
+        lindenDollarText = mono
+    )
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePack.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePack.kt
@@ -72,8 +72,40 @@ data class ThemePack(
     val colorSuccess: String = "#4CAF50",
     
     /** Optional: Warning color */
-    val colorWarning: String = "#FFC107"
+    val colorWarning: String = "#FFC107",
+
+    /** Optional: semantic family to drive typography defaults */
+    val themeFamily: ThemeFamily? = null,
+
+    /** Optional: default density mode for this theme */
+    val densityModeDefault: DensityMode? = null,
+
+    /** Optional: default corner style profile */
+    val cornerStyleProfile: CornerStyleProfile? = null
 ) {
+    @Serializable
+    enum class ThemeFamily {
+        DEFAULT,
+        CLASSIC,
+        MODERN,
+        ELEGANT,
+        INDUSTRIAL
+    }
+
+    @Serializable
+    enum class DensityMode {
+        COMPACT,
+        BALANCED,
+        SPACIOUS
+    }
+
+    @Serializable
+    enum class CornerStyleProfile {
+        STANDARD,
+        SHARP,
+        ORGANIC
+    }
+
     companion object {
         private val json = Json { 
             prettyPrint = true 
@@ -111,10 +143,40 @@ data class ThemePack(
                 colorBackground = "#1A1A1A",
                 colorSurface = "#2D2D2D",
                 colorOnSurface = "#FFFFFF",
-                colorOnSurfaceVariant = "#B0B0B0"
+                colorOnSurfaceVariant = "#B0B0B0",
+                themeFamily = ThemeFamily.DEFAULT,
+                densityModeDefault = DensityMode.BALANCED,
+                cornerStyleProfile = CornerStyleProfile.STANDARD
             )
         }
+
+        private val metadataFallbacks: Map<String, ThemeMetadataProfile> = mapOf(
+            "firestorm" to ThemeMetadataProfile(ThemeFamily.MODERN, DensityMode.COMPACT, CornerStyleProfile.SHARP),
+            "sl_classic" to ThemeMetadataProfile(ThemeFamily.CLASSIC, DensityMode.BALANCED, CornerStyleProfile.STANDARD),
+            "royal_silver" to ThemeMetadataProfile(ThemeFamily.ELEGANT, DensityMode.SPACIOUS, CornerStyleProfile.ORGANIC),
+            "slate_gunmetal" to ThemeMetadataProfile(ThemeFamily.INDUSTRIAL, DensityMode.COMPACT, CornerStyleProfile.SHARP)
+        )
     }
+
+    data class ThemeMetadataProfile(
+        val family: ThemeFamily,
+        val densityMode: DensityMode,
+        val cornerStyle: CornerStyleProfile
+    )
+
+    fun resolvedThemeFamily(): ThemeFamily {
+        return themeFamily ?: companionMetadataFallback()?.family ?: ThemeFamily.DEFAULT
+    }
+
+    fun resolvedDensityDefault(): DensityMode {
+        return densityModeDefault ?: companionMetadataFallback()?.densityMode ?: DensityMode.BALANCED
+    }
+
+    fun resolvedCornerStyleProfile(): CornerStyleProfile {
+        return cornerStyleProfile ?: companionMetadataFallback()?.cornerStyle ?: CornerStyleProfile.STANDARD
+    }
+
+    private fun companionMetadataFallback(): ThemeMetadataProfile? = metadataFallbacks[id]
     
     /**
      * Convert this theme pack to a JSON string

--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePreviewHarness.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePreviewHarness.kt
@@ -1,0 +1,80 @@
+package com.linkpoint.ui.theme
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ThemePreviewHarness(
+    themePack: ThemePack,
+    densityMode: ThemePack.DensityMode,
+    modifier: Modifier = Modifier
+) {
+    LinkpointTheme(themePack = themePack, densityMode = densityMode, darkTheme = true) {
+        val spacing = LinkpointTokens.design.spacing
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
+        ) {
+            Text("${themePack.name} • ${densityMode.name}", style = LocalLinkpointTypography.current.coordinateText)
+
+            Button(onClick = {}) {
+                Text("Primary Button")
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                FilterChip(selected = true, onClick = {}, label = { Text("Online") })
+                FilterChip(selected = false, onClick = {}, label = { Text("Busy") })
+                FilterChip(selected = false, onClick = {}, label = { Text("L$ 1250") })
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(spacing.md), verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                    Text("Parcel: Sandbox 84, 128, 23", style = LocalLinkpointTypography.current.coordinateText)
+                    Text("Balance: L$ 4,980", style = LocalLinkpointTypography.current.lindenDollarText)
+                    Text("Chat, inventory, and quick actions should reflect active shape + spacing tokens.")
+                }
+            }
+
+            OutlinedTextField(
+                value = "SLURL: secondlife://Sandbox/128/128/25",
+                onValueChange = {},
+                label = { Text("Teleport Target") },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Preview(name = "Default / Balanced", showBackground = true)
+@Composable
+private fun ThemePreviewHarnessDefaultBalanced() {
+    ThemePreviewHarness(BuiltInThemes.LINKPOINT_DEFAULT, ThemePack.DensityMode.BALANCED)
+}
+
+@Preview(name = "Firestorm / Compact", showBackground = true)
+@Composable
+private fun ThemePreviewHarnessFirestormCompact() {
+    ThemePreviewHarness(BuiltInThemes.FIRESTORM, ThemePack.DensityMode.COMPACT)
+}
+
+@Preview(name = "Royal / Spacious", showBackground = true)
+@Composable
+private fun ThemePreviewHarnessRoyalSpacious() {
+    ThemePreviewHarness(BuiltInThemes.ROYAL_SILVER, ThemePack.DensityMode.SPACIOUS)
+}


### PR DESCRIPTION
### Motivation
- Provide a small design-system layer so UI spacing, corner geometry, elevation and typography can be driven by theme metadata and a user-selectable density mode.
- Let themes carry optional metadata (family / density / corner profile) so defaults for typography, spacing and shapes can be inferred when a theme is activated.
- Expose density as a persisted user preference so composables can consume tokenized paddings/gaps via a `CompositionLocal`.

### Description
- Added a density-aware design token layer under `ui/theme`: `LinkpointDesignTokens.kt`, `LinkpointTypography.kt`, `LinkpointShapes.kt`, and `LinkpointDensitySettings.kt` which provide `LocalDesignTokens`, `LocalLinkpointTypography`, `LocalLinkpointShapes`, and `LocalDensityMode` respectively, plus a convenience `LinkpointTokens` object for tokens access.
- Extended `ThemePack` with optional metadata fields and enums (`themeFamily`, `densityModeDefault`, `cornerStyleProfile`) and added fallback mapping and resolver helpers (`resolvedThemeFamily()`, `resolvedDensityDefault()`, `resolvedCornerStyleProfile()`).
- Updated `LinkpointTheme.kt` to consume the active `ThemePack` and wire in density, design tokens, typography tokens and shape tokens into `CompositionLocalProvider` and `MaterialTheme` (typography/shapes are applied to `MaterialTheme`).
- Added persisted density selection UI and usage in `SettingsScreen.kt` using `DensitySettingsStore` (Preferences DataStore) and a `DensityModeSetting` chip row, and switched main settings layout padding/gaps to use tokenized spacing (`LinkpointTokens.design.spacing`).
- Added `ThemePreviewHarness.kt` with `@Preview` composables rendering representative controls across themes and densities to exercise tokens visually in previews.
- Added `androidx.datastore:datastore-preferences` dependency in `build.gradle.kts` and committed all changes.

### Testing
- `git diff --check` passed with no whitespace/merge errors.
- Project Kotlin compile attempted via Gradle (`./Linkpoint/gradlew ... compileDebugKotlin`) could not complete in this environment because the Android SDK location is not configured (`ANDROID_HOME`/`local.properties` `sdk.dir` missing), so a full compile/test was not run.
- Changes were committed locally (commit message: `Add tokenized UI theme system with density persistence`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5431a3d8832387fa1ecf29d94065)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a comprehensive design token system with density-aware theming capabilities. The changes add three user-selectable density modes (*Compact*, *Balanced*, *Spacious*) that control spacing, corner radii, typography, and shapes throughout the application. The `ThemePack` data class is extended with optional metadata fields for theme family, default density, and corner style profiles, which drive token generation. A new DataStore-backed persistence layer (`DensitySettingsStore`) saves the user's density preference, and the settings screen now includes UI for selecting density modes using filter chips. The design token layer provides `CompositionLocal` providers for spacing, radii, elevation, motion, typography, and shapes, all wired into `MaterialTheme` and accessible via a convenient `LinkpointTokens` object. The settings screen has been updated to consume tokenized spacing values, and a preview harness demonstrates the token system across different themes and densities.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/build.gradle.kts` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePack.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointDesignTokens.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTypography.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointShapes.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointDensitySettings.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/LinkpointTheme.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsScreen.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/ThemePreviewHarness.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->