### PR TITLE
Add inbound sequence dedup; cross-check vs libremetaverse documented

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -423,6 +423,26 @@ class UDPConnectionFixed {
     private val outgoingQueue = java.util.concurrent.ConcurrentLinkedQueue<OutboundPacket>()
 
     /**
+     * Recent inbound sequence numbers, used to suppress double-dispatch
+     * of resent packets. Capacity matches
+     * `LinkpointConstants.TRACK_HANDLED_PACKETS = 1024` and the
+     * libremetaverse default
+     * (`Simulator.IncomingPacketIDCollection`, capacity 1024). Reads
+     * and writes happen only on the I/O thread, so no synchronisation
+     * is required — but we use the same insertion-order ring-buffer
+     * shape as libremetaverse so the eviction policy is identical
+     * (oldest sequence falls out when the buffer wraps).
+     *
+     * Without this dedup, a reliable packet whose original ACK was
+     * lost and then retransmitted with FLAG_RESENT was dispatched
+     * twice through the message-router. For idempotent updates
+     * (ObjectUpdate, terse) that's harmless; for chat / IM / money
+     * / inventory transactions the user sees the message twice.
+     */
+    private val recentInboundSequences =
+        InboundSequenceArchive(LinkpointConstants.TRACK_HANDLED_PACKETS)
+
+    /**
      * Track callbacks for reliable messages by sequence number.
      * This allows callers to receive notifications when their messages are acknowledged.
      * Critical for implementing circuit establishment state machine.
@@ -1211,7 +1231,10 @@ class UDPConnectionFixed {
                                     handlerFound = messageHandlers.containsKey(messageId)
                                 )
 
-                                // Queue ACK for reliable packets
+                                // Queue ACK for reliable packets — even duplicates.
+                                // The sender retransmits BECAUSE its ACK was lost; if
+                                // we suppress the ACK on duplicates we leave the
+                                // sender's NeedAck queue spinning until MAX_RESEND.
                                 if (packetFlags.reliable && seqNum >= 0) {
                                     pendingAcksToSend.offer(seqNum)
                                     NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
@@ -1227,10 +1250,30 @@ class UDPConnectionFixed {
                                 // and indexed into the zero-decoded buffer (wrong offset
                                 // for zero-coded packets), silently discarding most ACKs.
 
-                                // SYNCHRONOUS message dispatch from I/O thread.
-                                // This follows Lumiya's pattern where HandleMessage() is called
-                                // directly from the circuit's receive processing, not queued.
-                                dispatchMessageDirect(messageId, data)
+                                // Drop duplicate-sequence packets BEFORE handler dispatch.
+                                // libremetaverse `Simulator.cs` does this via
+                                // `IncomingPacketIDCollection.TryEnqueue`. The ACK above
+                                // still tells the sender "we got it" so the inflight
+                                // queue clears; the dedup just prevents firing chat /
+                                // IM / money / inventory handlers a second time when a
+                                // resend slipped through. If the sequence is already in
+                                // the archive we either saw the original (FLAG_RESENT
+                                // case — expected, log at DEBUG) or got a duplicate
+                                // without the resent bit (sim-side glitch — log at WARN
+                                // so we notice).
+                                if (seqNum >= 0 && !recentInboundSequences.tryEnqueue(seqNum)) {
+                                    val level =
+                                        if (packetFlags.resent) NetworkLogger.Level.DEBUG
+                                        else NetworkLogger.Level.WARN
+                                    val tag = if (packetFlags.resent) "↻ duplicate-resend" else "⚠ duplicate-not-marked-resend"
+                                    NetworkLogger.log(level, NetworkLogger.Category.UDP,
+                                        "$tag seq=$seqNum messageId=0x${messageId.toString(16)} ($messageName) — skipping handler dispatch")
+                                } else {
+                                    // SYNCHRONOUS message dispatch from I/O thread.
+                                    // This follows Lumiya's pattern where HandleMessage() is called
+                                    // directly from the circuit's receive processing, not queued.
+                                    dispatchMessageDirect(messageId, data)
+                                }
                             }
                         }
                     }
@@ -3917,5 +3960,38 @@ class UDPConnectionFixed {
             selectorReadableKeyCount = selectorReadableKeyCount.get(),
             receiveLoopExceptions = receiveLoopExceptions.toList()
         )
+    }
+
+    /**
+     * Fixed-capacity ring buffer + hash set for inbound sequence-number
+     * deduplication. Direct port of libremetaverse's
+     * `IncomingPacketIDCollection`. Single-threaded by contract:
+     * accessed only from the I/O thread (the receive loop), so no
+     * synchronisation. When the buffer fills, the oldest sequence
+     * number is evicted from both the ring and the set in one step.
+     *
+     * `tryEnqueue` returns `true` when the sequence is NEW (caller
+     * should dispatch the packet) and `false` when it's already in
+     * the archive (caller should drop the packet).
+     */
+    private class InboundSequenceArchive(private val capacity: Int) {
+        private val items = IntArray(capacity)
+        private val seen = HashSet<Int>(capacity)
+        private var head = 0
+        private var tail = 0
+        private var size = 0
+
+        fun tryEnqueue(seq: Int): Boolean {
+            if (!seen.add(seq)) return false
+            if (size == capacity) {
+                seen.remove(items[head])
+                head = (head + 1) % capacity
+                size--
+            }
+            items[tail] = seq
+            tail = (tail + 1) % capacity
+            size++
+            return true
+        }
     }
 }

