### PR TITLE
Add configurable display-name formatting and apply to social UI

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -64,6 +64,7 @@ import com.linkpoint.service.BackgroundResumeScheduler
 import com.linkpoint.service.IdleHandler
 import com.linkpoint.service.LinkpointConnectionService
 import com.linkpoint.users.DisplayNameManager
+import com.linkpoint.users.DisplayNameFormattingPolicyHolder
 import com.linkpoint.chat.MuteManager
 import com.linkpoint.users.UserProfileManager
 import com.linkpoint.voice.VoiceManager
@@ -607,6 +608,7 @@ class LinkpointApp : Application() {
     // Display names (NEW)
     lateinit var displayNameManager: DisplayNameManager
         private set
+    val displayNameFormattingPolicy = DisplayNameFormattingPolicyHolder()
     
     // Mute list (NEW)
     lateinit var muteManager: MuteManager

--- a/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt
@@ -17,6 +17,8 @@ import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.network.ChatType
 import com.linkpoint.chat.SessionType
+import com.linkpoint.users.DisplayName
+import com.linkpoint.users.DisplayNameOutputMode
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
@@ -50,6 +52,17 @@ class ChatActivity : AppCompatActivity() {
     private var activeGroupSessionId: UUID? = null
     
     private val app by lazy { LinkpointApp.getInstance() }
+
+    private fun formatSender(rawName: String, sourceId: UUID? = null): String {
+        val policy = app.displayNameFormattingPolicy.policy
+        return DisplayName(
+            agentId = sourceId ?: UUID(0L, 0L),
+            username = rawName,
+            displayName = null,
+            isDefault = true,
+            nextUpdate = 0L
+        ).format(policy.copy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK))
+    }
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -275,7 +288,7 @@ class ChatActivity : AppCompatActivity() {
     private fun com.linkpoint.chat.IMMessage.toActivityMessage(channel: ActivityChatChannel): ActivityChatMessage {
         return ActivityChatMessage(
             id = id.toString(),
-            sender = fromName,
+            sender = formatSender(fromName, fromAgentId),
             content = message,
             timestamp = timestamp,
             type = ActivityMessageType.NORMAL,
@@ -293,7 +306,7 @@ class ChatActivity : AppCompatActivity() {
         }
         return ActivityChatMessage(
             id = id.toString(),
-            sender = fromName,
+            sender = formatSender(fromName, sourceId),
             content = message,
             timestamp = timestamp,
             type = activityType,

--- a/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendActionsDialog.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendActionsDialog.kt
@@ -13,6 +13,8 @@ import com.linkpoint.LinkpointApp
 import com.linkpoint.R
 import com.linkpoint.ui.chat.ChatActivity
 import com.linkpoint.ui.profile.ProfileActivity
+import com.linkpoint.users.DisplayName
+import com.linkpoint.users.DisplayNameOutputMode
 import com.linkpoint.world.Friend
 import kotlinx.coroutines.launch
 
@@ -22,6 +24,18 @@ import kotlinx.coroutines.launch
 class FriendActionsDialog : DialogFragment() {
 
     private lateinit var friend: Friend
+
+    private fun formattedFriendName(): String {
+        val app = LinkpointApp.getInstance()
+        val policy = app.displayNameFormattingPolicy.policy
+        return DisplayName(
+            agentId = friend.agentId,
+            username = friend.name,
+            displayName = null,
+            isDefault = true,
+            nextUpdate = 0L
+        ).format(policy.copy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK))
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         friend = requireArguments().getParcelable<Friend>("friend")
@@ -35,7 +49,7 @@ class FriendActionsDialog : DialogFragment() {
         )
 
         return MaterialAlertDialogBuilder(requireContext())
-            .setTitle(friend.name)
+            .setTitle(formattedFriendName())
             .setItems(options) { _, which ->
                 when (which) {
                     0 -> sendIM()
@@ -50,7 +64,7 @@ class FriendActionsDialog : DialogFragment() {
 
     private fun sendIM() {
         val app = LinkpointApp.getInstance()
-        val sessionId = app.imManager.startP2PSession(friend.agentId, friend.name)
+        val sessionId = app.imManager.startP2PSession(friend.agentId, formattedFriendName())
         app.imManager.markAsRead(sessionId)
 
         val intent = Intent(requireContext(), ChatActivity::class.java).apply {

--- a/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsAdapter.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsAdapter.kt
@@ -8,7 +8,11 @@ import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.linkpoint.LinkpointApp
 import com.linkpoint.R
+import com.linkpoint.users.DisplayName
+import com.linkpoint.users.DisplayNameOutputMode
+import com.linkpoint.users.DisplayNameFormattingPolicy
 import com.linkpoint.world.Friend
 import java.text.SimpleDateFormat
 import java.util.*
@@ -52,7 +56,17 @@ class FriendsAdapter(
         private val lastSeen: TextView = itemView.findViewById(R.id.last_seen)
 
         fun bind(friend: Friend) {
-            friendName.text = friend.name
+            val policy = (itemView.context.applicationContext as? LinkpointApp)
+                ?.displayNameFormattingPolicy
+                ?.policy
+                ?: DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK)
+            friendName.text = DisplayName(
+                agentId = friend.agentId,
+                username = friend.name,
+                displayName = null,
+                isDefault = true,
+                nextUpdate = 0L
+            ).format(policy)
             
             if (friend.isOnline) {
                 friendStatus.text = itemView.context.getString(R.string.online)

--- a/Linkpoint/src/main/java/com/linkpoint/ui/profile/ProfileActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/profile/ProfileActivity.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.tabs.TabLayout
 import com.linkpoint.LinkpointApp
 import com.linkpoint.R
+import com.linkpoint.users.DisplayName
+import com.linkpoint.users.DisplayNameOutputMode
 import com.linkpoint.world.AvatarProfile
 import com.linkpoint.world.GroupMembership
 import com.linkpoint.world.ProfilePick
@@ -128,15 +130,33 @@ class ProfileActivity : AppCompatActivity() {
     }
     
     private fun updateUI(profile: AvatarProfile) {
-        displayName.text = profile.displayName.ifEmpty { "Unknown" }
+        val app = application as LinkpointApp
+        val policy = app.displayNameFormattingPolicy.policy
+        val formattedPrimaryName = DisplayName(
+            agentId = profile.agentId,
+            username = profile.userName,
+            displayName = profile.displayName,
+            isDefault = profile.displayName.isBlank(),
+            nextUpdate = 0L
+        ).format(policy)
+        displayName.text = formattedPrimaryName.ifEmpty { "Unknown" }
         userName.text = profile.userName
         bornDate.text = "Born: ${profile.bornOn}"
         
         if (profile.partner != null) {
             partnerName.text = "Partner: (loading...)"
             lifecycleScope.launch {
-                val name = (application as LinkpointApp).profileManager.getDisplayName(profile.partner)
-                partnerName.text = "Partner: ${name ?: "(unknown)"}"
+                val rawName = app.profileManager.getDisplayName(profile.partner)
+                val formattedName = rawName?.let {
+                    DisplayName(
+                        agentId = profile.partner,
+                        username = it,
+                        displayName = null,
+                        isDefault = true,
+                        nextUpdate = 0L
+                    ).format(policy.copy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK))
+                }
+                partnerName.text = "Partner: ${formattedName ?: "(unknown)"}"
             }
         } else {
             partnerName.visibility = View.GONE

--- a/Linkpoint/src/main/java/com/linkpoint/users/DisplayNameFormattingPolicy.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/users/DisplayNameFormattingPolicy.kt
@@ -1,0 +1,24 @@
+package com.linkpoint.users
+
+/**
+ * UI-agnostic display-name formatting policy.
+ *
+ * Mirrors Firestorm-style behavior concepts (format mode + legacy handling)
+ * without static/global mutable flags.
+ */
+data class DisplayNameFormattingPolicy(
+    val outputMode: DisplayNameOutputMode = DisplayNameOutputMode.DISPLAY_ONLY,
+    val hideResidentLastName: Boolean = true,
+    val fallbackToUsernameWhenLegacyIncomplete: Boolean = true
+)
+
+enum class DisplayNameOutputMode {
+    DISPLAY_ONLY,
+    DISPLAY_AND_USERNAME,
+    LEGACY_FALLBACK
+}
+
+class DisplayNameFormattingPolicyHolder(
+    var policy: DisplayNameFormattingPolicy = DisplayNameFormattingPolicy()
+)
+

--- a/Linkpoint/src/main/java/com/linkpoint/users/DisplayNameManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/users/DisplayNameManager.kt
@@ -294,33 +294,82 @@ data class DisplayName(
     val legacyFirstName: String = "",
     val legacyLastName: String = ""
 ) {
+    fun format(policy: DisplayNameFormattingPolicy = DisplayNameFormattingPolicy()): String {
+        val effectiveDisplay = displayName?.takeIf { it.isNotBlank() }
+        val effectiveUsername = username.takeIf { it.isNotBlank() }
+        val legacy = buildLegacyName(policy)
+
+        return when (policy.outputMode) {
+            DisplayNameOutputMode.DISPLAY_ONLY -> effectiveDisplay
+                ?: effectiveUsername
+                ?: legacy
+
+            DisplayNameOutputMode.DISPLAY_AND_USERNAME -> {
+                if (effectiveDisplay != null && effectiveUsername != null && effectiveDisplay != effectiveUsername) {
+                    "$effectiveDisplay ($effectiveUsername)"
+                } else {
+                    effectiveDisplay ?: effectiveUsername ?: legacy
+                }
+            }
+
+            DisplayNameOutputMode.LEGACY_FALLBACK -> {
+                if (effectiveDisplay != null && !isDefault) {
+                    effectiveDisplay
+                } else {
+                    legacy
+                }
+            }
+        }
+    }
+
+    private fun buildLegacyName(policy: DisplayNameFormattingPolicy): String {
+        val first = legacyFirstName.ifBlank { extractLegacyFirstFromUsername(username) }
+        val last = legacyLastName.ifBlank { extractLegacyLastFromUsername(username) }
+        if (first.isBlank() && last.isBlank()) {
+            return username.ifBlank { "Resident" }
+        }
+        if (policy.hideResidentLastName && last.equals("Resident", ignoreCase = true)) {
+            return first.ifBlank {
+                if (policy.fallbackToUsernameWhenLegacyIncomplete) username else "Resident"
+            }
+        }
+        return listOf(first, last)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank {
+                if (policy.fallbackToUsernameWhenLegacyIncomplete) username.ifBlank { "Resident" } else "Resident"
+            }
+    }
+
+    private fun extractLegacyFirstFromUsername(rawUsername: String): String {
+        val tokenized = rawUsername.replace('.', ' ').trim().split(" ").filter { it.isNotBlank() }
+        return tokenized.firstOrNull() ?: ""
+    }
+
+    private fun extractLegacyLastFromUsername(rawUsername: String): String {
+        val tokenized = rawUsername.replace('.', ' ').trim().split(" ").filter { it.isNotBlank() }
+        return if (tokenized.size >= 2) tokenized.drop(1).joinToString(" ") else ""
+    }
+
     /**
      * Get the name to display (display name if set, otherwise username).
      */
     fun getEffectiveName(): String {
-        return displayName ?: username
+        return format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.DISPLAY_ONLY))
     }
     
     /**
      * Get the full display with both names.
      */
     fun getFullDisplay(): String {
-        return if (displayName != null && !isDefault) {
-            "$displayName ($username)"
-        } else {
-            username
-        }
+        return format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.DISPLAY_AND_USERNAME))
     }
     
     /**
      * Get legacy full name.
      */
     fun getLegacyName(): String {
-        return if (legacyLastName.isNotEmpty() && legacyLastName != "Resident") {
-            "$legacyFirstName $legacyLastName"
-        } else {
-            legacyFirstName.ifEmpty { username }
-        }
+        return format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK))
     }
 }
 

--- a/Linkpoint/src/test/kotlin/com/linkpoint/users/DisplayNameFormattingTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/users/DisplayNameFormattingTest.kt
@@ -1,0 +1,78 @@
+package com.linkpoint.users
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.UUID
+
+class DisplayNameFormattingTest {
+
+    private val agentId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+
+    @Test
+    fun `legacy fallback hides Resident last name`() {
+        val name = DisplayName(
+            agentId = agentId,
+            username = "charlie.resident",
+            displayName = null,
+            isDefault = true,
+            nextUpdate = 0L,
+            legacyFirstName = "Charlie",
+            legacyLastName = "Resident"
+        )
+
+        assertEquals(
+            "Charlie",
+            name.format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK))
+        )
+    }
+
+    @Test
+    fun `legacy fallback uses username when last name missing`() {
+        val name = DisplayName(
+            agentId = agentId,
+            username = "soloavatar",
+            displayName = null,
+            isDefault = true,
+            nextUpdate = 0L,
+            legacyFirstName = "",
+            legacyLastName = ""
+        )
+
+        assertEquals(
+            "soloavatar",
+            name.format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.LEGACY_FALLBACK))
+        )
+    }
+
+    @Test
+    fun `display plus username falls back to username when display name empty`() {
+        val name = DisplayName(
+            agentId = agentId,
+            username = "avery.avatar",
+            displayName = "",
+            isDefault = false,
+            nextUpdate = 0L
+        )
+
+        assertEquals(
+            "avery.avatar",
+            name.format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.DISPLAY_AND_USERNAME))
+        )
+    }
+
+    @Test
+    fun `display plus username includes both when display present`() {
+        val name = DisplayName(
+            agentId = agentId,
+            username = "avery.avatar",
+            displayName = "Avery",
+            isDefault = false,
+            nextUpdate = 0L
+        )
+
+        assertEquals(
+            "Avery (avery.avatar)",
+            name.format(DisplayNameFormattingPolicy(outputMode = DisplayNameOutputMode.DISPLAY_AND_USERNAME))
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize display-name formatting to avoid placeholder-heavy outputs like "Resident (xxxx)" and to make UI behavior configurable across surfaces.
- Mirror Firestorm-style display behaviors (display-only, display+username, legacy fallback) without introducing static globals.
- Apply a consistent, policy-driven formatter to friend/chat/profile surfaces to reduce duplicated logic and regression risk.
- Add tests to prevent regressions for tricky legacy name cases (Resident, missing last name, empty display name).

### Description
- Added `DisplayNameFormattingPolicy.kt` introducing `DisplayNameFormattingPolicy`, `DisplayNameOutputMode`, and `DisplayNameFormattingPolicyHolder` as a UI-agnostic policy holder.
- Extended `DisplayName` in `DisplayNameManager.kt` with a `format(policy)` method plus helpers for building legacy names and extracting name parts, and delegated `getEffectiveName`, `getFullDisplay`, and `getLegacyName` to the new formatter.
- Exposed an instance-level `displayNameFormattingPolicy` on `LinkpointApp` so components can read/set policy without static mutable globals.
- Wired the formatter into social surfaces: friends list rendering (`FriendsAdapter`), friend actions dialog (title and IM label, `FriendActionsDialog`), legacy chat sender formatting (`ChatActivity`), and profile header/partner fallback (`ProfileActivity`).
- Added `DisplayNameFormattingTest` covering Resident last-name hiding, missing legacy last-name fallback, empty display name fallback, and display+username formatting.

### Testing
- Attempted to run targeted unit tests with `./gradlew test --tests com.linkpoint.users.DisplayNameFormattingTest --tests com.linkpoint.users.UserProfileManagerTest`, which failed due to the environment lacking an Android SDK location (`ANDROID_HOME` / `local.properties`).
- The new `DisplayNameFormattingTest` was added and asserts the expected formatting behavior for the documented edge cases and is ready to run in a properly configured build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb05cdd30832389b2c2c3ff654623)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR centralizes display-name formatting logic to avoid inconsistent outputs and placeholder-heavy strings across the app. It introduces a configurable policy system (`DisplayNameFormattingPolicy` with three output modes: display-only, display+username, and legacy fallback) that replaces scattered formatting code. The policy is exposed via `LinkpointApp` and applied consistently across social surfaces including friends list, chat messages, friend action dialogs, and profile views. The changes include comprehensive unit tests covering edge cases like "Resident" last-name hiding, missing legacy names, and empty display name fallback.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/users/DisplayNameFormattingPolicy.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/users/DisplayNameManager.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/users/DisplayNameFormattingTest.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendsAdapter.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/friends/FriendActionsDialog.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/chat/ChatActivity.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/profile/ProfileActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->