### PR TITLE
Harden LLVector3/LLQuaternion math, add angle-axis helpers and regression tests

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/avatar/AvatarAnimator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/avatar/AvatarAnimator.kt
@@ -170,7 +170,9 @@ class AvatarAnimator(
     
     private fun interpolateRotation(keys: List<AnimationKey>, time: Float): LLQuaternion {
         if (keys.isEmpty()) return LLQuaternion.identity()
-        if (keys.size == 1) return LLQuaternion(keys[0].value[0], keys[0].value[1], keys[0].value[2], keys[0].value[3])
+        if (keys.size == 1) {
+            return LLQuaternion(keys[0].value[0], keys[0].value[1], keys[0].value[2], keys[0].value[3]).normalize()
+        }
         
         // Find surrounding keys
         var prevKey = keys[0]
@@ -187,7 +189,7 @@ class AvatarAnimator(
         }
         
         if (prevKey == nextKey) {
-            return LLQuaternion(prevKey.value[0], prevKey.value[1], prevKey.value[2], prevKey.value[3])
+            return LLQuaternion(prevKey.value[0], prevKey.value[1], prevKey.value[2], prevKey.value[3]).normalize()
         }
         
         val t = (time - prevKey.time) / (nextKey.time - prevKey.time)

--- a/Linkpoint/src/main/java/com/linkpoint/avatar/MovementController.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/avatar/MovementController.kt
@@ -130,9 +130,9 @@ class MovementController(
      * Update current rotation (from simulator).
      */
     fun updateRotation(rot: LLQuaternion) {
-        rotation = rot
+        rotation = rot.normalize()
         // Extract yaw from quaternion
-        heading = rot.getYaw()
+        heading = rotation.getYaw()
     }
     
     /**

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/types/LLVector3.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/types/LLVector3.kt
@@ -4,6 +4,13 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.math.abs
+import kotlin.math.acos
+import kotlin.math.asin
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sign
+import kotlin.math.sin
 import kotlin.math.sqrt
 
 /**
@@ -16,6 +23,7 @@ data class LLVector3(
     val z: Float = 0f
 ) : Parcelable {
     companion object {
+        private const val NORMALIZE_EPSILON_SQUARED = 1.0e-12f
         fun zero() = LLVector3(0f, 0f, 0f)
         fun one() = LLVector3(1f, 1f, 1f)
         fun unitX() = LLVector3(1f, 0f, 0f)
@@ -49,10 +57,15 @@ data class LLVector3(
     
     fun length(): Float = sqrt(x * x + y * y + z * z)
     fun lengthSquared(): Float = x * x + y * y + z * z
+
+    fun isFinite(): Boolean = x.isFinite() && y.isFinite() && z.isFinite()
     
     fun normalize(): LLVector3 {
-        val len = length()
-        return if (len > 0f) LLVector3(x / len, y / len, z / len) else zero()
+        if (!isFinite()) return zero()
+        val lenSq = lengthSquared()
+        if (!lenSq.isFinite() || lenSq <= NORMALIZE_EPSILON_SQUARED) return zero()
+        val invLen = 1f / sqrt(lenSq)
+        return LLVector3(x * invLen, y * invLen, z * invLen)
     }
     
     fun dot(other: LLVector3): Float = x * other.x + y * other.y + z * other.z
@@ -100,6 +113,7 @@ data class LLQuaternion(
     val w: Float = 1f
 ) : Parcelable {
     companion object {
+        private const val NORMALIZE_EPSILON_SQUARED = 1.0e-12f
         fun identity() = LLQuaternion(0f, 0f, 0f, 1f)
         
         fun fromBytes(bytes: ByteArray, offset: Int = 0): LLQuaternion {
@@ -110,7 +124,7 @@ data class LLQuaternion(
             // W is calculated to normalize
             val wSquared = 1f - x * x - y * y - z * z
             val w = if (wSquared > 0f) sqrt(wSquared) else 0f
-            return LLQuaternion(x, y, z, w)
+            return LLQuaternion(x, y, z, w).normalize()
         }
         
         /**
@@ -123,23 +137,36 @@ data class LLQuaternion(
             val z = buffer.short / 32768f
             val wSquared = 1f - x * x - y * y - z * z
             val w = if (wSquared > 0f) sqrt(wSquared) else 0f
-            return LLQuaternion(x, y, z, w)
+            return LLQuaternion(x, y, z, w).normalize()
         }
         
         fun fromEuler(pitch: Float, roll: Float, yaw: Float): LLQuaternion {
-            val cy = kotlin.math.cos(yaw * 0.5f)
-            val sy = kotlin.math.sin(yaw * 0.5f)
-            val cp = kotlin.math.cos(pitch * 0.5f)
-            val sp = kotlin.math.sin(pitch * 0.5f)
-            val cr = kotlin.math.cos(roll * 0.5f)
-            val sr = kotlin.math.sin(roll * 0.5f)
+            val cy = cos(yaw * 0.5f)
+            val sy = sin(yaw * 0.5f)
+            val cp = cos(pitch * 0.5f)
+            val sp = sin(pitch * 0.5f)
+            val cr = cos(roll * 0.5f)
+            val sr = sin(roll * 0.5f)
             
             return LLQuaternion(
                 x = sr * cp * cy - cr * sp * sy,
                 y = cr * sp * cy + sr * cp * sy,
                 z = cr * cp * sy - sr * sp * cy,
                 w = cr * cp * cy + sr * sp * sy
-            )
+            ).normalize()
+        }
+
+        fun fromAngleAxis(angle: Float, axis: LLVector3): LLQuaternion {
+            val normalizedAxis = axis.normalize()
+            if (!normalizedAxis.isFinite()) return identity()
+            val halfAngle = angle * 0.5f
+            val s = sin(halfAngle)
+            return LLQuaternion(
+                x = normalizedAxis.x * s,
+                y = normalizedAxis.y * s,
+                z = normalizedAxis.z * s,
+                w = cos(halfAngle)
+            ).normalize()
         }
     }
     
@@ -151,9 +178,14 @@ data class LLQuaternion(
         return buffer.array()
     }
     
+    fun isFinite(): Boolean = x.isFinite() && y.isFinite() && z.isFinite() && w.isFinite()
+
     fun normalize(): LLQuaternion {
-        val len = sqrt(x * x + y * y + z * z + w * w)
-        return if (len > 0f) LLQuaternion(x / len, y / len, z / len, w / len) else identity()
+        if (!isFinite()) return identity()
+        val lenSq = x * x + y * y + z * z + w * w
+        if (!lenSq.isFinite() || lenSq <= NORMALIZE_EPSILON_SQUARED) return identity()
+        val invLen = 1f / sqrt(lenSq)
+        return LLQuaternion(x * invLen, y * invLen, z * invLen, w * invLen)
     }
     
     fun conjugate() = LLQuaternion(-x, -y, -z, w)
@@ -168,8 +200,10 @@ data class LLQuaternion(
     }
     
     fun rotate(v: LLVector3): LLVector3 {
+        if (!v.isFinite()) return LLVector3.zero()
+        val rotation = normalize()
         val qv = LLQuaternion(v.x, v.y, v.z, 0f)
-        val result = this * qv * conjugate()
+        val result = rotation * qv * rotation.conjugate()
         return LLVector3(result.x, result.y, result.z)
     }
     
@@ -218,15 +252,16 @@ data class LLQuaternion(
      * Convert to 4x4 rotation matrix (column-major for OpenGL/Filament)
      */
     fun toMatrix(out: FloatArray = FloatArray(16)): FloatArray {
-        val xx = x * x
-        val yy = y * y
-        val zz = z * z
-        val xy = x * y
-        val xz = x * z
-        val yz = y * z
-        val wx = w * x
-        val wy = w * y
-        val wz = w * z
+        val q = normalize()
+        val xx = q.x * q.x
+        val yy = q.y * q.y
+        val zz = q.z * q.z
+        val xy = q.x * q.y
+        val xz = q.x * q.z
+        val yz = q.y * q.z
+        val wx = q.w * q.x
+        val wy = q.w * q.y
+        val wz = q.w * q.z
         
         out[0] = 1f - 2f * (yy + zz)
         out[1] = 2f * (xy + wz)
@@ -255,25 +290,34 @@ data class LLQuaternion(
      * Convert to Euler angles (pitch, roll, yaw in radians)
      */
     fun toEuler(): LLVector3 {
+        val q = normalize()
         // Roll (x-axis rotation)
-        val sinrCosp = 2f * (w * x + y * z)
-        val cosrCosp = 1f - 2f * (x * x + y * y)
-        val roll = kotlin.math.atan2(sinrCosp, cosrCosp)
+        val sinrCosp = 2f * (q.w * q.x + q.y * q.z)
+        val cosrCosp = 1f - 2f * (q.x * q.x + q.y * q.y)
+        val roll = atan2(sinrCosp, cosrCosp)
         
         // Pitch (y-axis rotation)
-        val sinp = 2f * (w * y - z * x)
-        val pitch = if (kotlin.math.abs(sinp) >= 1f) {
-            kotlin.math.PI.toFloat() / 2f * kotlin.math.sign(sinp)
+        val sinp = 2f * (q.w * q.y - q.z * q.x)
+        val pitch = if (abs(sinp) >= 1f) {
+            Math.PI.toFloat() / 2f * sign(sinp)
         } else {
-            kotlin.math.asin(sinp)
+            asin(sinp)
         }
         
         // Yaw (z-axis rotation)
-        val sinyCosp = 2f * (w * z + x * y)
-        val cosyCosp = 1f - 2f * (y * y + z * z)
-        val yaw = kotlin.math.atan2(sinyCosp, cosyCosp)
+        val sinyCosp = 2f * (q.w * q.z + q.x * q.y)
+        val cosyCosp = 1f - 2f * (q.y * q.y + q.z * q.z)
+        val yaw = atan2(sinyCosp, cosyCosp)
         
         return LLVector3(pitch, roll, yaw)
+    }
+
+    fun toAngleAxis(): Pair<Float, LLVector3> {
+        val q = normalize()
+        val angle = 2f * acos(q.w.coerceIn(-1f, 1f))
+        val axisScale = sqrt((1f - q.w * q.w).coerceAtLeast(0f))
+        if (axisScale <= 1e-6f) return 0f to LLVector3.unitX()
+        return angle to LLVector3(q.x / axisScale, q.y / axisScale, q.z / axisScale).normalize()
     }
     
     override fun toString() = "($x, $y, $z, $w)"

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/types/LLQuaternionVectorRegressionTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/types/LLQuaternionVectorRegressionTest.kt
@@ -1,0 +1,60 @@
+package com.linkpoint.protocol.types
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+class LLQuaternionVectorRegressionTest {
+
+    @Test
+    fun vectorFiniteAndNormalizeRejectNaNInfinity() {
+        val nanVector = LLVector3(Float.NaN, 1f, 2f)
+        val infVector = LLVector3(Float.POSITIVE_INFINITY, 1f, 2f)
+
+        assertFalse(nanVector.isFinite())
+        assertFalse(infVector.isFinite())
+        assertEquals(LLVector3.zero(), nanVector.normalize())
+        assertEquals(LLVector3.zero(), infVector.normalize())
+    }
+
+    @Test
+    fun quaternionFiniteAndNormalizeRejectNaNInfinity() {
+        val nanQuaternion = LLQuaternion(Float.NaN, 0f, 0f, 1f)
+        val infQuaternion = LLQuaternion(0f, Float.NEGATIVE_INFINITY, 0f, 1f)
+
+        assertFalse(nanQuaternion.isFinite())
+        assertFalse(infQuaternion.isFinite())
+        assertEquals(LLQuaternion.identity(), nanQuaternion.normalize())
+        assertEquals(LLQuaternion.identity(), infQuaternion.normalize())
+    }
+
+    @Test
+    fun normalizeHandlesNearZeroMagnitudes() {
+        val tinyVector = LLVector3(1e-9f, -1e-9f, 1e-9f)
+        val tinyQuaternion = LLQuaternion(1e-9f, -1e-9f, 1e-9f, -1e-9f)
+
+        assertEquals(LLVector3.zero(), tinyVector.normalize())
+        assertEquals(LLQuaternion.identity(), tinyQuaternion.normalize())
+    }
+
+    @Test
+    fun eulerRoundTripNearGimbalRemainsStable() {
+        val pitch = (Math.PI.toFloat() / 2f) - 1e-4f
+        val roll = 0.3f
+        val yaw = -1.2f
+        val original = LLQuaternion.fromEuler(pitch, roll, yaw)
+
+        val euler = original.toEuler()
+        val reconstructed = LLQuaternion.fromEuler(euler.x, euler.y, euler.z)
+        val dot = abs(
+            original.x * reconstructed.x +
+                original.y * reconstructed.y +
+                original.z * reconstructed.z +
+                original.w * reconstructed.w
+        )
+
+        assertTrue("Expected orientation-preserving round-trip, got dot=$dot", dot > 0.999f)
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent NaN/Infinity and tiny-magnitude values from propagating into animation, camera and terse-update math by making vector/quaternion operations defensive and well-defined. 
- Provide stable, call-site-friendly conversion helpers (angle-axis / Euler) for operations used by avatar animation, camera transforms and terse update decoding. 

### Description
- Added `isFinite()` checks and near-zero-safe normalization for `LLVector3` and `LLQuaternion`, returning safe defaults (`LLVector3.zero()` / `LLQuaternion.identity()`) when inputs are invalid or magnitude is effectively zero. 
- Normalized quaternions defensively in decoding/conversion paths: `fromBytes`, `fromTerse`, and `fromEuler` now produce normalized quaternions. 
- Made quaternion consumers robust: `rotate`, `toMatrix`, and `toEuler` use a normalized quaternion before computing results. 
- Added angle-axis helpers: `LLQuaternion.fromAngleAxis(angle, axis)` and `LLQuaternion.toAngleAxis()` for explicit conversions. 
- Updated call sites that assumed unchecked normalization: normalized keyframe quaternions in `AvatarAnimator.interpolateRotation` and normalized inbound rotations in `MovementController.updateRotation`. 
- Added regression tests at `Linkpoint/src/test/kotlin/com/linkpoint/protocol/types/LLQuaternionVectorRegressionTest.kt` covering NaN/Infinity inputs, near-gimbal Euler round-trips, and normalization edge cases. 

### Testing
- Attempted to run the new unit tests with Gradle: `./gradlew :Linkpoint:testDebugUnitTest --tests com.linkpoint.protocol.types.LLQuaternionVectorRegressionTest`, which failed due to missing Android SDK location. 
- Re-ran with `ANDROID_HOME=/workspace/Linkpoint/android-sdk` and targeted `testStableDebugUnitTest`; Gradle configuration/install steps proceeded but compilation failed before tests ran due to unrelated, pre-existing Kotlin compilation errors in other project files (these errors are not caused by the vector/quaternion changes). 
- The new tests are present and should pass once the broader project compiles; no test failures attributable to the changes were observed locally because the test task could not complete due to the unrelated compilation failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb0422d3483239486e53638b089d0)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens vector and quaternion mathematical operations to prevent NaN, Infinity, and near-zero magnitude values from propagating through avatar animation, camera transforms, and network update decoding. It adds defensive `isFinite()` checks and epsilon-aware normalization to `LLVector3` and `LLQuaternion`, ensures all quaternion factory methods (`fromBytes`, `fromTerse`, `fromEuler`) and consumers (`rotate`, `toMatrix`, `toEuler`) work with normalized values, and introduces new angle-axis conversion helpers (`fromAngleAxis` and `toAngleAxis`). Call sites in `AvatarAnimator` and `MovementController` are updated to explicitly normalize quaternions where previously assumed, and comprehensive regression tests validate the changes against edge cases including NaN/Infinity inputs and gimbal-lock scenarios.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/types/LLQuaternionVectorRegressionTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/types/LLVector3.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/avatar/MovementController.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/avatar/AvatarAnimator.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->