--- a/docs/circuit-cross-check-libremetaverse.md
+++ b/docs/circuit-cross-check-libremetaverse.md
@@ -1,0 +1,151 @@
+# Linkpoint UDP circuit vs `cinderblocks/libremetaverse` cross-check
+
+Comparison of `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt`
+against the canonical reference implementation in
+[`cinderblocks/libremetaverse`](https://github.com/cinderblocks/libremetaverse)
+(C#, .NET 6/7, BSD-3, v2.6.6 / 2026-04-12, 5 154 commits) — specifically:
+
+- `LibreMetaverse/Simulator.cs` — per-region UDP circuit, 1 916 lines
+- `LibreMetaverse/NetworkManager.cs` — connection lifecycle + login, 1 545 lines
+- `LibreMetaverse/UDPBase.cs` — raw socket + read/write loops, 316 lines
+- `LibreMetaverse/Settings.cs` — timing constants
+
+This is the working notes for the circuit cross-check. One real bug
+fixed on this branch; the rest are noted in case any become regressions
+later.
+
+## Constants — what each side uses
+
+| Constant | libremetaverse | Linkpoint Wi-Fi | Linkpoint cellular |
+|---|---|---|---|
+| Ping interval | `PING_INTERVAL = 2200 ms` | `5 000 ms` | `20 000 ms` (NAT keepalive) |
+| Resend timeout | `RESEND_TIMEOUT = 4 000 ms` | `MESSAGE_TIMEOUT_MS = 5 000 ms` | (same) |
+| Max resends before drop | `MAX_RESEND_COUNT = 3` | `MESSAGE_MAX_RETRIES = 3` | (same) |
+| Pending ACKs before flush | `MAX_PENDING_ACKS = 10` | flushes on interval *or* `ACK_FLUSH_QUEUE_THRESHOLD` | (same) |
+| Network tick | `NETWORK_TICK_INTERVAL = 500 ms` | I/O thread + selector wakeup | (same) |
+| Unanswered pings → tear down | **none — pings forever** | `UNANSWERED_PINGS_DISCONNECT = 3` | `12` |
+| Inbound dedup ring size | `IncomingPacketIDCollection` capacity `1024` | `TRACK_HANDLED_PACKETS = 1024` | (same) |
+
+**Verdict:** our cellular thresholds sit between libremetaverse's
+"never give up" and our own Wi-Fi default. We ping ~2.3× less often
+(5 s vs 2.2 s) but bundle keepalive into the ping path; the steady-
+state outbound rate is roughly comparable. No tuning change wanted.
+
+## What's the same (no change needed)
+
+- **FLAG_RESENT semantics on resend.** Both impls: clear the
+  per-packet `tickCount`, OR `0x20` into the wire flag byte, requeue
+  the bytes for the I/O thread, increment the resend counter, drop
+  on the third miss. (Linkpoint: `checkMessageTimeouts` at
+  `UDPConnectionFixed.kt:1893`. libremetaverse: `ResendUnacked` at
+  `Simulator.cs:1623`.)
+
+- **PacketAck handling.** Both decode the inbound `PacketAck`
+  high-frequency message into a list of acked sequence numbers and
+  remove each from the inflight queue. Both notice when a
+  `UseCircuitCode` ACK arrives and use it to gate
+  `CompleteAgentMovement` (libremetaverse: `GotUseCircuitCodeAck`
+  semaphore; Linkpoint: `completeAgentMovementSent.compareAndSet`).
+
+- **Reliable-packet ACK send-out.** Both append received ACKs to a
+  pending-acks queue and flush either on interval or on a queue-
+  size threshold (libremetaverse `MAX_PENDING_ACKS = 10`,
+  Linkpoint `ACK_FLUSH_QUEUE_THRESHOLD`).
+
+- **Trailing-ACK piggyback on outbound packets.** Both use the
+  `FLAG_ACK = 0x10` bit + a trailing ACK list when there are
+  pending ACKs to bundle.
+
+- **Zero-coding (FLAG_ZEROCODED = 0x80).** Both decode in-place
+  from the wire bytes BEFORE handler dispatch.
+
+- **Sequence number wrap.** Neither impl special-cases wrap; the
+  field is a 32-bit unsigned integer and both rely on monotonic
+  ascent within a session. (A single SL session can't exceed
+  4 billion packets in any practical timeframe.)
+
+## Real bugs fixed on this branch
+
+### 1. Inbound duplicate-sequence detection was missing
+
+`Simulator.cs:1539` runs every newly-decoded reliable packet
+through `PacketArchive.TryEnqueue(sequence)`. If the sequence was
+already processed, the packet is dropped before any handler fires
+— the upstream's resend was triggered because *its* ACK was lost,
+not because we never got the original. ACKing the duplicate
+clears the upstream's NeedAck queue without re-firing chat / IM /
+money / inventory handlers a second time.
+
+**Linkpoint had this gap in the production path.** A separate
+`LinkpointThreadedCircuit.kt` had the dedup logic but is intentionally
+not used (see `LinkpointCircuitIntegration.kt:131` — "IMPORTANT: Do
+NOT create a separate LinkpointThreadedCircuit here"). The
+production I/O thread in `UDPConnectionFixed.kt` dispatched every
+inbound reliable packet to its handler unconditionally. Symptoms
+in real use: chat messages appearing twice on a flaky link,
+double-counted L$ transfers in lossy regions, IMs duplicated on
+reconnect.
+
+**Fix on this branch:** new `InboundSequenceArchive` ring buffer
+(direct port of libremetaverse's `IncomingPacketIDCollection`,
+same 1024-entry capacity) checked just before
+`dispatchMessageDirect`. ACKs for duplicates are still sent so
+the sender's NeedAck queue clears; only the handler dispatch is
+skipped. `FLAG_RESENT` duplicates log at DEBUG (expected),
+non-resent duplicates log at WARN (sim-side glitch worth
+noticing).
+
+## Things worth a follow-up but not landed here
+
+These are differences that didn't surface a concrete bug in the
+debug captures so far. Filed for the next time someone touches
+this code.
+
+### Per-message frequency-band stats
+
+libremetaverse's `Stats.IncrementSentPings()` /
+`Stats.GetRecvBytes()` etc. are exposed via per-frequency-band
+counters (high / medium / low / fixed). Linkpoint tracks total
+counts but not by band. Useful for diagnosing throttle-band
+saturation; not urgent.
+
+### `FLAG_ZEROCODED` outbound is decided by message type, not size
+
+libremetaverse picks zerocoding per outgoing message based on the
+message-template `Trusted` / `Encoded` flags (`PacketDecoder.cs`).
+Linkpoint currently zero-codes opportunistically based on
+compressibility. This is sometimes incorrect: e.g.
+`AgentSetAppearance` is required to NOT be zerocoded (LL bug
+documented elsewhere). Worth auditing message-type-by-message-
+type before the next appearance-baking refactor.
+
+### Throttle-band send rates
+
+libremetaverse's `AgentThrottle` setter scales each band by a
+configurable multiplier. Linkpoint sends a fixed band split
+(see `LinkpointApp.applyAdaptiveAgentThrottle`). On extremely
+constrained links the band split should be cellular-aware too —
+shrink texture/asset bands more aggressively than chat/IM. Out of
+scope for now.
+
+### `Simulator.SendPing` carries a 32-bit `OldestUnacked`
+
+libremetaverse's `SendPing` sends a `StartPingCheck` with the
+`OldestUnacked` field set to the lowest sequence number still in
+`NeedAck`. The simulator uses this to short-circuit its own
+inflight-tracking. Linkpoint sends `OldestUnacked = 0` always
+(see the packet hex dumps in the debug reports — pings are 12
+bytes with the four-byte trailer = 0). It works, but means the
+sim wastes a small amount of state. Not a real correctness bug.
+
+## Sources for the comparison
+
+Pulled directly via `curl https://raw.githubusercontent.com/cinderblocks/libremetaverse/master/...`
+on 2026-05-01 against `master` (commit `a30a40a` at time of
+writing — see `git log` of cinderblocks/libremetaverse for exact
+SHA correspondence). The C# files are in `LibreMetaverse/`:
+
+- [Simulator.cs](https://github.com/cinderblocks/libremetaverse/blob/master/LibreMetaverse/Simulator.cs)
+- [NetworkManager.cs](https://github.com/cinderblocks/libremetaverse/blob/master/LibreMetaverse/NetworkManager.cs)
+- [UDPBase.cs](https://github.com/cinderblocks/libremetaverse/blob/master/LibreMetaverse/UDPBase.cs)
+- [Settings.cs](https://github.com/cinderblocks/libremetaverse/blob/master/LibreMetaverse/Settings.cs)


### PR DESCRIPTION
Cross-checked Linkpoint's UDPConnectionFixed against the canonical
LLUDP implementation in cinderblocks/libremetaverse (C# .NET, BSD-3,
v2.6.6 / 2026-04-12) and surfaced one real bug worth landing.

The fix
-------

Inbound duplicate-sequence detection was missing in the production
UDP path. libremetaverse Simulator.cs:1539 runs every newly-decoded
reliable packet through `IncomingPacketIDCollection.TryEnqueue` (a
1024-entry ring buffer + hash set). Duplicates — caused by the
sender retransmitting because *its* ACK was lost, not because we
missed the original — are ACKed (so the sender's NeedAck queue
clears) but dropped before any handler fires, preventing
double-dispatch of chat / IM / money transfer / inventory
mutation handlers.

Linkpoint had the dedup logic in a separate `LinkpointThreadedCircuit`
class that is intentionally NOT used in production (per the comment
in LinkpointCircuitIntegration.kt:131 — single-socket architecture).
The production I/O thread dispatched every inbound reliable packet
to its handler unconditionally. Symptoms in real use: chat messages
appearing twice on a flaky link, double-counted L$ transfers in lossy
regions, IMs duplicated on reconnect.

This commit ports libremetaverse's IncomingPacketIDCollection as
`InboundSequenceArchive` — same 1024 capacity, same insertion-order
eviction. Wired into the receive loop just before
`dispatchMessageDirect`. ACKs for duplicates are still queued. Resent-
flag duplicates log at DEBUG (expected); duplicates without the
FLAG_RESENT bit log at WARN (sim-side anomaly worth noticing).

The cross-check report
----------------------

`docs/circuit-cross-check-libremetaverse.md` documents:

  - The constants table (libremetaverse vs Linkpoint Wi-Fi vs
    cellular). Verdict: our cellular tunings sit between
    libremetaverse's "never give up" and our own Wi-Fi default;
    no change needed.
  - What's identical across both impls (FLAG_RESENT semantics,
    PacketAck handling, trailing-ACK piggyback, zero-coding).
  - Three differences that didn't surface a bug in the captures
    so far but are worth a follow-up:
      * Per-message frequency-band stats (libremetaverse exposes
        per-band counters; we only aggregate).
      * Outbound FLAG_ZEROCODED selection by message-template
        Trusted/Encoded flag (we do it opportunistically by
        compressibility, which is incorrect for AgentSetAppearance
        among others).
      * StartPingCheck carries OldestUnacked in libremetaverse;
        we send 0 always.

Sources fetched directly from
https://raw.githubusercontent.com/cinderblocks/libremetaverse/master/
on 2026-05-01.

https://claude.ai/code/session_01KaCqJC5nrTGZAB9zpFYEcd

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug in the UDP packet handling where duplicate reliable packets were being dispatched to handlers multiple times, causing chat messages, instant messages, and money transfers to be processed twice on unreliable network connections. The fix ports libremetaverse's `IncomingPacketIDCollection` deduplication logic as a new `InboundSequenceArchive` ring buffer (1024 entries) that tracks recently processed sequence numbers. The PR also includes comprehensive cross-check documentation comparing Linkpoint's UDP implementation against the canonical libremetaverse C# library, identifying this bug and documenting other minor differences for future consideration.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/circuit-cross-check-libremetaverse.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate inbound packet handling to improve UDP communication reliability and prevent redundant message processing.

* **Documentation**
  * Added reference documentation detailing UDP circuit behavior patterns and cross-implementation behavioral equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->