### PR TITLE
Replace placeholder onboarding and system destinations with functional Compose UIs

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt
@@ -1,66 +1,110 @@
 package com.linkpoint.ui.onboarding
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 data class OnboardingEntryScreenState(
     val title: String = "Onboarding",
-    val description: String = "Onboarding handoff destination placeholder."
+    val firstName: String = "",
+    val lastName: String = "",
+    val password: String = ""
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OnboardingEntryDestination(
     state: OnboardingEntryScreenState = OnboardingEntryScreenState(),
+    onFirstNameChanged: (String) -> Unit = {},
+    onLastNameChanged: (String) -> Unit = {},
+    onPasswordChanged: (String) -> Unit = {},
+    onContinue: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text(state.title) })
-        }
-    ) { innerPadding ->
-        Box(
+    Scaffold(topBar = { TopAppBar(title = { Text(state.title) }) }) { innerPadding ->
+        Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            contentAlignment = Alignment.Center
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(text = state.description)
+            OutlinedTextField(state.firstName, onFirstNameChanged, label = { Text("First name") }, modifier = Modifier.fillMaxWidth())
+            OutlinedTextField(state.lastName, onLastNameChanged, label = { Text("Last name") }, modifier = Modifier.fillMaxWidth())
+            OutlinedTextField(state.password, onPasswordChanged, label = { Text("Password") }, modifier = Modifier.fillMaxWidth())
+            Button(onClick = onContinue, enabled = state.firstName.isNotBlank() && state.password.isNotBlank(), modifier = Modifier.fillMaxWidth()) {
+                Text("Continue")
+            }
         }
     }
 }
 
 data class StartLocationScreenState(
     val title: String = "Start Location",
-    val description: String = "Start location selection destination placeholder."
+    val selectedLocation: String = "Home",
+    val availableLocations: List<String> = listOf("Home", "Last", "WelcomeHub")
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StartLocationDestination(
     state: StartLocationScreenState = StartLocationScreenState(),
+    onLocationSelected: (String) -> Unit = {},
+    onJoinWorld: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text(state.title) })
-        }
-    ) { innerPadding ->
-        Box(
+    var expanded by remember { mutableStateOf(false) }
+
+    Scaffold(topBar = { TopAppBar(title = { Text(state.title) }) }) { innerPadding ->
+        Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            contentAlignment = Alignment.Center
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(text = state.description)
+            ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+                OutlinedTextField(
+                    value = state.selectedLocation,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Spawn location") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                    state.availableLocations.forEach { location ->
+                        DropdownMenuItem(
+                            text = { Text(location) },
+                            onClick = {
+                                onLocationSelected(location)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+            Button(onClick = onJoinWorld, modifier = Modifier.fillMaxWidth()) {
+                Text("Join world")
+            }
         }
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt
@@ -1,77 +1,154 @@
 package com.linkpoint.ui.system
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 data class SettingsScreenState(
     val title: String = "Settings",
-    val description: String = "Settings destination placeholder."
+    val avatarName: String = "",
+    val pushNotificationsEnabled: Boolean = true,
+    val autoAcceptTeleportEnabled: Boolean = false,
+    val cameraDistanceMeters: String = "4.0"
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsDestination(
     state: SettingsScreenState = SettingsScreenState(),
+    onAvatarNameChanged: (String) -> Unit = {},
+    onPushNotificationsChanged: (Boolean) -> Unit = {},
+    onAutoAcceptTeleportChanged: (Boolean) -> Unit = {},
+    onCameraDistanceChanged: (String) -> Unit = {},
+    onSave: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    DestinationScaffold(state.title, state.description, modifier)
+    Scaffold(topBar = { TopAppBar(title = { Text(state.title) }) }) { innerPadding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedTextField(
+                value = state.avatarName,
+                onValueChange = onAvatarNameChanged,
+                label = { Text("Avatar display name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = state.cameraDistanceMeters,
+                onValueChange = onCameraDistanceChanged,
+                label = { Text("Camera distance (m)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            SettingToggleRow("Push notifications", state.pushNotificationsEnabled, onPushNotificationsChanged)
+            SettingToggleRow("Auto-accept teleports", state.autoAcceptTeleportEnabled, onAutoAcceptTeleportChanged)
+            Button(onClick = onSave, modifier = Modifier.align(Alignment.End)) { Text("Save") }
+        }
+    }
 }
 
 data class TosScreenState(
     val title: String = "Terms of Service",
-    val description: String = "Terms of service destination placeholder."
+    val termsVersion: String = "2026.05",
+    val accepted: Boolean = false
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TosDestination(
     state: TosScreenState = TosScreenState(),
+    onAcceptedChanged: (Boolean) -> Unit = {},
+    onContinue: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    DestinationScaffold(state.title, state.description, modifier)
+    Scaffold(topBar = { TopAppBar(title = { Text(state.title) }) }) { innerPadding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("Version ${state.termsVersion}")
+            Text("By continuing, you agree to the virtual world code of conduct, privacy policy, and moderation rules.")
+            SettingToggleRow("I agree", state.accepted, onAcceptedChanged)
+            Button(onClick = onContinue, enabled = state.accepted, modifier = Modifier.align(Alignment.End)) {
+                Text("Continue")
+            }
+        }
+    }
 }
 
 data class ThemePickerScreenState(
     val title: String = "Theme Picker",
-    val description: String = "Theme picker destination placeholder."
+    val selectedTheme: ThemeOption = ThemeOption.SYSTEM
 )
+
+enum class ThemeOption(val label: String) {
+    SYSTEM("System"),
+    LIGHT("Light"),
+    DARK("Dark")
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ThemePickerDestination(
     state: ThemePickerScreenState = ThemePickerScreenState(),
+    onThemeSelected: (ThemeOption) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    DestinationScaffold(state.title, state.description, modifier)
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DestinationScaffold(
-    title: String,
-    description: String,
-    modifier: Modifier = Modifier
-) {
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text(title) })
-        }
-    ) { innerPadding ->
-        Box(
+    Scaffold(topBar = { TopAppBar(title = { Text(state.title) }) }) { innerPadding ->
+        Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            contentAlignment = Alignment.Center
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Text(text = description)
+            Text("Choose app theme")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ThemeOption.entries.forEach { option ->
+                    FilterChip(
+                        selected = state.selectedTheme == option,
+                        onClick = { onThemeSelected(option) },
+                        label = { Text(option.label) }
+                    )
+                }
+            }
         }
+    }
+}
+
+@Composable
+private fun SettingToggleRow(
+    label: String,
+    enabled: Boolean,
+    onChanged: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(label)
+        Switch(checked = enabled, onCheckedChange = onChanged)
     }
 }


### PR DESCRIPTION
### Motivation
- Remove placeholder/demo UI code and provide interactive, state-driven Compose destinations that can be wired to app viewmodels and navigation.
- Make onboarding and system flows usable for real input, selection, and acceptance workflows instead of static text placeholders.

### Description
- Replaced placeholder system screens in `Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt` with functional implementations: `SettingsDestination` (editable fields, toggles, `onSave` callback), `TosDestination` (version display, acceptance toggle, gated continue action), and `ThemePickerDestination` (new `ThemeOption` enum and selectable chips via `onThemeSelected`).
- Added a `SettingToggleRow` composable helper and replaced `DestinationScaffold` usage with explicit `Scaffold`/`Column` layouts and spacing for real input controls.
- Replaced placeholder onboarding screens in `Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt` with `OnboardingEntryDestination` (captures `firstName`, `lastName`, `password` with `onContinue` gating) and `StartLocationDestination` (dropdown selection using `ExposedDropdownMenuBox` with `onLocationSelected` and `onJoinWorld` callbacks).
- Minor imports and layout polishing (padding, spacing, `OutlinedTextField`, `FilterChip`, etc.) to support the new interactive controls.

### Testing
- Attempted an automated Kotlin compilation with `./gradlew :Linkpoint:compileDebugKotlin --no-daemon`; the task failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir` not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70de60f908323ac8ca6f9a30d87b8)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR transforms static placeholder screens into interactive Compose UI destinations for onboarding and system flows. The changes replace simple text placeholders with functional forms that include editable text fields, dropdown menus, toggles, and buttons with proper state management and callbacks. Specifically, the onboarding flow now captures user input (name, password) and location selection, while the system screens provide settings configuration (avatar name, notifications, camera distance), terms of service acceptance gating, and theme selection via filter chips. A reusable `SettingToggleRow` helper component was introduced, and the deprecated `DestinationScaffold` wrapper was removed in favor of explicit `Scaffold`/`Column` layouts.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/ui/system/SystemDestinations.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/onboarding/OnboardingDestinations.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding form now includes fields for first name, last name, and password with a continue button.
  * Location selection screen with dropdown menu and join world button.
  * Settings screen with options for avatar name, push notifications toggle, auto-accept teleport toggle, and camera distance adjustment.
  * Terms of Service screen with acceptance checkbox and version display.
  * Theme picker with System, Light, and Dark theme options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->