### PR TITLE
WorldOverlay: declutter right rail, make HUD adaptive to all device sizes

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/JoystickView.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/JoystickView.kt
@@ -8,7 +8,6 @@ import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
-import kotlin.math.atan2
 import kotlin.math.min
 import kotlin.math.sqrt
 
@@ -62,7 +61,12 @@ class JoystickView @JvmOverloads constructor(
         style = Paint.Style.STROKE
         strokeWidth = 3f
     }
-    
+
+    private val indicatorPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.argb(80, 255, 255, 255)
+        style = Paint.Style.FILL
+    }
+
     // Dimensions
     private var centerX = 0f
     private var centerY = 0f
@@ -107,11 +111,6 @@ class JoystickView @JvmOverloads constructor(
     }
     
     private fun drawDirectionIndicators(canvas: Canvas) {
-        val indicatorPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.argb(80, 255, 255, 255)
-            style = Paint.Style.FILL
-        }
-        
         val indicatorSize = baseRadius * 0.15f
         val offset = baseRadius * 0.7f
         
@@ -130,25 +129,26 @@ class JoystickView @JvmOverloads constructor(
         when (event.action) {
             MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE -> {
                 isTouching = true
-                
-                // Calculate distance from center
+
+                val maxDistance = baseRadius - stickRadius
+                if (maxDistance <= 0f) {
+                    // View hasn't been measured yet; nothing meaningful to report.
+                    return true
+                }
+
                 val dx = event.x - centerX
                 val dy = event.y - centerY
                 val distance = sqrt(dx * dx + dy * dy)
-                
-                // Constrain to base circle
-                val maxDistance = baseRadius - stickRadius
+
                 if (distance <= maxDistance) {
                     stickX = event.x
                     stickY = event.y
                 } else {
-                    // Normalize and scale
                     val ratio = maxDistance / distance
                     stickX = centerX + dx * ratio
                     stickY = centerY + dy * ratio
                 }
-                
-                // Calculate normalized values (-1 to 1)
+
                 val normalizedX = (stickX - centerX) / maxDistance
                 val normalizedY = -(stickY - centerY) / maxDistance // Invert Y
                 
@@ -180,14 +180,16 @@ class JoystickView @JvmOverloads constructor(
      */
     fun getXPosition(): Float {
         val maxDistance = baseRadius - stickRadius
+        if (maxDistance <= 0f) return 0f
         return (stickX - centerX) / maxDistance
     }
-    
+
     /**
      * Get current Y position (-1 to 1).
      */
     fun getYPosition(): Float {
         val maxDistance = baseRadius - stickRadius
+        if (maxDistance <= 0f) return 0f
         return -(stickY - centerY) / maxDistance
     }
     

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldOverlayCompose.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldOverlayCompose.kt
@@ -1,25 +1,34 @@
 package com.linkpoint.ui.world
 
-import androidx.compose.foundation.background
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.EventSeat
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.FlightTakeoff
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Map
@@ -34,13 +43,18 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
@@ -52,18 +66,75 @@ private object WorldOverlayZ {
     const val TOP_STATUS = 1f
     const val RIGHT_ACTIONS = 2f
     const val BOTTOM_CHAT = 3f
-    const val MOVEMENT = 4f
-    const val CAMERA = 4f
+    const val JOYSTICKS = 4f
 }
 
 /**
+ * Resolved sizes for the overlay derived from the current viewport.
+ *
+ * Computed by [WorldOverlay] once per layout pass via [BoxWithConstraints] so
+ * the HUD stays balanced on small phones (~320dp), normal phones, foldables
+ * unfolded (~600dp+) and tablets (~800dp+) without manual breakpoints in each
+ * sub-composable.
+ */
+private data class OverlayMetrics(
+    val movementJoystick: Dp,
+    val cameraJoystick: Dp,
+    val railIcon: Dp,
+    val railTop: Dp,
+    val railBottom: Dp,
+    val chatBottom: Dp,
+    val chatMaxWidth: Dp,
+    val edgePad: Dp,
+)
+
+private fun overlayMetricsFor(width: Dp, height: Dp): OverlayMetrics {
+    val w = width.value
+    val h = height.value
+    // Joystick diameter scales with screen width but clamps at sane ergonomic
+    // bounds — small phones get smaller sticks so they don't dominate the
+    // viewport, tablets cap at 200dp so they don't become hand-size targets.
+    val movement = (w * 0.30f).coerceIn(110f, 200f).dp
+    val camera = (w * 0.24f).coerceIn(90f, 170f).dp
+    // Rail clearances follow the joystick height so the rail always finishes
+    // above the sticks, even in compact landscape.
+    val railBottom = (movement.value + 32f).coerceAtLeast(150f).dp
+    val railTop = if (h < 600f) 56.dp else 80.dp
+    val chatBottom = (movement.value + 56f).coerceAtLeast(170f).dp
+    val chatMax = (w * 0.7f).coerceIn(220f, 480f).dp
+    val edgePad = if (w >= 600f) 20.dp else 12.dp
+    val railIcon = if (w >= 600f) 48.dp else 40.dp
+    return OverlayMetrics(
+        movementJoystick = movement,
+        cameraJoystick = camera,
+        railIcon = railIcon,
+        railTop = railTop,
+        railBottom = railBottom,
+        chatBottom = chatBottom,
+        chatMaxWidth = chatMax,
+        edgePad = edgePad,
+    )
+}
+
+private data class HudAction(
+    val icon: ImageVector,
+    val label: String,
+    val onClick: () -> Unit,
+)
+
+/**
  * Linkpoint 2.0 world HUD overlay. Renders on top of the GL viewport:
- * - Top: glass status pill with region name, coord, fps/bandwidth tags.
- * - Right: vertical glass action stack (chat, minimap, inventory, fly, sit…).
- * - Bottom-left: chat preview pill.
+ * - Top: glass status pill with region name, FPS/bandwidth, interaction-mode tag.
+ * - Right: vertical glass action rail with primary actions + expandable "More".
+ * - Bottom-center: chat preview pill.
  * - Bottom corners: movement & camera joysticks.
  *
- * See design/screens-1.jsx → WorldScreen for the visual reference.
+ * The rail is intentionally short by default (5 primary actions) so it does
+ * not crowd the viewport or fight the joysticks at the bottom; the secondary
+ * actions live behind a chevron toggle. The whole rail is also scrollable as
+ * a fallback for very small screens.
+ *
+ * See design/screens-2.jsx → WorldScreen for the visual reference.
  */
 @Composable
 fun WorldOverlay(
@@ -84,110 +155,75 @@ fun WorldOverlay(
     onJump: () -> Unit,
     onSit: () -> Unit,
 ) {
-    val tokens = Linkpoint2.tokens
-    Box(modifier = Modifier.fillMaxSize()) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val metrics = overlayMetricsFor(maxWidth, maxHeight)
+
         if (state.overlaysVisibility.topStatusHud) {
-            L2GlassSurface(
+            TopStatusBar(
+                state = state,
+                onMenu = onMenu,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 12.dp)
+                    .statusBarsPadding()
+                    .padding(horizontal = metrics.edgePad, vertical = 12.dp)
                     .align(Alignment.TopCenter)
                     .zIndex(WorldOverlayZ.TOP_STATUS),
-                shape = RoundedCornerShape(tokens.radii.lg),
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp),
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onMenu) {
-                        Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White)
-                    }
-                    Column(modifier = Modifier.weight(1f).padding(start = 4.dp)) {
-                        Text(
-                            text = state.regionName,
-                            color = Color.White,
-                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                        )
-                        Text(
-                            text = "FPS ${state.fps ?: "--"}  ·  ${state.bandwidthKbps ?: "--"} kbps",
-                            color = tokens.coordColor,
-                            style = MaterialTheme.typography.labelSmall,
-                            fontFamily = FontFamily.Monospace,
-                        )
-                    }
-                    L2HudTag {
-                        Text(
-                            text = state.interactionMode.name,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = Color.White,
-                        )
-                    }
-                }
-            }
+            )
         }
 
         if (state.overlaysVisibility.rightActionStack) {
-            L2GlassSurface(
+            val primary = remember(onChat, onMinimap, onInventory, onFriends, onCameraMode) {
+                listOf(
+                    HudAction(Icons.AutoMirrored.Filled.Chat, "Chat", onChat),
+                    HudAction(Icons.Default.Map, "Minimap", onMinimap),
+                    HudAction(Icons.Default.Work, "Inventory", onInventory),
+                    HudAction(Icons.Default.Group, "Friends", onFriends),
+                    HudAction(Icons.Default.PhotoCamera, "Camera", onCameraMode),
+                )
+            }
+            val secondary = remember(onXr, onGestures, onNearby, onFly, onRun, onJump, onSit) {
+                listOf(
+                    HudAction(Icons.Default.ViewInAr, "XR", onXr),
+                    HudAction(Icons.Default.SportsEsports, "Gestures", onGestures),
+                    HudAction(Icons.Default.NearMe, "Nearby", onNearby),
+                    HudAction(Icons.Default.FlightTakeoff, "Fly", onFly),
+                    HudAction(Icons.AutoMirrored.Filled.DirectionsRun, "Run", onRun),
+                    HudAction(Icons.Default.ArrowUpward, "Jump", onJump),
+                    HudAction(Icons.Default.EventSeat, "Sit", onSit),
+                )
+            }
+            RightActionRail(
+                primary = primary,
+                secondary = secondary,
+                iconSize = metrics.railIcon,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(end = 12.dp)
+                    .statusBarsPadding()
+                    .navigationBarsPadding()
+                    .padding(top = metrics.railTop, bottom = metrics.railBottom, end = metrics.edgePad)
                     .zIndex(WorldOverlayZ.RIGHT_ACTIONS),
-                shape = RoundedCornerShape(28.dp),
-                contentPadding = PaddingValues(6.dp),
-            ) {
-                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                    HudActionButton(Icons.AutoMirrored.Filled.Chat, onChat, "Chat")
-                    HudActionButton(Icons.Default.Map, onMinimap, "Minimap")
-                    HudActionButton(Icons.Default.Work, onInventory, "Inventory")
-                    HudActionButton(Icons.Default.ViewInAr, onXr, "XR")
-                    HudActionButton(Icons.Default.SportsEsports, onGestures, "Gestures")
-                    HudActionButton(Icons.Default.Group, onFriends, "Friends")
-                    HudActionButton(Icons.Default.NearMe, onNearby, "Nearby")
-                    HudActionButton(Icons.Default.PhotoCamera, onCameraMode, "Camera")
-                    HudActionButton(Icons.Default.FlightTakeoff, onFly, "Fly")
-                    HudActionButton(Icons.AutoMirrored.Filled.DirectionsRun, onRun, "Run")
-                    HudActionButton(Icons.Default.ArrowUpward, onJump, "Jump")
-                    HudActionButton(Icons.Default.EventSeat, onSit, "Sit")
-                }
-            }
+            )
         }
 
         if (state.overlaysVisibility.bottomChatPreview) {
-            L2GlassSurface(
+            BottomChatPreview(
+                maxWidth = metrics.chatMaxWidth,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 16.dp, start = 16.dp, end = 16.dp)
+                    .navigationBarsPadding()
+                    .padding(bottom = metrics.chatBottom, start = metrics.edgePad, end = metrics.edgePad)
                     .zIndex(WorldOverlayZ.BOTTOM_CHAT),
-                shape = RoundedCornerShape(tokens.radii.pill),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(tokens.radii.pill))
-                        .background(Color.Transparent),
-                ) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.Chat,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(
-                        text = "Chat preview · Tap to open",
-                        color = Color.White,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-            }
+            )
         }
 
         if (state.overlaysVisibility.movementJoystick) {
             AndroidView(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
-                    .padding(start = 16.dp, bottom = 24.dp)
-                    .zIndex(WorldOverlayZ.MOVEMENT)
-                    .size(150.dp),
+                    .navigationBarsPadding()
+                    .padding(start = metrics.edgePad, bottom = 24.dp)
+                    .zIndex(WorldOverlayZ.JOYSTICKS)
+                    .size(metrics.movementJoystick),
                 factory = { movementJoystickFactory() },
             )
         }
