### PR TITLE
Improve default theme colors for WCAG AA accessibility compliance

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/theme/BuiltInThemes.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/theme/BuiltInThemes.kt
@@ -16,8 +16,9 @@ object BuiltInThemes {
         author = "Linkpoint",
         version = "1.0.0",
         isBuiltIn = true,
-        colorPrimary = "#4A90D9",
-        colorPrimaryDark = "#2E6AB0",
+        // Primary darkened from #4A90D9 to satisfy WCAG AA (4.5:1) against #FFFFFF onPrimary.
+        colorPrimary = "#1976D2",
+        colorPrimaryDark = "#0D47A1",
         colorOnPrimary = "#FFFFFF",
         colorSecondary = "#00BCD4",
         colorOnSecondary = "#000000",


### PR DESCRIPTION
## Summary
Updated the built-in default theme's primary colors to meet WCAG AA contrast ratio requirements (4.5:1) against white text.

## Changes
- Changed `colorPrimary` from `#4A90D9` to `#1976D2` (darker blue)
- Changed `colorPrimaryDark` from `#2E6AB0` to `#0D47A1` (darker blue)
- Added clarifying comment explaining the color adjustment rationale

## Details
The primary color has been darkened to ensure sufficient contrast against the white `colorOnPrimary` text, meeting WCAG AA accessibility standards. This improves readability and accessibility for all users, particularly those with visual impairments.

https://claude.ai/code/session_01KrvMFGV4h9yschcf5S7PUp

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the default theme's primary colors to darker shades of blue to ensure WCAG AA accessibility compliance. The `colorPrimary` is changed from `#4A90D9` to `#1976D2` and `colorPrimaryDark` from `#2E6AB0` to `#0D47A1` to achieve the required 4.5:1 contrast ratio against white text, improving readability for users with visual impairments.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/theme/BuiltInThemes.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->