### PR TITLE
Split LLCircuit ACK semantics into explicit inbound/outbound methods; add tests and networking comparison doc

### DIFF
--- a/Linkpoint/docs/libremetaverse-networking-comparison.md
+++ b/Linkpoint/docs/libremetaverse-networking-comparison.md
@@ -1,0 +1,175 @@
+# LibreMetaverse vs Linkpoint: Connection & Networking Deep Dive (with concrete Linkpoint fixes)
+
+## Scope
+
+This document compares connection + networking behavior in:
+
+- **LibreMetaverse** (`https://github.com/cinderblocks/libremetaverse`)
+- **Linkpoint** (this repository)
+
+and converts the comparison into concrete, implementation-ready fixes for Linkpoint.
+
+---
+
+## 1) What LibreMetaverse centralizes that Linkpoint currently splits
+
+## LibreMetaverse model (observed)
+
+LibreMetaverse exposes a **single networking authority** in `NetworkManager`:
+
+- simulator connect/disconnect lifecycle (`Connect(...)`, `DisconnectSim(...)`)
+- explicit connection state (`Connected`)
+- simulator lifecycle events (`SimConnecting`, `SimConnected`, disconnected variants)
+- capability event callback registration (`RegisterEventCallback`, `UnregisterEventCallback`)
+- seeded simulator caps wiring in connect flow
+
+At `GridClient` scope it also maintains a dedicated HTTP capability client (`HttpCapsClient`), keeping UDP simulator transport and caps/event queue in one unified network stack.
+
+## Linkpoint model (observed)
+
+Linkpoint networking responsibility is distributed across three places:
+
+1. **Feature managers** (chat/profiles/snapshots/etc.) deciding UDP vs caps behavior.
+2. **`UDPConnectionFixed` production path** with reconnect/watchdog parity expectations.
+3. **`LLMessageSystem` + `LLCircuit`** transport primitives with sequence, resend tracking, and ACK state.
+
+The parity target (Lumiya behavior) is documented, but ownership is fragmented.
+
+### Why this matters
+
+When ownership is split, correctness becomes “convention-based”: a feature manager forgetting to mark a message reliable, or diverging caps fallback policy, can break behavior without transport-layer protection.
+
+---
+
+## 2) Reliable delivery mechanics: where Linkpoint is strong vs fragile
+
+## Strong pieces already present
+
+`LLCircuit` already has useful building blocks:
+
+- `waitingAcks` resend map
+- `pendingAcks` accumulation
+- sequence number generation
+- packet-in liveness updates via `updateLastPacketInTime()`
+
+`LLMessageSystem.send(...)` correctly places reliable messages in resend tracking (`queueForResend(...)`).
+
+## Fragility points
+
+1. **ACK semantics are overloaded in `LLCircuit.ackPacket(...)`.**
+   The same method currently both queues outbound ACK intent and removes from resend wait map. These are two distinct operations and should be separated to avoid subtle coupling.
+2. **No explicit transport-level reliability policy map.**
+   Emission reliability is call-site dependent (`sendReliable` vs `sendUnreliable`) rather than template-driven; this can drift from protocol intent.
+3. **Reconnect/watchdog policy is not represented in `LLMessageSystem`.**
+   The parity document requires receive-idle driven timeout logic and reconnect ladder behavior in the production path.
+
+---
+
+## 3) Capability/eventing split: policy drift risk
+
+Feature modules currently choose caps-first or UDP-first independently. This is flexible but risks inconsistent behavior and duplicated fallback logic.
+
+LibreMetaverse’s shape suggests a better pattern: central network facade resolves capability availability and event-queue subscription, while domain managers consume normalized APIs.
+
+---
+
+## 4) Concrete fixes for Linkpoint (prioritized)
+
+## P0 — make reliability semantics explicit in transport
+
+1. Split `LLCircuit.ackPacket(...)` into:
+   - `recordInboundSequenceForAck(seq)` (only pending ACK list)
+   - `handleAckForOutboundSequence(seq)` (only resend-map removal)
+2. Update call sites so inbound packet processing and outbound ACK processing are never conflated.
+
+**Benefit:** removes hidden coupling and makes resend logic auditable.
+
+## P0 — move message reliability to a central policy table
+
+Create a transport reliability policy (template/message ID -> reliable bool), then make `send(...)` enforce it by default.
+
+- Feature layers can still override only in exceptional, documented cases.
+- Add tests that assert key protocol messages remain reliable/unreliable per parity expectations.
+
+**Benefit:** prevents reliability regressions caused by individual call-site mistakes.
+
+## P1 — introduce a `NetworkSessionFacade` authority
+
+Add a single facade (or manager) owning:
+
+- current/default simulator/session
+- connection state machine (connecting/connected/reconnecting/disconnected)
+- watchdog and reconnect decision logic
+- caps event callback registration lifecycle
+
+Feature managers should depend on this facade, not raw transport + raw capability clients.
+
+**Benefit:** one source of truth for lifecycle and diagnostics.
+
+## P1 — enforce receive-idle watchdog invariants
+
+Codify parity requirements from `docs/lumiya-parity/01-connection-lifecycle.md` into tests/checks:
+
+- no inbound for timeout window -> ping checks
+- repeated missed pings -> single timeout transition
+- timeout transition -> reconnect attempt when policy gates allow
+
+**Benefit:** converts fragile runtime behavior into testable contract.
+
+## P2 — unify caps fallback policy by domain contract
+
+For each feature area, define and codify:
+
+- primary transport (caps vs UDP)
+- fallback trigger conditions
+- retry/backoff/timeout behavior
+
+Expose as reusable helpers to stop per-manager reimplementation.
+
+**Benefit:** consistency, less duplicated error handling, cleaner telemetry.
+
+---
+
+## 5) Suggested implementation slices (small, shippable)
+
+### Slice A (safe refactor, no behavior change intended)
+
+- Refactor `LLCircuit` ACK API split (`ackPacket` decomposition).
+- Add/adjust unit tests for ACK bookkeeping only.
+
+### Slice B (behavior hardening)
+
+- Add centralized reliability policy lookup in transport send path.
+- Gate with tests for known message classes.
+
+### Slice C (architecture convergence)
+
+- Add `NetworkSessionFacade` wrapper around current production path.
+- Migrate one module (chat) to consume facade first.
+
+### Slice D (watchdog/reconnect confidence)
+
+- Add integration tests around timeout->reconnect transitions.
+- Assert no duplicate timeout transitions.
+
+---
+
+## 6) Immediate next code changes recommended
+
+1. **Refactor `LLCircuit` ACK API split first** (low-risk, high clarity).
+2. **Add reliability policy registry** near message template catalog.
+3. **Add a minimal connection-state model object** used by `UDPConnectionFixed` and feature managers.
+
+These three changes are small enough to land incrementally but directly support parity and long-term architecture cleanup.
+
+---
+
+## 7) Bottom line
+
+LibreMetaverse demonstrates the payoff of a centralized network core. Linkpoint already has many needed primitives, but today they are distributed across transport classes, feature managers, and parity docs.
+
+The best path forward is incremental centralization:
+
+- tighten ACK/reliability semantics in transport,
+- enforce reliability/watchdog rules with tests,
+- then converge lifecycle + caps ownership behind one network facade.

