### PR TITLE
Add BitPack bit-level pack/unpack utility and focused bitstream tests

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/binary/BitPack.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/binary/BitPack.kt
@@ -1,0 +1,163 @@
+package com.linkpoint.protocol.binary
+
+import kotlin.math.min
+
+/**
+ * Bit-level pack/unpack utility for protocol payloads.
+ *
+ * Bits are packed and unpacked MSB-first within each byte to match
+ * Second Life terrain/message bitstream conventions.
+ */
+class BitPack private constructor(
+    private val buffer: ByteArray,
+    private val limitBytes: Int,
+    private val readOnly: Boolean,
+    private var writeByteIndex: Int,
+    private var readByteIndex: Int,
+) {
+    private var writeAccumulator = 0
+    private var writeBitCount = 0
+
+    private var readBitOffset = 0
+
+    constructor(maxBytes: Int) : this(
+        buffer = ByteArray(maxBytes),
+        limitBytes = maxBytes,
+        readOnly = false,
+        writeByteIndex = 0,
+        readByteIndex = 0,
+    )
+
+    constructor(source: ByteArray) : this(
+        buffer = source.copyOf(),
+        limitBytes = source.size,
+        readOnly = true,
+        writeByteIndex = source.size,
+        readByteIndex = 0,
+    )
+
+    /** Number of fully written bytes, excluding any unflushed accumulator bits. */
+    fun byteSize(): Int = writeByteIndex
+
+    /** Number of bits currently staged in the write accumulator. */
+    fun pendingBits(): Int = writeBitCount
+
+    /**
+     * Pack [bitCount] bits from [value], taking bits from most-significant to least-significant.
+     */
+    fun packBits(value: Int, bitCount: Int) {
+        require(!readOnly) { "BitPack is read-only" }
+        require(bitCount >= 0) { "bitCount must be non-negative" }
+        require(bitCount <= 32) { "bitCount must be <= 32" }
+
+        if (bitCount == 0) return
+
+        for (bitIndex in bitCount - 1 downTo 0) {
+            val bit = (value ushr bitIndex) and 0x01
+            appendBit(bit)
+        }
+    }
+
+    /**
+     * Pack [bitCount] bits from [source], reading source bits MSB-first.
+     */
+    fun packBits(source: ByteArray, bitCount: Int) {
+        require(!readOnly) { "BitPack is read-only" }
+        require(bitCount >= 0) { "bitCount must be non-negative" }
+        require(bitCount <= source.size * 8) {
+            "bitCount exceeds source bit length"
+        }
+
+        var remaining = bitCount
+        var sourceByte = 0
+
+        while (remaining > 0) {
+            val bitsThisByte = min(remaining, 8)
+            val value = source[sourceByte].toInt() and 0xFF
+            for (bitIndex in 7 downTo 8 - bitsThisByte) {
+                appendBit((value ushr bitIndex) and 0x01)
+            }
+            sourceByte++
+            remaining -= bitsThisByte
+        }
+    }
+
+    /**
+     * Flushes the write accumulator into the backing buffer.
+     *
+     * Any partial byte is left-aligned and padded with zero bits.
+     */
+    fun flush() {
+        require(!readOnly) { "BitPack is read-only" }
+
+        if (writeBitCount == 0) return
+
+        val padded = writeAccumulator shl (8 - writeBitCount)
+        writeByte(padded and 0xFF)
+        writeAccumulator = 0
+        writeBitCount = 0
+    }
+
+    /**
+     * Returns a copy of the written bytes.
+     *
+     * If [flushPending] is true, a partial accumulator byte is flushed first.
+     */
+    fun toByteArray(flushPending: Boolean = true): ByteArray {
+        if (!readOnly && flushPending) {
+            flush()
+        }
+        return buffer.copyOf(writeByteIndex)
+    }
+
+    /**
+     * Unpacks [bitCount] bits into an unsigned int represented as [Int].
+     */
+    fun unpackBits(bitCount: Int): Int {
+        require(bitCount >= 0) { "bitCount must be non-negative" }
+        require(bitCount <= 32) { "bitCount must be <= 32" }
+
+        var value = 0
+        repeat(bitCount) {
+            value = (value shl 1) or readBit()
+        }
+        return value
+    }
+
+    private fun appendBit(bit: Int) {
+        writeAccumulator = (writeAccumulator shl 1) or (bit and 0x01)
+        writeBitCount++
+
+        if (writeBitCount == 8) {
+            writeByte(writeAccumulator and 0xFF)
+            writeAccumulator = 0
+            writeBitCount = 0
+        }
+    }
+
+    private fun writeByte(value: Int) {
+        check(writeByteIndex < limitBytes) {
+            "BitPack overflow: limit=$limitBytes bytes"
+        }
+
+        buffer[writeByteIndex] = value.toByte()
+        writeByteIndex++
+    }
+
+    private fun readBit(): Int {
+        check(readByteIndex < limitBytes) {
+            "BitPack underflow: attempted to read past $limitBytes bytes"
+        }
+
+        val current = buffer[readByteIndex].toInt() and 0xFF
+        val bit = (current ushr (7 - readBitOffset)) and 0x01
+
+        readBitOffset++
+        if (readBitOffset == 8) {
+            readBitOffset = 0
+            readByteIndex++
+        }
+
+        return bit
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/binary/BitPackTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/binary/BitPackTest.kt
@@ -1,0 +1,63 @@
+package com.linkpoint.protocol.binary
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BitPackTest {
+
+    @Test
+    fun `round-trip pack and unpack works across non byte aligned fields`() {
+        val writer = BitPack(maxBytes = 8)
+
+        writer.packBits(0b101, 3)
+        writer.packBits(0b11011, 5)
+        writer.packBits(0b1010110011, 10)
+        writer.packBits(0b1111111, 7)
+
+        val packed = writer.toByteArray(flushPending = true)
+        val reader = BitPack(packed)
+
+        assertEquals(0b101, reader.unpackBits(3))
+        assertEquals(0b11011, reader.unpackBits(5))
+        assertEquals(0b1010110011, reader.unpackBits(10))
+        assertEquals(0b1111111, reader.unpackBits(7))
+    }
+
+    @Test
+    fun `flush writes pending accumulator bits left aligned and zero padded`() {
+        val writer = BitPack(maxBytes = 2)
+
+        writer.packBits(0b101, 3)
+        assertEquals(0, writer.byteSize())
+        assertEquals(3, writer.pendingBits())
+
+        writer.flush()
+        assertEquals(1, writer.byteSize())
+        assertEquals(0, writer.pendingBits())
+
+        assertArrayEquals(byteArrayOf(0b10100000.toByte()), writer.toByteArray(flushPending = false))
+    }
+
+    @Test
+    fun `max size boundary is enforced for packing and unpacking`() {
+        val writer = BitPack(maxBytes = 1)
+        writer.packBits(0b11001010, 8)
+        assertEquals(1, writer.byteSize())
+
+        val overflowError = runCatching {
+            writer.packBits(1, 1)
+            writer.flush()
+        }.exceptionOrNull()
+        assertTrue(overflowError is IllegalStateException)
+
+        val reader = BitPack(byteArrayOf(0x7F))
+        assertEquals(0x7F, reader.unpackBits(8))
+
+        val underflowError = runCatching {
+            reader.unpackBits(1)
+        }.exceptionOrNull()
+        assertTrue(underflowError is IllegalStateException)
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, well-scoped bit-level pack/unpack utility for protocol payloads to support non-byte-aligned fields and accumulator semantics similar to Firestorm `LLBitPack` while keeping Linkpoint naming and Kotlin style. 
- Keep this change isolated as a reusable protocol utility to enable staged integration and parity testing without replacing `terrain/BitBuffer.kt` yet.

### Description
- Add `com.linkpoint.protocol.binary.BitPack` implementing MSB-first bit packing, unpacking, an accumulator-based `flush()` that left-aligns and zero-pads partial bytes, and explicit overflow/underflow guards. 
- Provide constructors for writer (`BitPack(maxBytes)`) and reader (`BitPack(source: ByteArray)`) usage and utilities `byteSize()`, `pendingBits()`, `toByteArray()`, `packBits(...)`, and `unpackBits(...)`. 
- Add focused tests in `Linkpoint/src/test/kotlin/com/linkpoint/protocol/binary/BitPackTest.kt` covering non-byte-aligned round-trip pack/unpack, accumulator flush alignment/zero-padding, and max-size boundary handling for writer overflow and reader underflow. 
- Leave existing `terrain/BitBuffer.kt` unchanged to allow incremental parity testing and verification before integration.

### Testing
- Added JUnit tests in `com.linkpoint.protocol.binary.BitPackTest` that exercise round-trip packing/unpacking, flush behavior, and boundary checks (these tests are committed with the change). 
- Attempted to run `./gradlew :Linkpoint:test --tests com.linkpoint.protocol.binary.BitPackTest`, which failed to run in this environment due to missing Android SDK configuration (`SDK location not found`), so automated tests could not be executed here. 
- The test sources are self-contained and should run successfully in a CI environment with a proper SDK/local properties configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb037dc1c83239dd7354e0536aebd)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new `BitPack` utility class for bit-level packing and unpacking of protocol payloads. The implementation provides MSB-first bit packing with separate constructors for writer and reader modes, supports non-byte-aligned fields through an accumulator-based approach with `flush()` for left-aligned zero-padding of partial bytes, and includes explicit overflow and underflow guards. The accompanying test suite validates round-trip packing/unpacking across non-byte-aligned fields, flush behavior with partial bytes, and boundary condition handling. This is designed as a reusable protocol utility to support staged integration without replacing existing `terrain/BitBuffer.kt`.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/binary/BitPack.kt` |
| 2 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/binary/BitPackTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->