### PR TITLE
Add MessageIdRegistry compatibility shims and Kotlin fixes for NetworkLogger/UDPConnectionFixed

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
@@ -328,14 +328,11 @@ object NetworkLogger {
     /**
      * Protocol statistics for HTTP/2 usage tracking
      */
-    typealias ProtocolStatistics = ProtocolUsageTracker.ProtocolStatistics
-    typealias RequestType = ProtocolUsageTracker.RequestType
-
     private val protocolUsageTracker = ProtocolUsageTracker()
 
-    fun getProtocolStatistics(): ProtocolStatistics = protocolUsageTracker.getProtocolStatistics()
+    fun getProtocolStatistics(): ProtocolUsageTracker.ProtocolStatistics = protocolUsageTracker.getProtocolStatistics()
 
-    fun trackProtocolUsageByType(type: RequestType, protocol: String) {
+    fun trackProtocolUsageByType(type: ProtocolUsageTracker.RequestType, protocol: String) {
         protocolUsageTracker.trackByType(type, protocol)
     }
     

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIdRegistry.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIdRegistry.kt
@@ -1,0 +1,3 @@
+package com.linkpoint.protocol.messages
+
+typealias MessageIdRegistry = com.linkpoint.protocol.messages.ids.MessageIdRegistry

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -112,7 +112,7 @@ import java.util.concurrent.atomic.AtomicLong
  */
 class UDPConnectionFixed(
     private val clock: () -> Long = { System.currentTimeMillis() },
-    private val eventEmitter: EventBus = EventBus.getInstance(),
+    private val eventEmitter: EventBus = EventBus,
     private val logger: (Int, String, String) -> Unit = { priority, tag, message -> Log.println(priority, tag, message) },
     private val transport: UdpDatagramTransport = UdpDatagramTransport(),
     private val reliabilitySupervisor: ReliabilitySupervisor = ReliabilitySupervisor(),

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/ids/MessageIdNameRegistry.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/ids/MessageIdNameRegistry.kt
@@ -1,0 +1,6 @@
+package com.linkpoint.protocol.messages.ids
+
+object MessageIdNameRegistry {
+    fun getMessageName(messageId: Int, messageNameMap: Map<Int, String>): String =
+        messageNameMap[messageId] ?: "Unknown($messageId)"
+}

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/ids/MessageTemplateCatalog.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/ids/MessageTemplateCatalog.kt
@@ -1,0 +1,7 @@
+package com.linkpoint.protocol.messages.ids
+
+object MessageTemplateCatalog {
+    val supportedParserOrWriterMessages: Set<Int> = emptySet()
+    val declaredOnlyMessagesWithRationale: Map<Int, String> = emptyMap()
+    val deprecatedMessagesWithRationale: Map<Int, String> = emptyMap()
+}


### PR DESCRIPTION
### Motivation
- A large set of Kotlin compilation failures were caused by unresolved references to `MessageIdRegistry` and related helper types, blocking downstream compilation of many files.
- Additional compiler issues arose from experimental nested typealias usage and an incorrect default `EventBus` wiring in `UDPConnectionFixed` that needed small, safe fixes to progress the build.

### Description
- Added `typealias MessageIdRegistry = com.linkpoint.protocol.messages.ids.MessageIdRegistry` in `com.linkpoint.protocol.messages` so existing call sites continue to resolve without editing thousands of references.
- Added minimal fallback implementations for `MessageIdNameRegistry` and `MessageTemplateCatalog` in `com.linkpoint.protocol.messages.ids` to satisfy symbol references used by the registry.
- Fixed `UDPConnectionFixed` default parameter to use the `EventBus` object directly instead of calling a nonexistent `getInstance()` method.
- Replaced nested `typealias` usage in `NetworkLogger` with direct references to `ProtocolUsageTracker.ProtocolStatistics` and `ProtocolUsageTracker.RequestType` to avoid experimental feature issues.

### Testing
- Ran `./gradlew :Linkpoint:compileStableDebugKotlin --console=plain`, which progressed past the large `MessageIdRegistry` unresolved-reference cluster but the task ultimately failed due to remaining unrelated Kotlin errors in `ProtocolDiagnostics`, `CacheSectionBuilder`, and a few `UDPConnectionFixed` sections.
- The changes compile locally up to the previously-blocking symbol errors and significantly reduce the unresolved-reference noise, enabling further follow-up fixes to complete the full Kotlin build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f686ffbc388323aeef18ca8140387e)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR resolves Kotlin compilation failures by adding compatibility shims for `MessageIdRegistry` and related types, fixing an incorrect `EventBus` default parameter in `UDPConnectionFixed`, and removing experimental nested typealias usage in `NetworkLogger`. The changes introduce a typealias to maintain backward compatibility with existing code references, add minimal fallback implementations for registry helper types, and replace nested typealiases with direct type references to avoid experimental feature warnings.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/ids/MessageIdNameRegistry.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/ids/MessageTemplateCatalog.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIdRegistry.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message registry and naming infrastructure to support message tracking and identification.

* **Refactor**
  * Reorganized protocol API types for improved code clarity and consistency.
  * Updated event handling initialization in UDP connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->