--- a/Linkpoint/src/main/java/com/linkpoint/linden/llmessage/LLCircuit.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/linden/llmessage/LLCircuit.kt
@@ -26,9 +26,30 @@ class LLCircuit(val host: Host) {
 
     fun nextSequenceNumber(): UInt = seqNum.getAndIncrement().toUInt()
 
-    fun ackPacket(seq: UInt) {
+    /**
+     * Track an inbound packet sequence that must be acknowledged back to the peer.
+     */
+    fun recordInboundSequenceForAck(seq: UInt) {
         pendingAcks.add(seq)
+    }
+
+    /**
+     * Mark an outbound reliable sequence as acknowledged by the peer.
+     */
+    fun handleAckForOutboundSequence(seq: UInt) {
         waitingAcks.remove(seq)
+    }
+
+
+
+    /**
+     * Backwards-compatible helper for older callers that used a single ACK API.
+     * Prefer calling the explicit inbound/outbound methods directly.
+     */
+    @Deprecated("Use recordInboundSequenceForAck() or handleAckForOutboundSequence()")
+    fun ackPacket(seq: UInt) {
+        recordInboundSequenceForAck(seq)
+        handleAckForOutboundSequence(seq)
     }
 
     fun needsResend(seq: UInt): Boolean = seq in waitingAcks

--- a/Linkpoint/src/test/kotlin/com/linkpoint/linden/llmessage/LLCircuitAckSemanticsTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/linden/llmessage/LLCircuitAckSemanticsTest.kt
@@ -1,0 +1,47 @@
+package com.linkpoint.linden.llmessage
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LLCircuitAckSemanticsTest {
+
+    private fun circuit(): LLCircuit = LLCircuit(Host.fromString("127.0.0.1:13000")!!)
+
+    @Test
+    fun `recordInboundSequenceForAck only records pending ACKs`() {
+        val circuit = circuit()
+        val seq = 42u
+
+        circuit.queueForResend(seq, byteArrayOf(1, 2, 3))
+        circuit.recordInboundSequenceForAck(seq)
+
+        assertTrue(circuit.getPendingAcks().contains(seq))
+        assertTrue(circuit.needsResend(seq))
+    }
+
+    @Test
+    fun `handleAckForOutboundSequence only clears resend tracking`() {
+        val circuit = circuit()
+        val seq = 7u
+
+        circuit.recordInboundSequenceForAck(seq)
+        circuit.queueForResend(seq, byteArrayOf(9, 9, 9))
+        circuit.handleAckForOutboundSequence(seq)
+
+        assertFalse(circuit.needsResend(seq))
+        assertTrue(circuit.getPendingAcks().contains(seq))
+    }
+
+    @Test
+    fun `legacy ackPacket preserves old combined behavior`() {
+        val circuit = circuit()
+        val seq = 99u
+
+        circuit.queueForResend(seq, byteArrayOf(8, 8, 8))
+        circuit.ackPacket(seq)
+
+        assertTrue(circuit.getPendingAcks().contains(seq))
+        assertFalse(circuit.needsResend(seq))
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce coupling between inbound ACK queuing and outbound resend bookkeeping by making ACK responsibilities explicit in the transport layer.
- Make resend/ack logic auditable and easier to reason about to prevent subtle reliability regressions.
- Capture high-level networking observations and recommended fixes for Linkpoint vs LibreMetaverse in a new comparison document.

### Description

- Split the previous combined `ackPacket` into two explicit methods: `recordInboundSequenceForAck(seq)` for pending ACK bookkeeping and `handleAckForOutboundSequence(seq)` for clearing outbound resend tracking, and added a deprecated `ackPacket` shim that preserves legacy combined behavior.
- Added unit tests in `LLCircuitAckSemanticsTest` that validate the distinct behaviors of inbound ACK recording, outbound ACK handling, and the legacy combined helper.
- Added a new analysis document `Linkpoint/docs/libremetaverse-networking-comparison.md` that compares networking architectures and proposes concrete, prioritized fixes and implementation slices for Linkpoint.

### Testing

- Ran the unit test suite including `LLCircuitAckSemanticsTest` (located at `src/test/kotlin/...`) and the new tests passed.
- Project builds and unit tests were executed via the standard build runner and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c0853ca883238dd8e22a944920a4)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the ACK handling logic in `LLCircuit` by splitting the previously combined `ackPacket` method into two explicit methods: `recordInboundSequenceForAck` for tracking incoming packets that need acknowledgment and `handleAckForOutboundSequence` for clearing outbound resend tracking. The legacy `ackPacket` method is deprecated but preserved for backward compatibility. New unit tests validate the distinct behaviors of both methods as well as the legacy combined behavior. Additionally, a comprehensive networking comparison document is added that analyzes architectural differences between LibreMetaverse and Linkpoint, identifies fragility points in the current implementation, and proposes prioritized fixes including reliability policy enforcement, centralized network session management, and watchdog/reconnect improvements.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/docs/libremetaverse-networking-comparison.md` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/linden/llmessage/LLCircuit.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/linden/llmessage/LLCircuitAckSemanticsTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added networking architecture comparison guide documenting system design considerations.

* **Refactor**
  * Separated message acknowledgment handling into distinct methods for improved clarity and maintainability.

* **Tests**
  * Added test suite validating acknowledgment tracking and resend mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->