### PR TITLE
Refactor Settings into Configurators and extract LogExportCoordinator

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/LogExportCoordinator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/LogExportCoordinator.kt
@@ -1,0 +1,80 @@
+package com.linkpoint.ui.settings
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceFragmentCompat
+import com.linkpoint.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+class LogExportCoordinator(
+    private val fragment: PreferenceFragmentCompat,
+    private val context: Context,
+) {
+    private var pendingText: String? = null
+    private val createDocumentLauncher: ActivityResultLauncher<Intent> =
+        fragment.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.data?.let { uri -> writeTextToUri(uri, pendingText) }
+            }
+            pendingText = null
+        }
+
+    fun exportText(defaultFilename: String, textProvider: suspend () -> String) {
+        fragment.viewLifecycleOwner.lifecycleScope.launch {
+            pendingText = withContext(Dispatchers.IO) { textProvider() }
+            val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TITLE, defaultFilename)
+            }
+            runCatching { createDocumentLauncher.launch(intent) }
+                .onFailure {
+                    pendingText = null
+                    Toast.makeText(context, context.getString(R.string.settings_file_picker_failed, it.message), Toast.LENGTH_LONG).show()
+                }
+        }
+    }
+
+    fun shareFile(file: File, chooserTitle: String, subject: String) {
+        SettingsShareHelper.shareFile(fragment, context, file, chooserTitle, subject)
+    }
+
+    private fun writeTextToUri(uri: android.net.Uri, content: String?) {
+        if (content == null) {
+            Toast.makeText(context, R.string.settings_no_log_content, Toast.LENGTH_SHORT).show(); return
+        }
+        fragment.viewLifecycleOwner.lifecycleScope.launch {
+            val success = withContext(Dispatchers.IO) {
+                runCatching {
+                    context.contentResolver.openOutputStream(uri)?.use { os -> os.bufferedWriter().use { it.write(content) } }
+                }.isSuccess
+            }
+            Toast.makeText(context, if (success) R.string.settings_log_export_success else R.string.settings_log_export_failed, Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+
+private object SettingsShareHelper {
+    fun shareFile(fragment: PreferenceFragmentCompat, context: Context, file: File, chooserTitle: String, subject: String) {
+        val authority = context.packageName + ".fileprovider"
+        val uri = runCatching { androidx.core.content.FileProvider.getUriForFile(context, authority, file) }.getOrElse {
+            Toast.makeText(context, context.getString(R.string.settings_cannot_share_log, it.message), Toast.LENGTH_LONG).show(); return
+        }
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, subject)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        runCatching { fragment.startActivity(Intent.createChooser(send, chooserTitle)) }
+            .onFailure { Toast.makeText(context, R.string.settings_no_share_target, Toast.LENGTH_SHORT).show() }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt
@@ -1,6 +1,5 @@
 package com.linkpoint.ui.settings
 
-import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -11,8 +10,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.widget.Toast
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -25,16 +22,18 @@ import androidx.preference.SeekBarPreference
 import com.linkpoint.BuildConfig
 import com.linkpoint.R
 import com.linkpoint.network.NetworkLogger
-import com.linkpoint.service.BackgroundResumeScheduler
 import com.linkpoint.ui.theme.ThemeManager
 import com.linkpoint.ui.tos.TosActivity
+import com.linkpoint.ui.settings.config.BackgroundSettingsConfigurator
+import com.linkpoint.ui.settings.config.DebugSettingsConfigurator
+import com.linkpoint.ui.settings.config.DisplaySettingsConfigurator
+import com.linkpoint.ui.settings.config.GraphicsSettingsConfigurator
 import com.linkpoint.ui.world.WorldViewActivity
 import com.linkpoint.utils.CodexUploadService
 import com.linkpoint.utils.CrashReporter
 import com.linkpoint.utils.DebugReportService
 import com.linkpoint.utils.DiagnosticsLoggingConfig
 import com.linkpoint.utils.SessionLogRecorder
-import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -99,46 +98,25 @@ class SettingsActivity : AppCompatActivity() {
                 updateSessionLogStatusSummary(it)
             }
         }
-
-        
-        // ActivityResultLauncher for saving the exported log file
-        private var pendingLogContent: String? = null
-        private val createDocumentLauncher: ActivityResultLauncher<Intent> = 
-            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-                if (result.resultCode == Activity.RESULT_OK) {
-                    result.data?.data?.let { uri ->
-                        writeLogToUri(uri)
-                    }
-                }
-                pendingLogContent = null
-            }
+        private lateinit var logExportCoordinator: LogExportCoordinator
         
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.preferences, rootKey)
-            
-            // Display settings
-            setupDisplaySettings()
+            val context = requireContext()
+            logExportCoordinator = LogExportCoordinator(this, context)
 
-            // Interface settings
+            DisplaySettingsConfigurator(this, context).configure()
             setupInterfaceSettings()
             setupKthemeThemeMenu()
-            
-            // Graphics settings
-            findPreference<ListPreference>("graphics_quality")?.setOnPreferenceChangeListener { _, newValue ->
-                updateGraphicsQuality(newValue as String)
-                true
-            }
-
-            findPreference<SwitchPreferenceCompat>("enable_secondary_renderer")?.setOnPreferenceChangeListener { _, newValue ->
-                val enabled = newValue as Boolean
-                Toast.makeText(
-                    requireContext(),
-                    if (enabled) "Secondary renderer enabled. Reopen world view to apply."
-                    else "Primary renderer enabled. Reopen world view to apply.",
-                    Toast.LENGTH_LONG
-                ).show()
-                true
-            }
+            GraphicsSettingsConfigurator(this, context, ::updateGraphicsQuality).configure()
+            BackgroundSettingsConfigurator(this, context).configure()
+            DebugSettingsConfigurator(
+                this,
+                context,
+                onCopyLog = ::confirmCopyCombinedLog,
+                onExportLog = ::confirmExportDiagnostics,
+                onShareLog = ::confirmShareCombinedLog,
+            ).configure()
             
             // XR settings
             val xrManager = com.linkpoint.LinkpointApp.getInstance().xrManager
@@ -154,7 +132,7 @@ class SettingsActivity : AppCompatActivity() {
             findPreference<ListPreference>("xr_mode")?.isEnabled = xrManager.isUiEntryAvailable()
             
             // Voice settings
-            findPreference<SwitchPreferenceCompat>("enable_voice")?.setOnPreferenceChangeListener { _, newValue ->
+            findPreference<SwitchPreferenceCompat>(SettingsKeys.ENABLE_VOICE)?.setOnPreferenceChangeListener { _, newValue ->
                 updateVoice(newValue as Boolean)
                 true
             }
@@ -181,8 +159,6 @@ class SettingsActivity : AppCompatActivity() {
             // Cache settings
             setupCacheSettings()
 
-            setupBackgroundRuntimeSettings()
-
             
             // ToS viewing
             findPreference<Preference>("view_tos")?.setOnPreferenceClickListener {
@@ -193,28 +169,6 @@ class SettingsActivity : AppCompatActivity() {
             // XML buffer size setting (3-500 MB)
             setupNetworkBufferSettings()
         }
-        
-        private fun setupBackgroundRuntimeSettings() {
-            findPreference<SwitchPreferenceCompat>("background_resume_enabled")?.setOnPreferenceChangeListener { _, newValue ->
-                val enabled = newValue as Boolean
-                if (enabled) {
-                    BackgroundResumeScheduler.schedule(requireContext(), immediate = true)
-                } else {
-                    BackgroundResumeScheduler.cancel(requireContext())
-                }
-                true
-            }
-
-            findPreference<SwitchPreferenceCompat>("push_wakeups_enabled")?.setOnPreferenceChangeListener { _, _ ->
-                true
-            }
-
-            findPreference<ListPreference>("background_intensity_profile")?.setOnPreferenceChangeListener { _, _ ->
-                BackgroundResumeScheduler.schedule(requireContext(), immediate = false)
-                true
-            }
-        }
-
         private fun setupKthemeThemeMenu() {
             val themePreference = findPreference<Preference>("open_ktheme_theme_menu") ?: return
 
@@ -614,18 +568,6 @@ class SettingsActivity : AppCompatActivity() {
             // Combined log: copy / export / share. The combined log is the
             // most-recent debug report + crash logs glued into one text
             // blob, generated by generateCombinedLog().
-            findPreference<Preference>("copy_log")?.setOnPreferenceClickListener {
-                confirmCopyCombinedLog()
-                true
-            }
-            findPreference<Preference>("export_log")?.setOnPreferenceClickListener {
-                confirmExportDiagnostics()
-                true
-            }
-            findPreference<Preference>("share_log")?.setOnPreferenceClickListener {
-                confirmShareCombinedLog()
-                true
-            }
 
             // Session Log Recorder controls — see preferences.xml for the
             // matching <Preference> entries. Status summary refreshes on
@@ -1024,7 +966,7 @@ class SettingsActivity : AppCompatActivity() {
 
         private fun copyCombinedLogToClipboard() {
             viewLifecycleOwner.lifecycleScope.launch {
-                Toast.makeText(requireContext(), "Generating combined log…", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.settings_generating_combined_log), Toast.LENGTH_SHORT).show()
                 val full = withContext(Dispatchers.IO) { generateCombinedLog() }
                 // Android's clipboard is bounded by IPC payload size; cap
                 // at ~512 KB and keep the tail (most recent entries are
@@ -1071,7 +1013,7 @@ class SettingsActivity : AppCompatActivity() {
          */
         private fun shareCombinedLog() {
             viewLifecycleOwner.lifecycleScope.launch {
-                Toast.makeText(requireContext(), "Generating combined log…", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), getString(R.string.settings_generating_combined_log), Toast.LENGTH_SHORT).show()
                 val ctx = requireContext()
                 val tempFile = withContext(Dispatchers.IO) {
                     runCatching {
@@ -1084,27 +1026,10 @@ class SettingsActivity : AppCompatActivity() {
                     }.getOrNull()
                 }
                 if (tempFile == null) {
-                    Toast.makeText(ctx, "Failed to prepare log for sharing", Toast.LENGTH_LONG).show()
+                    Toast.makeText(ctx, getString(R.string.settings_failed_prepare_share), Toast.LENGTH_LONG).show()
                     return@launch
                 }
-                val authority = ctx.packageName + ".fileprovider"
-                val uri = try {
-                    FileProvider.getUriForFile(ctx, authority, tempFile)
-                } catch (e: Exception) {
-                    Toast.makeText(ctx, "Cannot share log: ${e.message}", Toast.LENGTH_LONG).show()
-                    return@launch
-                }
-                val send = Intent(Intent.ACTION_SEND).apply {
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_STREAM, uri)
-                    putExtra(Intent.EXTRA_SUBJECT, "Linkpoint combined log: ${tempFile.name}")
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                }
-                try {
-                    startActivity(Intent.createChooser(send, "Share combined log"))
-                } catch (e: Exception) {
-                    Toast.makeText(ctx, "No share target available", Toast.LENGTH_SHORT).show()
-                }
+                logExportCoordinator.shareFile(tempFile, getString(R.string.settings_share_combined_log), "Linkpoint combined log: ${tempFile.name}")
             }
         }
 
@@ -1125,68 +1050,12 @@ class SettingsActivity : AppCompatActivity() {
          * Export combined log to a user-selected location in the file system
          */
         private fun exportLog() {
-            viewLifecycleOwner.lifecycleScope.launch {
-                Toast.makeText(requireContext(), "Generating combined log...", Toast.LENGTH_SHORT).show()
-
-                val logContent = withContext(Dispatchers.IO) {
-                    generateCombinedLog()
-                }
-
-                pendingLogContent = logContent
-                val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US).format(Date())
-                val defaultFilename = "linkpoint_diagnostics_$timestamp.txt"
-
-                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TITLE, defaultFilename)
-                }
-
-                try {
-                    createDocumentLauncher.launch(intent)
-                } catch (e: Exception) {
-                    pendingLogContent = null
-                    Toast.makeText(
-                        requireContext(),
-                        "Could not open file picker: ${e.message}",
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
-            }
+            val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US).format(Date())
+            val defaultFilename = "linkpoint_diagnostics_$timestamp.txt"
+            Toast.makeText(requireContext(), getString(R.string.settings_generating_combined_log), Toast.LENGTH_SHORT).show()
+            logExportCoordinator.exportText(defaultFilename) { generateCombinedLog() }
         }
-        
-        /**
-         * Write the log content to the selected URI
-         */
-        private fun writeLogToUri(uri: Uri) {
-            val content = pendingLogContent
-            if (content == null) {
-                Toast.makeText(requireContext(), "No log content to save", Toast.LENGTH_SHORT).show()
-                return
-            }
-            
-            viewLifecycleOwner.lifecycleScope.launch {
-                val success = withContext(Dispatchers.IO) {
-                    try {
-                        requireContext().contentResolver.openOutputStream(uri)?.use { outputStream ->
-                            outputStream.bufferedWriter().use { writer ->
-                                writer.write(content)
-                            }
-                        }
-                        true
-                    } catch (e: Exception) {
-                        android.util.Log.e("SettingsActivity", "Failed to write log file", e)
-                        false
-                    }
-                }
-                
-                if (success) {
-                    Toast.makeText(requireContext(), "Log exported successfully", Toast.LENGTH_SHORT).show()
-                } else {
-                    Toast.makeText(requireContext(), "Failed to export log", Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
+
         
         // ──────────────────────────────────────────────────────────────
         // Session Log Recorder controls
@@ -1316,22 +1185,7 @@ class SettingsActivity : AppCompatActivity() {
                         "Failed to read session log: ${e.message}"
                     }
                 }
-                pendingLogContent = content
-                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_TITLE, file.name)
-                }
-                try {
-                    createDocumentLauncher.launch(intent)
-                } catch (e: Exception) {
-                    pendingLogContent = null
-                    Toast.makeText(
-                        requireContext(),
-                        "Could not open file picker: ${e.message}",
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
+                logExportCoordinator.exportText(file.name) { content }
             }
         }
 
@@ -1347,24 +1201,7 @@ class SettingsActivity : AppCompatActivity() {
                 return
             }
             val ctx = requireContext()
-            val authority = ctx.packageName + ".fileprovider"
-            val uri = try {
-                FileProvider.getUriForFile(ctx, authority, file)
-            } catch (e: Exception) {
-                Toast.makeText(ctx, "Cannot share log: ${e.message}", Toast.LENGTH_LONG).show()
-                return
-            }
-            val send = Intent(Intent.ACTION_SEND).apply {
-                type = "text/plain"
-                putExtra(Intent.EXTRA_STREAM, uri)
-                putExtra(Intent.EXTRA_SUBJECT, "Linkpoint session log: ${file.name}")
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }
-            try {
-                startActivity(Intent.createChooser(send, "Share session log"))
-            } catch (e: Exception) {
-                Toast.makeText(ctx, "No share target available", Toast.LENGTH_SHORT).show()
-            }
+            logExportCoordinator.shareFile(file, getString(R.string.settings_share_session_log), "Linkpoint session log: ${file.name}")
         }
 
         private fun formatBytesCompat(bytes: Long): String = when {
@@ -1643,7 +1480,7 @@ class SettingsActivity : AppCompatActivity() {
          * Setup Display settings (screen orientation)
          */
         private fun setupDisplaySettings() {
-            findPreference<ListPreference>("screen_orientation")?.apply {
+            findPreference<ListPreference>(SettingsKeys.SCREEN_ORIENTATION)?.apply {
                 // Update summary to show current value - use first entry as fallback if available
                 summary = entry ?: entries?.takeIf { it.isNotEmpty() }?.get(0) ?: "Portrait"
                 setOnPreferenceChangeListener { preference, newValue ->

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsKeys.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsKeys.kt
@@ -1,0 +1,26 @@
+package com.linkpoint.ui.settings
+
+object SettingsKeys {
+    const val SCREEN_ORIENTATION = "screen_orientation"
+    const val SHOW_HUD = "show_hud"
+    const val SHOW_JOYSTICKS = "show_joysticks"
+    const val SHOW_ACTION_BUTTONS = "show_action_buttons"
+    const val SHOW_MOVEMENT_BUTTONS = "show_movement_buttons"
+    const val CUSTOMIZE_LAYOUT = "customize_layout"
+
+    const val GRAPHICS_QUALITY = "graphics_quality"
+    const val ENABLE_SECONDARY_RENDERER = "enable_secondary_renderer"
+
+    const val ENABLE_VOICE = "enable_voice"
+
+    const val BACKGROUND_RESUME_ENABLED = "background_resume_enabled"
+    const val PUSH_WAKEUPS_ENABLED = "push_wakeups_enabled"
+    const val BACKGROUND_INTENSITY_PROFILE = "background_intensity_profile"
+
+    const val ENABLE_DEBUG_FLOATER = "enable_debug_floater"
+    const val CODEX_AUTO_UPLOAD = "codex_auto_upload"
+    const val COPY_LOG = "copy_log"
+    const val EXPORT_LOG = "export_log"
+    const val SHARE_LOG = "share_log"
+    const val SESSION_LOG_EXPORT = "session_log_export"
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/BackgroundSettingsConfigurator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/BackgroundSettingsConfigurator.kt
@@ -1,0 +1,26 @@
+package com.linkpoint.ui.settings.config
+
+import android.content.Context
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+import com.linkpoint.service.BackgroundResumeScheduler
+import com.linkpoint.ui.settings.SettingsKeys
+
+class BackgroundSettingsConfigurator(
+    private val fragment: PreferenceFragmentCompat,
+    private val context: Context,
+) {
+    fun configure() {
+        fragment.findPreference<SwitchPreferenceCompat>(SettingsKeys.BACKGROUND_RESUME_ENABLED)?.setOnPreferenceChangeListener { _, newValue ->
+            if (newValue as Boolean) BackgroundResumeScheduler.schedule(context, immediate = true)
+            else BackgroundResumeScheduler.cancel(context)
+            true
+        }
+        fragment.findPreference<SwitchPreferenceCompat>(SettingsKeys.PUSH_WAKEUPS_ENABLED)?.setOnPreferenceChangeListener { _, _ -> true }
+        fragment.findPreference<ListPreference>(SettingsKeys.BACKGROUND_INTENSITY_PROFILE)?.setOnPreferenceChangeListener { _, _ ->
+            BackgroundResumeScheduler.schedule(context, immediate = false)
+            true
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/DebugSettingsConfigurator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/DebugSettingsConfigurator.kt
@@ -1,0 +1,33 @@
+package com.linkpoint.ui.settings.config
+
+import android.content.Context
+import android.widget.Toast
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+import com.linkpoint.R
+import com.linkpoint.ui.settings.SettingsKeys
+
+class DebugSettingsConfigurator(
+    private val fragment: PreferenceFragmentCompat,
+    private val context: Context,
+    private val onCopyLog: () -> Unit,
+    private val onExportLog: () -> Unit,
+    private val onShareLog: () -> Unit,
+) {
+    fun configure() {
+        fragment.findPreference<SwitchPreferenceCompat>(SettingsKeys.ENABLE_DEBUG_FLOATER)?.setOnPreferenceChangeListener { _, newValue ->
+            val msg = if (newValue as Boolean) R.string.settings_debug_floater_enabled else R.string.settings_debug_floater_disabled
+            Toast.makeText(context, context.getString(msg), Toast.LENGTH_SHORT).show()
+            true
+        }
+        fragment.findPreference<SwitchPreferenceCompat>(SettingsKeys.CODEX_AUTO_UPLOAD)?.setOnPreferenceChangeListener { _, newValue ->
+            val msg = if (newValue as Boolean) R.string.settings_codex_auto_upload_enabled else R.string.settings_codex_auto_upload_disabled
+            Toast.makeText(context, context.getString(msg), Toast.LENGTH_SHORT).show()
+            true
+        }
+        fragment.findPreference<Preference>(SettingsKeys.COPY_LOG)?.setOnPreferenceClickListener { onCopyLog(); true }
+        fragment.findPreference<Preference>(SettingsKeys.EXPORT_LOG)?.setOnPreferenceClickListener { onExportLog(); true }
+        fragment.findPreference<Preference>(SettingsKeys.SHARE_LOG)?.setOnPreferenceClickListener { onShareLog(); true }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/DisplaySettingsConfigurator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/DisplaySettingsConfigurator.kt
@@ -1,0 +1,26 @@
+package com.linkpoint.ui.settings.config
+
+import android.content.Context
+import android.widget.Toast
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceFragmentCompat
+import com.linkpoint.R
+import com.linkpoint.ui.settings.SettingsKeys
+
+class DisplaySettingsConfigurator(
+    private val fragment: PreferenceFragmentCompat,
+    private val context: Context,
+) {
+    fun configure() {
+        fragment.findPreference<ListPreference>(SettingsKeys.SCREEN_ORIENTATION)?.apply {
+            summary = entry ?: entries?.takeIf { it.isNotEmpty() }?.get(0) ?: "Portrait"
+            setOnPreferenceChangeListener { preference, newValue ->
+                val listPref = preference as ListPreference
+                val index = listPref.findIndexOfValue(newValue as String)
+                if (index >= 0) listPref.summary = listPref.entries[index]
+                Toast.makeText(context, context.getString(R.string.settings_orientation_apply_hint), Toast.LENGTH_SHORT).show()
+                true
+            }
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/GraphicsSettingsConfigurator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/settings/config/GraphicsSettingsConfigurator.kt
@@ -1,0 +1,28 @@
+package com.linkpoint.ui.settings.config
+
+import android.content.Context
+import android.widget.Toast
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+import com.linkpoint.R
+import com.linkpoint.ui.settings.SettingsKeys
+
+class GraphicsSettingsConfigurator(
+    private val fragment: PreferenceFragmentCompat,
+    private val context: Context,
+    private val onGraphicsQualityUpdated: (String) -> Unit,
+) {
+    fun configure() {
+        fragment.findPreference<ListPreference>(SettingsKeys.GRAPHICS_QUALITY)?.setOnPreferenceChangeListener { _, newValue ->
+            onGraphicsQualityUpdated(newValue as String)
+            true
+        }
+        fragment.findPreference<SwitchPreferenceCompat>(SettingsKeys.ENABLE_SECONDARY_RENDERER)?.setOnPreferenceChangeListener { _, newValue ->
+            val enabled = newValue as Boolean
+            val message = if (enabled) R.string.settings_secondary_renderer_enabled else R.string.settings_secondary_renderer_disabled
+            Toast.makeText(context, context.getString(message), Toast.LENGTH_LONG).show()
+            true
+        }
+    }
+}

--- a/Linkpoint/src/main/res/values/strings.xml
+++ b/Linkpoint/src/main/res/values/strings.xml
@@ -70,6 +70,24 @@
     <string name="flags">Flags</string>
     
     <!-- Settings -->
+    <string name="settings_orientation_apply_hint">Screen orientation will apply when you return to the world view</string>
+    <string name="settings_secondary_renderer_enabled">Secondary renderer enabled. Reopen world view to apply.</string>
+    <string name="settings_secondary_renderer_disabled">Primary renderer enabled. Reopen world view to apply.</string>
+    <string name="settings_debug_floater_enabled">Debug floater will appear in world view</string>
+    <string name="settings_debug_floater_disabled">Debug floater disabled</string>
+    <string name="settings_codex_auto_upload_enabled">Codex auto-upload enabled</string>
+    <string name="settings_codex_auto_upload_disabled">Codex auto-upload disabled</string>
+    <string name="settings_generating_combined_log">Generating combined log…</string>
+    <string name="settings_failed_prepare_share">Failed to prepare log for sharing</string>
+    <string name="settings_share_combined_log">Share combined log</string>
+    <string name="settings_share_session_log">Share session log</string>
+    <string name="settings_file_picker_failed">Could not open file picker: %1$s</string>
+    <string name="settings_no_log_content">No log content to save</string>
+    <string name="settings_log_export_success">Log exported successfully</string>
+    <string name="settings_log_export_failed">Failed to export log</string>
+    <string name="settings_cannot_share_log">Cannot share log: %1$s</string>
+    <string name="settings_no_share_target">No share target available</string>
+
     <string name="settings_graphics">Graphics</string>
     <string name="settings_audio">Audio</string>
     <string name="settings_network">Network</string>


### PR DESCRIPTION
### Motivation
- Reduce `SettingsFragment` responsibility by extracting preference setup into focused configurator classes and centralize preference keys to avoid string-key drift.
- Encapsulate SAF / export/share flow and `ActivityResult` state to simplify fragment lifecycle handling and reduce duplicated code.

### Description
- Introduced `com.linkpoint.ui.settings.config` with `DisplaySettingsConfigurator`, `GraphicsSettingsConfigurator`, `BackgroundSettingsConfigurator`, and `DebugSettingsConfigurator`, each accepting a `PreferenceFragmentCompat`, `Context`, and any callbacks/dependencies required for their domain.
- Added `SettingsKeys.kt` to centralize preference key constants and updated usages in `SettingsActivity.SettingsFragment` and configurators to reference `SettingsKeys` instead of raw string literals.
- Extracted combined/session log export and share plumbing into `LogExportCoordinator`, which owns the `ActivityResultLauncher`, pending text state, SAF document creation, and URI write logic, and added a small `SettingsShareHelper` to share files via `FileProvider`.
- Refactored `SettingsFragment.onCreatePreferences()` into a concise orchestration that initializes `LogExportCoordinator` and invokes the configurators in order, and moved new user-facing strings into `strings.xml` for the new flows.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` in-tree which failed because the `:app` project task could not be located in this Gradle setup (module name mismatch), so compilation was not completed.
- Ran `./gradlew projects` which failed configuration due to missing Android SDK location (`ANDROID_HOME` / `local.properties` `sdk.dir`) in this environment, so a full build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66e8a3ccc8323a8a12db394f6f7d4)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the `SettingsFragment` to reduce its responsibilities by extracting preference configuration logic into dedicated configurator classes (`DisplaySettingsConfigurator`, `GraphicsSettingsConfigurator`, `BackgroundSettingsConfigurator`, `DebugSettingsConfigurator`) and introducing a centralized `SettingsKeys` object for preference key constants. It also extracts the Storage Access Framework (SAF) export and share flows into a new `LogExportCoordinator` that manages `ActivityResultLauncher` lifecycle and document creation, eliminating duplicate code for exporting and sharing both combined diagnostic logs and session logs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsKeys.kt` |
| 2 | `Linkpoint/src/main/res/values/strings.xml` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/LogExportCoordinator.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/config/DisplaySettingsConfigurator.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/config/GraphicsSettingsConfigurator.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/config/BackgroundSettingsConfigurator.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/config/DebugSettingsConfigurator.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/ui/settings/SettingsActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->