@@ -196,9 +232,10 @@ fun WorldOverlay(
             AndroidView(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
-                    .padding(end = 16.dp, bottom = 24.dp)
-                    .zIndex(WorldOverlayZ.CAMERA)
-                    .size(120.dp),
+                    .navigationBarsPadding()
+                    .padding(end = metrics.edgePad, bottom = 24.dp)
+                    .zIndex(WorldOverlayZ.JOYSTICKS)
+                    .size(metrics.cameraJoystick),
                 factory = { cameraJoystickFactory() },
             )
         }
@@ -206,18 +243,131 @@ fun WorldOverlay(
 }
 
 @Composable
-private fun HudActionButton(
-    icon: ImageVector,
-    onClick: () -> Unit,
-    label: String,
+private fun TopStatusBar(
+    state: WorldUiState,
+    onMenu: () -> Unit,
+    modifier: Modifier,
 ) {
-    IconButton(
-        onClick = onClick,
-        modifier = Modifier
-            .size(44.dp)
-            .clip(CircleShape),
+    val tokens = Linkpoint2.tokens
+    L2GlassSurface(
+        modifier = modifier,
+        shape = RoundedCornerShape(tokens.radii.lg),
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 6.dp),
     ) {
-        Icon(icon, contentDescription = label, tint = Color.White)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onMenu) {
+                Icon(Icons.Default.Menu, contentDescription = "Menu", tint = Color.White)
+            }
+            Column(modifier = Modifier.weight(1f).padding(start = 4.dp)) {
+                Text(
+                    text = state.regionName,
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "FPS ${state.fps ?: "--"}  ·  ${state.bandwidthKbps ?: "--"} kbps",
+                    color = tokens.coordColor,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontFamily = FontFamily.Monospace,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            L2HudTag {
+                Text(
+                    text = state.interactionMode.shortLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Clip,
+                )
+            }
+        }
     }
-    Spacer(Modifier.height(0.dp))
+}
+
+@Composable
+private fun RightActionRail(
+    primary: List<HudAction>,
+    secondary: List<HudAction>,
+    iconSize: Dp,
+    modifier: Modifier,
+) {
+    val tokens = Linkpoint2.tokens
+    var expanded by remember { mutableStateOf(false) }
+    L2GlassSurface(
+        modifier = modifier,
+        shape = RoundedCornerShape(tokens.radii.xl),
+        contentPadding = PaddingValues(6.dp),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.verticalScroll(rememberScrollState()),
+        ) {
+            primary.forEach { HudActionButton(it, iconSize) }
+            HudActionToggle(expanded = expanded, iconSize = iconSize, onToggle = { expanded = !expanded })
+            AnimatedVisibility(
+                visible = expanded,
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically(),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    secondary.forEach { HudActionButton(it, iconSize) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HudActionButton(action: HudAction, size: Dp) {
+    IconButton(
+        onClick = action.onClick,
+        modifier = Modifier.size(size),
+    ) {
+        Icon(action.icon, contentDescription = action.label, tint = Color.White)
+    }
+}
+
+@Composable
+private fun HudActionToggle(expanded: Boolean, iconSize: Dp, onToggle: () -> Unit) {
+    IconButton(
+        onClick = onToggle,
+        modifier = Modifier.size(iconSize),
+    ) {
+        Icon(
+            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+            contentDescription = if (expanded) "Show fewer actions" else "Show more actions",
+            tint = Color.White,
+        )
+    }
+}
+
+@Composable
+private fun BottomChatPreview(maxWidth: Dp, modifier: Modifier) {
+    val tokens = Linkpoint2.tokens
+    L2GlassSurface(
+        modifier = modifier.widthIn(max = maxWidth),
+        shape = RoundedCornerShape(tokens.radii.pill),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.AutoMirrored.Filled.Chat,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = "Chat preview · Tap to open",
+                color = Color.White,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldUiState.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldUiState.kt
@@ -17,8 +17,8 @@ data class WorldUiState(
         val hudAttachments: Boolean = true
     )
 
-    enum class InteractionMode {
-        FOLLOW,
-        MOUSELOOK
+    enum class InteractionMode(val shortLabel: String) {
+        FOLLOW("FOLLOW"),
+        MOUSELOOK("LOOK")
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/voice/WebRtcVoiceSession.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/voice/WebRtcVoiceSession.kt
@@ -24,7 +24,6 @@ import org.webrtc.PeerConnectionFactory
 import org.webrtc.RtpReceiver
 import org.webrtc.SessionDescription
 import java.nio.ByteBuffer
-import java.nio.charset.Charsets
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 


### PR DESCRIPTION
The right-side action rail was crammed with 12 icons running ~590dp tall,
which on a typical phone overlapped both the top status pill and the
bottom-right camera joystick (visible in the user-supplied screenshots:
the chat icon ran inside the FOLLOW tag and the running figure sat
behind the camera joystick).

Layout changes
- Split rail into 5 primary actions (Chat, Minimap, Inventory, Friends,
  Camera) plus a chevron toggle; secondary actions (XR, Gestures,
  Nearby, Fly, Run, Jump, Sit) animate in only when expanded.
- Wrap the rail in verticalScroll so even an over-long expansion can
  never escape its safe-area window.
- Replace fixed dp insets with adaptive metrics computed once per
  layout pass via BoxWithConstraints: joystick diameter scales with
  width (110-200dp / 90-170dp), rail clearances follow joystick height,
  rail icons grow on >=600dp screens (40dp -> 48dp), edge padding
  widens on tablets.
- Add statusBarsPadding/navigationBarsPadding so the HUD respects
  cutouts and gesture nav on every device.
- TopStatusBar: maxLines=1 + ellipsis on region/FPS lines; replace
  raw enum.name with a short shortLabel ("FOLLOW"/"LOOK") so the
  interaction-mode tag no longer truncates to "FOLL...".

Code-review fixes
- JoystickView: hoist indicatorPaint out of onDraw (was allocated
  every frame), guard divide-by-zero in getXPosition/getYPosition
  and onTouchEvent before the view is measured, drop unused
  kotlin.math.atan2 import.
- WorldOverlayCompose: drop dead Spacer(0.dp), collapse duplicate
  Z constants (MOVEMENT == CAMERA -> JOYSTICKS), make actions
  list-driven via private HudAction so adding/reordering icons no
  longer means duplicating IconButton blocks.
- WebRtcVoiceSession: remove invalid `import java.nio.charset.Charsets`
  (no such class - Charsets resolves to kotlin.text.Charsets); the
  bad import was breaking compileStableDebugKotlin for the whole app.

https://claude.ai/code/session_01B4KX5ZeE2vhwVTbCdCdzR8

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the world overlay HUD to fix visual clutter and layout issues on mobile devices. The right action rail has been reorganized into 5 primary actions with an expandable toggle for 7 secondary actions, preventing overlap with the status bar and joysticks. Layout metrics are now computed adaptively using `BoxWithConstraints` so joystick sizes, icon dimensions, and padding scale appropriately across phones, foldables, and tablets. System insets (`statusBarsPadding`/`navigationBarsPadding`) have been added to respect device cutouts and gesture navigation. The status bar now uses `maxLines=1` and ellipsis to prevent truncation, and interaction modes display short labels ("FOLLOW"/"LOOK"). Code-review improvements include hoisting paint allocations out of `onDraw` in `JoystickView`, guarding divide-by-zero in joystick position calculations, making the action rail list-driven via a `HudAction` data class, and removing an invalid import that was breaking compilation.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldUiState.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/voice/WebRtcVoiceSession.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/world/JoystickView.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldOverlayCompose.kt` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `Linkpoint/src/main/java/com/linkpoint/voice/WebRtcVoiceSession.kt` | Removing an invalid import from the voice/WebRTC module is unrelated to the UI/HUD layout changes that are the focus of this PR. This appears to be a compilation fix that happened to be discovered during development. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->