### PR TITLE
Android graphics drivers: Singularity-alignment passes + capability gates

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/textures/TextureEntryParser.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/textures/TextureEntryParser.kt
@@ -83,7 +83,14 @@ object TextureEntryParser {
         val offsetS: Float,
         val offsetT: Float,
         val rotation: Float,
-        val materialsId: UUID
+        val materialsId: UUID,
+        /**
+         * SL "glow" (emissive intensity) in the range 0..1. Encoded
+         * on the wire as one U8 per face (LL viewer
+         * `LLTextureEntry::setGlow`). Producers feed this into the
+         * emissive double-pass; 0 means the face is excluded.
+         */
+        val glow: Float = 0f
     )
 
     /**
@@ -139,11 +146,14 @@ object TextureEntryParser {
             applyOverrides(buffer, faces, ::readQuantS16) { f, v -> f.copy(offsetT = v) }
             // 5. Rotation (S16 quantised to ~-2π..2π)
             applyOverrides(buffer, faces, ::readQuantRot) { f, v -> f.copy(rotation = v) }
-            // 6. Skip bumpmap / mediaflags / glow (U8 each, with face overrides).
+            // 6. Skip bumpmap / mediaflags (U8 each, with face overrides).
             skipU8Overrides(buffer)
             skipU8Overrides(buffer)
-            skipU8Overrides(buffer)
-            // 7. MaterialsID (UUID, optional)
+            // 7. Glow (U8 per face, normalised to 0..1). Drives the
+            //    emissive double-pass. LL viewer encodes / decodes it
+            //    via LLTextureEntry::setGlow / packGlow at /255.
+            applyOverrides(buffer, faces, ::readGlowU8) { f, v -> f.copy(glow = v) }
+            // 8. MaterialsID (UUID, optional)
             if (buffer.remaining() >= 16) {
                 applyOverrides(buffer, faces, ::readUUID) { f, v -> f.copy(materialsId = v) }
             }
@@ -200,6 +210,10 @@ object TextureEntryParser {
         val b = ((buffer.get().toInt() and 0xFF) xor 0xFF) / 255f
         val a = ((buffer.get().toInt() and 0xFF) xor 0xFF) / 255f
         return floatArrayOf(r, g, b, a)
+    }
+
+    private fun readGlowU8(buffer: ByteBuffer): Float {
+        return (buffer.get().toInt() and 0xFF) / 255f
     }
 
     private fun readQuantS16(buffer: ByteBuffer): Float {

--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt
@@ -310,6 +310,22 @@ object RenderDiagnostics {
         )
     }
 
+    /**
+     * Driver-capability summary, emitted once after [glContextInfo].
+     * Captures the pre-context probe profile (Vulkan presence,
+     * OpenGL ES requested version, vendor family) alongside the
+     * post-context capability snapshot and resolved feature flags
+     * so a session log alone can answer "which optional passes did
+     * the renderer actually run on this device?".
+     */
+    fun glDriverCapabilities(profileSummary: String, capsSummary: String, featureFlags: String) {
+        SessionLogRecorder.logRender(
+            "Lumiya",
+            "driver_caps",
+            "profile=[$profileSummary] caps=[$capsSummary] flags=[$featureFlags]"
+        )
+    }
+
     fun glInitDone(durationMs: Long) {
         SessionLogRecorder.logRender("Lumiya", "init_done", "durationMs=$durationMs")
     }

--- a/Linkpoint/src/main/java/com/linkpoint/render/driver/GpuCapabilities.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/driver/GpuCapabilities.kt
@@ -1,0 +1,206 @@
+package com.linkpoint.render.driver
+
+/**
+ * Post-context GPU capability snapshot. Built once by
+ * [LumiyaRenderContext.queryGPUCapabilities] after a GL context
+ * exists, then read freely by feature gates around the renderer.
+ *
+ * Splitting this from the pre-context [GraphicsDriverProbe.DriverProfile]
+ * matters because some features can only be detected after the
+ * driver loads (extension list, max sample count). The two pieces
+ * are joined in [resolveFeatureFlags] which produces a single
+ * [FeatureFlags] decision used by every subsystem.
+ *
+ * @property glVersion 30 / 31 / 32 — the highest GLES version the
+ *           driver actually negotiates. May be lower than
+ *           [GraphicsDriverProbe.DriverProfile.glesMajorVersion]
+ *           when an emulator or a buggy driver downgrades.
+ * @property vendor [GraphicsDriverProbe.VendorFamily] inferred from
+ *           GL_VENDOR / GL_RENDERER (refined past the pre-context
+ *           Build.HARDWARE guess once we have GL strings).
+ * @property extensions Set of GL extension strings the driver
+ *           reports. Pre-tokenised into a HashSet so feature checks
+ *           are O(1).
+ * @property maxTextureSize / [maxRenderbufferSize] / [maxSamples]
+ *           Driver-side hard limits. Producers should clamp their
+ *           own targets to these or risk a context-loss-on-bind.
+ */
+data class GpuCapabilities(
+    val glVersion: Int,
+    val vendor: GraphicsDriverProbe.VendorFamily,
+    val rendererString: String,
+    val vendorString: String,
+    val versionString: String,
+    val extensions: Set<String>,
+    val maxTextureSize: Int,
+    val maxRenderbufferSize: Int,
+    val maxSamples: Int,
+    val maxUniformBlockSize: Int,
+    val maxAnisotropy: Float
+) {
+    fun hasExtension(name: String): Boolean = name in extensions
+
+    /** Concise log line — vendor, version, key extension flags. */
+    fun summary(): String = buildString {
+        append("GL ES $glVersion ($vendorString / $rendererString)")
+        append(" maxTex=$maxTextureSize")
+        if (maxSamples > 1) append(" msaa=$maxSamples")
+        if (maxAnisotropy > 1f) append(" aniso=$maxAnisotropy")
+    }
+
+    companion object {
+        /** Empty caps used during early init / unit tests. */
+        val EMPTY = GpuCapabilities(
+            glVersion = 0,
+            vendor = GraphicsDriverProbe.VendorFamily.UNKNOWN,
+            rendererString = "",
+            vendorString = "",
+            versionString = "",
+            extensions = emptySet(),
+            maxTextureSize = 0,
+            maxRenderbufferSize = 0,
+            maxSamples = 0,
+            maxUniformBlockSize = 0,
+            maxAnisotropy = 1f
+        )
+    }
+}
+
+/**
+ * Per-feature on/off decision, derived from the pre-context driver
+ * probe + the post-context GPU caps. One source of truth for every
+ * feature gate so the renderer can't ship a feature that contradicts
+ * what the driver advertises.
+ *
+ * Design note: each flag corresponds to exactly one optional code
+ * path. Producers that consult these flags should treat `false` as
+ * "skip this code entirely", not "fall back to a slower variant" —
+ * fallbacks live inside the producer and the flag only decides
+ * whether to even attempt.
+ */
+data class FeatureFlags(
+    /**
+     * Persistent-mapped UBO via GL_EXT_buffer_storage. Saves per-frame
+     * glBufferSubData on Adreno/Mali drivers that implement it. Off
+     * if the extension isn't there, off on PowerVR which historically
+     * mishandles persistent maps.
+     */
+    val persistentMappedUBO: Boolean,
+    /**
+     * Hardware occlusion queries via
+     * GL_ANY_SAMPLES_PASSED_CONSERVATIVE. Requires GL ES 3.0+; gated
+     * off on devices that don't reach it. Even when supported,
+     * [com.linkpoint.render.lumiya.spatial.OcclusionQuerySet] is off
+     * by default (see its docstring) — this flag just unblocks the
+     * runtime toggle.
+     */
+    val occlusionQueries: Boolean,
+    /**
+     * FXAA off-screen pass. Needs FBOs (GLES 3.0+) and at least 4MB of
+     * extra color/depth RAM. We also disable on devices with very
+     * small max texture sizes since the resolve sampler would
+     * otherwise sample outside the framebuffer.
+     */
+    val fxaa: Boolean,
+    /**
+     * Planar water reflection / refraction (mWaterRef / mWaterDis).
+     * Requires FBOs + a fragment shader version of the water
+     * sampler. Off by default and only enabled when explicitly
+     * requested by the user — but this flag is the floor that even
+     * the user request can't override.
+     */
+    val waterPlanarReflections: Boolean,
+    /** Anisotropic filtering via GL_EXT_texture_filter_anisotropic. */
+    val anisotropicFiltering: Boolean,
+    /** Compute shaders (GLES 3.1+). Used by future GPU skinning paths. */
+    val computeShaders: Boolean,
+    /**
+     * Vulkan present and at hardware level ≥ 1. Read by future
+     * Vulkan-backed renderer; the GLES path ignores this. Producers
+     * that want to *prefer* Vulkan should also check that the device
+     * meets a deqp date threshold.
+     */
+    val vulkanReady: Boolean,
+    /**
+     * Tile-based renderer hint. True for Adreno / Mali / PowerVR;
+     * false for desktop-style architectures. Used by passes that
+     * benefit from invalidate-after-resolve (FXAA) or want to avoid
+     * mid-pass framebuffer reads.
+     */
+    val tileBasedRenderer: Boolean
+) {
+    companion object {
+        /** Worst-case flags — every optional feature off. */
+        val ALL_OFF = FeatureFlags(
+            persistentMappedUBO = false,
+            occlusionQueries = false,
+            fxaa = false,
+            waterPlanarReflections = false,
+            anisotropicFiltering = false,
+            computeShaders = false,
+            vulkanReady = false,
+            tileBasedRenderer = false
+        )
+    }
+}
+
+/**
+ * Combine a pre-context driver profile with a post-context GPU caps
+ * snapshot to decide which optional features the renderer should
+ * enable. Pure function; trivially testable.
+ *
+ * Conservative defaults: when in doubt, off. The renderer should
+ * *never* die because a feature gate said "on" on a driver that
+ * couldn't deliver — better to ship a featureless frame than no
+ * frame at all.
+ */
+fun resolveFeatureFlags(
+    profile: GraphicsDriverProbe.DriverProfile,
+    caps: GpuCapabilities
+): FeatureFlags {
+    val gles = caps.glVersion
+    val tbr = caps.vendor in setOf(
+        GraphicsDriverProbe.VendorFamily.ADRENO,
+        GraphicsDriverProbe.VendorFamily.MALI,
+        GraphicsDriverProbe.VendorFamily.POWERVR,
+        GraphicsDriverProbe.VendorFamily.XCLIPSE
+    )
+
+    // PowerVR mishandled GL_EXT_buffer_storage on shipped drivers
+    // through ~2022 (lost writes after a context-loss restore).
+    // Disable until we have a known-good allow-list.
+    val persistent = caps.hasExtension("GL_EXT_buffer_storage") &&
+        caps.vendor != GraphicsDriverProbe.VendorFamily.POWERVR
+
+    val occlusion = gles >= 30
+
+    val fxaa = gles >= 30 && caps.maxTextureSize >= 1024
+
+    // Reflections need a second world pass + extra FBOs. Require
+    // GLES 3.1 since the shader fetches gl_FragCoord-derived UV
+    // perturbation that misbehaves on some 3.0 drivers, and require
+    // a max texture size large enough for a half-res 1080p target.
+    val reflections = gles >= 31 &&
+        caps.maxTextureSize >= 2048 &&
+        caps.maxRenderbufferSize >= 2048
+
+    val aniso = caps.hasExtension("GL_EXT_texture_filter_anisotropic") &&
+        caps.maxAnisotropy > 1f
+
+    val compute = gles >= 31
+
+    // Vulkan-readiness is purely about whether a future Vulkan
+    // backend would have a chance. Ignore by GLES backend.
+    val vk = profile.hasVulkan && profile.vulkanHardwareLevel >= 1
+
+    return FeatureFlags(
+        persistentMappedUBO = persistent,
+        occlusionQueries = occlusion,
+        fxaa = fxaa,
+        waterPlanarReflections = reflections,
+        anisotropicFiltering = aniso,
+        computeShaders = compute,
+        vulkanReady = vk,
+        tileBasedRenderer = tbr
+    )
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/driver/GraphicsDriverProbe.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/driver/GraphicsDriverProbe.kt
@@ -1,0 +1,228 @@
+package com.linkpoint.render.driver
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+
+/**
+ * Pre-context graphics-driver probe. Runs on the main thread *before*
+ * any GL context is created, so the renderer can decide whether the
+ * device is even capable of running the Lumiya pipeline before
+ * burning surface state on a doomed initialisation.
+ *
+ * Sources of information (all available without a GL context):
+ *  - [PackageManager.hasSystemFeature] for Vulkan + OpenGL ES feature
+ *    flags declared by the device manufacturer.
+ *  - [ActivityManager.getDeviceConfigurationInfo] for the maximum GL
+ *    ES version the device can negotiate.
+ *  - [Build.HARDWARE] / [Build.MANUFACTURER] for vendor-family hints
+ *    used by [GpuCapabilities] heuristics later on.
+ *
+ * The probe is deliberately conservative — it never claims a feature
+ * is present unless the platform reports it. Producers can override
+ * (e.g. force-disable Vulkan) by passing custom flags into
+ * [DriverProfile.from], but the default path is "what the device tells
+ * us" and the renderer respects that.
+ */
+object GraphicsDriverProbe {
+
+    private const val TAG = "GraphicsDriverProbe"
+
+    /**
+     * Android system features used by the probe. Constants live here
+     * so tests can inject a fake [PackageManager] without depending
+     * on Android-runtime constants that aren't available under the
+     * JVM unit test classpath.
+     */
+    private const val FEATURE_VULKAN_HARDWARE_LEVEL = "android.hardware.vulkan.level"
+    private const val FEATURE_VULKAN_HARDWARE_VERSION = "android.hardware.vulkan.version"
+    private const val FEATURE_VULKAN_DEQP_LEVEL = "android.software.vulkan.deqp.level"
+    private const val FEATURE_OPENGLES_EXTENSION_PACK = "android.hardware.opengles.aep"
+
+    /**
+     * Snapshot of pre-context driver state. Immutable so it can be
+     * passed across threads.
+     *
+     * @property glesMajorVersion / [glesMinorVersion] from
+     *           [ActivityManager.getDeviceConfigurationInfo]'s reqGlEsVersion.
+     *           Format on the wire is 0xMMMMmmmm (M=major, m=minor); we
+     *           split it into two ints so callers can use them
+     *           directly. Values of 0 mean the device didn't advertise
+     *           a version (very old devices, or test mocks).
+     * @property vulkanHardwareLevel Vulkan hardware feature level (0,
+     *           1, …) or -1 if not advertised. -1 means the device has
+     *           no Vulkan driver at all; 0 means "Vulkan exists but
+     *           with restrictions" (no compute on graphics queue,
+     *           etc.); ≥1 means a reasonably full driver. From the
+     *           Android Vulkan compat doc.
+     * @property vulkanHardwareVersion Vulkan API version exposed by
+     *           the driver. Encoded the same way Vulkan itself does:
+     *           0xVVVRRRPPP_PPPP where V/R/P are major/minor/patch.
+     *           Matches the system-feature value. -1 if absent.
+     * @property vulkanDeqpLevel Date-encoded dEQP conformance level
+     *           (e.g. 132317184 = 2019-03-01). -1 if absent. Useful
+     *           for deciding whether the driver can be trusted with
+     *           features that historically had vendor bugs (e.g.
+     *           timestamp queries).
+     * @property hasOpenGlesAep True if the device advertises
+     *           "android.hardware.opengles.aep" — the Android
+     *           Extension Pack on top of GLES 3.1 that brings in
+     *           tessellation, geometry shaders, and ASTC.
+     * @property hardwareName / manufacturer Lower-cased
+     *           [Build.HARDWARE] / [Build.MANUFACTURER]; used by
+     *           [vendorFamily] to pick a known-bad-driver workaround.
+     */
+    data class DriverProfile(
+        val glesMajorVersion: Int,
+        val glesMinorVersion: Int,
+        val vulkanHardwareLevel: Int,
+        val vulkanHardwareVersion: Int,
+        val vulkanDeqpLevel: Int,
+        val hasOpenGlesAep: Boolean,
+        val hardwareName: String,
+        val manufacturer: String
+    ) {
+        /** True if the device exposes any Vulkan driver at all. */
+        val hasVulkan: Boolean
+            get() = vulkanHardwareLevel >= 0
+
+        /** True if the device meets our minimum requirement (GL ES 3.0). */
+        val meetsMinimumGles: Boolean
+            get() = glesMajorVersion > 3 ||
+                (glesMajorVersion == 3 && glesMinorVersion >= 0)
+
+        /**
+         * Vendor family inferred from the hardware/manufacturer
+         * strings. Used to pick known-bug workarounds. Not a
+         * judgement of quality — every family ships excellent and
+         * buggy drivers.
+         */
+        val vendorFamily: VendorFamily
+            get() {
+                val hay = "$hardwareName $manufacturer"
+                return when {
+                    hay.contains("qualcomm") || hay.contains("adreno") || hay.contains("snapdragon") -> VendorFamily.ADRENO
+                    hay.contains("mali") || hay.contains("arm") -> VendorFamily.MALI
+                    hay.contains("powervr") || hay.contains("imagination") -> VendorFamily.POWERVR
+                    hay.contains("tegra") || hay.contains("nvidia") -> VendorFamily.TEGRA
+                    hay.contains("intel") -> VendorFamily.INTEL
+                    hay.contains("samsung") || hay.contains("xclipse") -> VendorFamily.XCLIPSE
+                    else -> VendorFamily.UNKNOWN
+                }
+            }
+
+        /** Compact human-readable summary for logs / RenderDiagnostics. */
+        fun summary(): String = buildString {
+            append("GLES $glesMajorVersion.$glesMinorVersion")
+            if (hasOpenGlesAep) append(" (AEP)")
+            if (hasVulkan) {
+                append(", Vulkan L$vulkanHardwareLevel v$vulkanHardwareVersion")
+                if (vulkanDeqpLevel > 0) append(" deqp=$vulkanDeqpLevel")
+            } else {
+                append(", no Vulkan")
+            }
+            append(", vendor=$vendorFamily")
+        }
+
+        companion object {
+            /** Empty profile — used when we have no PackageManager (tests). */
+            val UNKNOWN = DriverProfile(
+                glesMajorVersion = 0,
+                glesMinorVersion = 0,
+                vulkanHardwareLevel = -1,
+                vulkanHardwareVersion = -1,
+                vulkanDeqpLevel = -1,
+                hasOpenGlesAep = false,
+                hardwareName = "",
+                manufacturer = ""
+            )
+
+            /**
+             * Construct a profile from raw values. Exposed for tests
+             * so capability decisions can be exercised without
+             * mocking [Context]. Production code should use
+             * [GraphicsDriverProbe.probe].
+             */
+            fun from(
+                glesMajor: Int,
+                glesMinor: Int,
+                vulkanLevel: Int = -1,
+                vulkanVersion: Int = -1,
+                vulkanDeqp: Int = -1,
+                aep: Boolean = false,
+                hardware: String = "",
+                manufacturer: String = ""
+            ): DriverProfile = DriverProfile(
+                glesMajor, glesMinor,
+                vulkanLevel, vulkanVersion, vulkanDeqp,
+                aep,
+                hardware.lowercase(),
+                manufacturer.lowercase()
+            )
+        }
+    }
+
+    enum class VendorFamily { ADRENO, MALI, POWERVR, TEGRA, INTEL, XCLIPSE, UNKNOWN }
+
+    /**
+     * Probe the device. Safe to call from any thread; returns
+     * [DriverProfile.UNKNOWN] on any failure rather than throwing,
+     * so a misconfigured app context never breaks renderer init.
+     */
+    fun probe(context: Context): DriverProfile = try {
+        val pm = context.packageManager
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val configInfo = am?.deviceConfigurationInfo
+        val reqGles = configInfo?.reqGlEsVersion ?: 0
+        val major = (reqGles ushr 16) and 0xFFFF
+        val minor = reqGles and 0xFFFF
+
+        val vulkanLevel = featureLevel(pm, FEATURE_VULKAN_HARDWARE_LEVEL)
+        val vulkanVersion = featureLevel(pm, FEATURE_VULKAN_HARDWARE_VERSION)
+        val vulkanDeqp = featureLevel(pm, FEATURE_VULKAN_DEQP_LEVEL)
+        val hasAep = pm.hasSystemFeature(FEATURE_OPENGLES_EXTENSION_PACK)
+
+        DriverProfile(
+            glesMajorVersion = major,
+            glesMinorVersion = minor,
+            vulkanHardwareLevel = vulkanLevel,
+            vulkanHardwareVersion = vulkanVersion,
+            vulkanDeqpLevel = vulkanDeqp,
+            hasOpenGlesAep = hasAep,
+            hardwareName = (Build.HARDWARE ?: "").lowercase(),
+            manufacturer = (Build.MANUFACTURER ?: "").lowercase()
+        ).also {
+            Log.i(TAG, "Driver probe: ${it.summary()}")
+        }
+    } catch (t: Throwable) {
+        Log.w(TAG, "Driver probe failed; using UNKNOWN profile", t)
+        DriverProfile.UNKNOWN
+    }
+
+    /**
+     * Read a versioned system feature. The Android API is awkward:
+     * when a feature has a "version" int (Vulkan does), it's a
+     * separate FeatureInfo entry rather than a getSystemFeature
+     * return value. We walk [PackageManager.getSystemAvailableFeatures]
+     * once and pick out what we need.
+     *
+     * Returns -1 if the feature isn't present.
+     */
+    private fun featureLevel(pm: PackageManager, name: String): Int {
+        return try {
+            val features = pm.systemAvailableFeatures ?: return -1
+            for (fi in features) {
+                if (fi.name == name) return fi.version
+            }
+            // Some features (e.g. dEQP level) are exposed via
+            // hasSystemFeature only; fall back so we can at least
+            // tell "present / not present".
+            if (pm.hasSystemFeature(name)) 0 else -1
+        } catch (t: Throwable) {
+            Log.v(TAG, "featureLevel($name) lookup failed: ${t.message}")
+            -1
+        }
+    }
+}

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt
@@ -5,6 +5,14 @@ enum class LumiyaRenderPass {
     WORLD_AVATAR,
     WORLD_SKY,
     WORLD_TRANSPARENT,
+    /**
+     * Glow / emissive double-pass. Re-draws faces with a non-zero
+     * SL "glow" value using additive blending so they brighten the
+     * already-composited colour. Skipped during interactive throttle
+     * — the popping under a fling is more distracting than the
+     * absent glow.
+     */
+    WORLD_EMISSIVE,
     WORLD_WATER,
     WORLD_PARTICLES,
     HUD
@@ -29,6 +37,7 @@ object LumiyaFramePlanner {
             passes += LumiyaRenderPass.WORLD_AVATAR
             passes += LumiyaRenderPass.WORLD_SKY
             passes += LumiyaRenderPass.WORLD_TRANSPARENT
+            if (!interactiveThrottle) passes += LumiyaRenderPass.WORLD_EMISSIVE
             passes += LumiyaRenderPass.WORLD_WATER
             if (!interactiveThrottle) passes += LumiyaRenderPass.WORLD_PARTICLES
         }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
@@ -4,6 +4,10 @@ import android.opengl.GLES32
 import android.opengl.Matrix
 import android.util.Log
 import com.linkpoint.render.RenderDiagnostics
+import com.linkpoint.render.driver.FeatureFlags
+import com.linkpoint.render.driver.GpuCapabilities
+import com.linkpoint.render.driver.GraphicsDriverProbe
+import com.linkpoint.render.driver.resolveFeatureFlags
 import com.linkpoint.render.lumiya.shaders.*
 import com.linkpoint.render.lumiya.glres.GLResourceManager
 import com.linkpoint.render.lumiya.glres.GLTextureCache
@@ -57,6 +61,32 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
     var maxTextureSize: Int = 2048
         private set
     var maxUniformBlockSize: Int = 16384
+        private set
+
+    /**
+     * Pre-context driver profile injected by the renderer at boot.
+     * Defaults to [GraphicsDriverProbe.DriverProfile.UNKNOWN] so the
+     * context degrades gracefully when the renderer hasn't probed
+     * the device yet (e.g. in unit tests). The renderer overrides
+     * this in [LumiyaRenderer.initialize] before [initialize] runs.
+     */
+    var driverProfile: GraphicsDriverProbe.DriverProfile =
+        GraphicsDriverProbe.DriverProfile.UNKNOWN
+
+    /**
+     * Post-context GPU capability snapshot, populated during
+     * [queryGPUCapabilities]. Read by feature gates around the
+     * renderer; never null after [initialize] returns true.
+     */
+    var gpuCapabilities: GpuCapabilities = GpuCapabilities.EMPTY
+        private set
+
+    /**
+     * Resolved feature flags derived from [driverProfile] +
+     * [gpuCapabilities]. Single source of truth for "should we run
+     * the X pass on this device?" decisions.
+     */
+    var featureFlags: FeatureFlags = FeatureFlags.ALL_OFF
         private set
 
     // ── Shader programs ──────────────────────────────────────────────────
@@ -209,7 +239,72 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
         GLES32.glGetIntegerv(GLES32.GL_MAX_UNIFORM_BLOCK_SIZE, buf, 0)
         maxUniformBlockSize = buf[0]
         supportsComputeShaders = glVersion >= 31
-        Log.i(TAG, "GPU: $gpuVendor $gpuRenderer  GL ES $glVersion  maxTex=$maxTextureSize")
+
+        // Build the structured capability snapshot. We collect
+        // extra per-driver hard limits and parse the extension list
+        // once so feature gates downstream are O(1) lookups.
+        val extensionsString = GLES32.glGetString(GLES32.GL_EXTENSIONS).orEmpty()
+        val extensionSet: Set<String> = if (extensionsString.isNotEmpty()) {
+            extensionsString.split(' ').filter { it.isNotEmpty() }.toHashSet()
+        } else {
+            emptySet()
+        }
+
+        val rbBuf = IntArray(1)
+        GLES32.glGetIntegerv(GLES32.GL_MAX_RENDERBUFFER_SIZE, rbBuf, 0)
+        val msaaBuf = IntArray(1)
+        // GL_MAX_SAMPLES is core in GLES 3.0+. Returns 0 on weird
+        // emulators; downstream callers must coerce >= 1.
+        GLES32.glGetIntegerv(GLES32.GL_MAX_SAMPLES, msaaBuf, 0)
+
+        // Anisotropy is gated behind GL_EXT_texture_filter_anisotropic.
+        // Token value is fixed across drivers (0x84FF). Avoid pulling
+        // an EGL header import for a single int.
+        val maxAniso = if ("GL_EXT_texture_filter_anisotropic" in extensionSet) {
+            val anisoBuf = FloatArray(1)
+            try {
+                GLES32.glGetFloatv(0x84FF, anisoBuf, 0)
+                if (anisoBuf[0] > 1f) anisoBuf[0] else 1f
+            } catch (_: Throwable) { 1f }
+        } else 1f
+
+        val vendor = inferVendorFamily(gpuVendor, gpuRenderer)
+        gpuCapabilities = GpuCapabilities(
+            glVersion = glVersion,
+            vendor = vendor,
+            rendererString = gpuRenderer,
+            vendorString = gpuVendor,
+            versionString = versionStr,
+            extensions = extensionSet,
+            maxTextureSize = maxTextureSize,
+            maxRenderbufferSize = rbBuf[0].coerceAtLeast(0),
+            maxSamples = msaaBuf[0].coerceAtLeast(1),
+            maxUniformBlockSize = maxUniformBlockSize,
+            maxAnisotropy = maxAniso
+        )
+        featureFlags = resolveFeatureFlags(driverProfile, gpuCapabilities)
+        Log.i(TAG, "GPU: ${gpuCapabilities.summary()}; flags=$featureFlags")
+    }
+
+    /**
+     * Refine the pre-context vendor guess once we have the GL strings
+     * — the GL_VENDOR / GL_RENDERER text is more reliable than
+     * Build.HARDWARE on devices where both layers disagree.
+     */
+    private fun inferVendorFamily(
+        vendorStr: String,
+        rendererStr: String
+    ): GraphicsDriverProbe.VendorFamily {
+        val hay = "$vendorStr $rendererStr".lowercase()
+        return when {
+            hay.contains("qualcomm") || hay.contains("adreno") -> GraphicsDriverProbe.VendorFamily.ADRENO
+            hay.contains("arm") || hay.contains("mali") -> GraphicsDriverProbe.VendorFamily.MALI
+            hay.contains("powervr") || hay.contains("imagination") -> GraphicsDriverProbe.VendorFamily.POWERVR
+            hay.contains("nvidia") || hay.contains("tegra") -> GraphicsDriverProbe.VendorFamily.TEGRA
+            hay.contains("intel") -> GraphicsDriverProbe.VendorFamily.INTEL
+            hay.contains("samsung") || hay.contains("xclipse") -> GraphicsDriverProbe.VendorFamily.XCLIPSE
+            else -> driverProfile.vendorFamily
+        }
     }
 
     private fun compileShaders(): Boolean {
@@ -266,8 +361,10 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
     }
 
     private fun tryCreatePersistentMappedUBO(): Boolean {
-        val extensions = GLES32.glGetString(GLES32.GL_EXTENSIONS).orEmpty()
-        if (!extensions.contains("GL_EXT_buffer_storage")) {
+        // Single source of truth: the resolved feature flag already
+        // covers the extension check + per-vendor allow-list (e.g.
+        // PowerVR persistent-map issues). We don't second-guess it.
+        if (!featureFlags.persistentMappedUBO) {
             return false
         }
         if (!GlExtHelper.isAvailable()) {
@@ -411,6 +508,14 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
      */
     fun setWaterPlanarReflectionsEnabled(enabled: Boolean, viewportWidth: Int, viewportHeight: Int) {
         if (waterPlanarReflectionsEnabled == enabled) return
+        // Belt-and-braces: even if a producer reaches in directly,
+        // we won't allocate FBOs on a driver that the resolved
+        // feature flag rules out. Mirrors the public guard in
+        // LumiyaRenderer.setWaterPlanarReflectionsEnabled.
+        if (enabled && !featureFlags.waterPlanarReflections) {
+            Log.w(TAG, "Refusing to enable water reflections; feature flag is off for this driver")
+            return
+        }
         waterPlanarReflectionsEnabled = enabled
         if (enabled) createWaterFramebuffers(viewportWidth, viewportHeight)
         else destroyWaterFramebuffers()

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt
@@ -34,6 +34,14 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
 
         /** Default draw distance (metres). */
         const val DEFAULT_DRAW_DISTANCE = 256.0f
+
+        /**
+         * Water FBOs render at viewport / [WATER_FBO_DIVISOR] on each
+         * axis. Half-res (divisor = 2) matches LL viewer
+         * `RenderReflectionDetail` defaults and is invisible at the
+         * pixel level once the wave normal perturbs the sample UV.
+         */
+        const val WATER_FBO_DIVISOR = 2
     }
 
     // ── GPU capability flags ─────────────────────────────────────────────
@@ -129,6 +137,30 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
     var fxaaDepthRenderbuffer = 0; private set
     var fxaaWidth = 0; private set
     var fxaaHeight = 0; private set
+
+    // ── Water reflection / refraction FBOs ───────────────────────────────
+    //
+    // Names mirror the LL viewer's `LLPipeline::mWaterRef` (planar
+    // reflection target) and `mWaterDis` (refraction / "distortion"
+    // target). They are sized to a fraction of the screen — the
+    // reflection texture is sampled through a perturbed UV in the
+    // water shader so a half-resolution target is invisible at the
+    // pixel level and saves substantial fill rate. Disabled by
+    // default; enable via [setWaterPlanarReflectionsEnabled] when the
+    // device is known to handle the extra two passes.
+
+    var waterPlanarReflectionsEnabled: Boolean = false
+        private set
+    /** Planar reflection FBO. Equivalent to LLPipeline::mWaterRef. */
+    var mWaterRef: Int = 0; private set
+    var waterReflectionTexture: Int = 0; private set
+    var waterReflectionDepthRb: Int = 0; private set
+    /** Refraction (under-water) FBO. Equivalent to LLPipeline::mWaterDis. */
+    var mWaterDis: Int = 0; private set
+    var waterRefractionTexture: Int = 0; private set
+    var waterRefractionDepthRb: Int = 0; private set
+    var waterFboWidth: Int = 0; private set
+    var waterFboHeight: Int = 0; private set
 
     // ── Global UBO for shared matrices ───────────────────────────────────
 
@@ -368,6 +400,108 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
         }
     }
 
+    // ── Water reflection / refraction FBOs ───────────────────────────────
+
+    /**
+     * Toggle planar water reflection / refraction passes. When enabled,
+     * the renderer maintains two off-screen FBOs sized to half the
+     * primary viewport ([WATER_FBO_DIVISOR]). Producers (water pass)
+     * sample these textures to produce the mirror-reflection +
+     * underwater-refraction look that LL/Singularity ship.
+     */
+    fun setWaterPlanarReflectionsEnabled(enabled: Boolean, viewportWidth: Int, viewportHeight: Int) {
+        if (waterPlanarReflectionsEnabled == enabled) return
+        waterPlanarReflectionsEnabled = enabled
+        if (enabled) createWaterFramebuffers(viewportWidth, viewportHeight)
+        else destroyWaterFramebuffers()
+    }
+
+    /**
+     * Recreate the water FBOs to match a new viewport. Cheap no-op
+     * when reflections are disabled. Call from [onSurfaceChanged] in
+     * the renderer alongside the FXAA FBO recreation.
+     */
+    fun resizeWaterFramebuffers(viewportWidth: Int, viewportHeight: Int) {
+        if (!waterPlanarReflectionsEnabled) return
+        createWaterFramebuffers(viewportWidth, viewportHeight)
+    }
+
+    private fun createWaterFramebuffers(viewportWidth: Int, viewportHeight: Int) {
+        destroyWaterFramebuffers()
+        val w = (viewportWidth / WATER_FBO_DIVISOR).coerceAtLeast(64)
+        val h = (viewportHeight / WATER_FBO_DIVISOR).coerceAtLeast(64)
+        waterFboWidth = w
+        waterFboHeight = h
+
+        val pair = createOffscreenColorDepth(w, h)
+        mWaterRef = pair.fbo
+        waterReflectionTexture = pair.color
+        waterReflectionDepthRb = pair.depth
+
+        val pair2 = createOffscreenColorDepth(w, h)
+        mWaterDis = pair2.fbo
+        waterRefractionTexture = pair2.color
+        waterRefractionDepthRb = pair2.depth
+
+        Log.i(TAG, "Water FBOs created: ${w}x${h} ref=$mWaterRef dis=$mWaterDis")
+    }
+
+    private fun destroyWaterFramebuffers() {
+        intArrayOf(mWaterRef, mWaterDis).filter { it != 0 }.forEach { fbo ->
+            GLES32.glDeleteFramebuffers(1, intArrayOf(fbo), 0)
+        }
+        intArrayOf(waterReflectionTexture, waterRefractionTexture).filter { it != 0 }.forEach { tex ->
+            GLES32.glDeleteTextures(1, intArrayOf(tex), 0)
+        }
+        intArrayOf(waterReflectionDepthRb, waterRefractionDepthRb).filter { it != 0 }.forEach { rb ->
+            GLES32.glDeleteRenderbuffers(1, intArrayOf(rb), 0)
+        }
+        mWaterRef = 0; waterReflectionTexture = 0; waterReflectionDepthRb = 0
+        mWaterDis = 0; waterRefractionTexture = 0; waterRefractionDepthRb = 0
+        waterFboWidth = 0; waterFboHeight = 0
+    }
+
+    private data class OffscreenAttachments(val fbo: Int, val color: Int, val depth: Int)
+
+    private fun createOffscreenColorDepth(width: Int, height: Int): OffscreenAttachments {
+        val fboBuf = IntArray(1); GLES32.glGenFramebuffers(1, fboBuf, 0)
+        val fbo = fboBuf[0]
+        GLES32.glBindFramebuffer(GLES32.GL_FRAMEBUFFER, fbo)
+
+        val texBuf = IntArray(1); GLES32.glGenTextures(1, texBuf, 0)
+        val color = texBuf[0]
+        GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, color)
+        GLES32.glTexImage2D(
+            GLES32.GL_TEXTURE_2D, 0, GLES32.GL_RGBA8,
+            width, height, 0,
+            GLES32.GL_RGBA, GLES32.GL_UNSIGNED_BYTE, null
+        )
+        GLES32.glTexParameteri(GLES32.GL_TEXTURE_2D, GLES32.GL_TEXTURE_MIN_FILTER, GLES32.GL_LINEAR)
+        GLES32.glTexParameteri(GLES32.GL_TEXTURE_2D, GLES32.GL_TEXTURE_MAG_FILTER, GLES32.GL_LINEAR)
+        GLES32.glTexParameteri(GLES32.GL_TEXTURE_2D, GLES32.GL_TEXTURE_WRAP_S, GLES32.GL_CLAMP_TO_EDGE)
+        GLES32.glTexParameteri(GLES32.GL_TEXTURE_2D, GLES32.GL_TEXTURE_WRAP_T, GLES32.GL_CLAMP_TO_EDGE)
+        GLES32.glFramebufferTexture2D(
+            GLES32.GL_FRAMEBUFFER, GLES32.GL_COLOR_ATTACHMENT0,
+            GLES32.GL_TEXTURE_2D, color, 0
+        )
+
+        val rbBuf = IntArray(1); GLES32.glGenRenderbuffers(1, rbBuf, 0)
+        val depth = rbBuf[0]
+        GLES32.glBindRenderbuffer(GLES32.GL_RENDERBUFFER, depth)
+        GLES32.glRenderbufferStorage(GLES32.GL_RENDERBUFFER, GLES32.GL_DEPTH_COMPONENT16, width, height)
+        GLES32.glFramebufferRenderbuffer(
+            GLES32.GL_FRAMEBUFFER, GLES32.GL_DEPTH_ATTACHMENT,
+            GLES32.GL_RENDERBUFFER, depth
+        )
+
+        val status = GLES32.glCheckFramebufferStatus(GLES32.GL_FRAMEBUFFER)
+        if (status != GLES32.GL_FRAMEBUFFER_COMPLETE) {
+            Log.e(TAG, "Water FBO incomplete: 0x${Integer.toHexString(status)}")
+        }
+        GLES32.glBindFramebuffer(GLES32.GL_FRAMEBUFFER, 0)
+        return OffscreenAttachments(fbo, color, depth)
+    }
+
     // ── Per-frame helpers ────────────────────────────────────────────────
 
     fun beginFrame() {
@@ -418,6 +552,7 @@ class LumiyaRenderContext(private val glThreadGuard: ((String) -> Unit)? = null)
 
     fun shutdown() {
         destroyFXAAFramebuffer()
+        destroyWaterFramebuffers()
         if (globalUBO != 0) {
             GLES32.glDeleteBuffers(1, intArrayOf(globalUBO), 0)
             globalUBO = 0

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
@@ -199,8 +199,21 @@ class LumiyaRenderer : RenderEngineProvider {
         ctx.aspectRatio = width.toFloat() / height.toFloat()
         GLES32.glViewport(0, 0, width, height)
         if (ctx.fxaaEnabled) ctx.createFXAAFramebuffer(width, height)
+        ctx.resizeWaterFramebuffers(width, height)
         rebuildHudMatrices(width, height)
         hudStore.setViewportSize(width, height)
+    }
+
+    /**
+     * Toggle planar water reflection / refraction at runtime. When
+     * enabled, [LumiyaRenderContext.mWaterRef] / [mWaterDis] become
+     * non-zero and the water pass is free to bind them as samplers
+     * for a mirror-reflection look. Mirrors LL viewer's
+     * `RenderWaterReflections` debug setting.
+     */
+    fun setWaterPlanarReflectionsEnabled(enabled: Boolean) {
+        requireGlThread("setWaterPlanarReflectionsEnabled")
+        ctx.setWaterPlanarReflectionsEnabled(enabled, viewportWidth, viewportHeight)
     }
 
     override fun onSurfaceDestroyed() {
@@ -284,6 +297,7 @@ class LumiyaRenderer : RenderEngineProvider {
                     hoverTextStore.draw(ctx, viewportWidth, viewportHeight)
                     GLES32.glDepthMask(true)
                 }
+                LumiyaRenderPass.WORLD_EMISSIVE -> primStore.drawEmissive(ctx)
                 LumiyaRenderPass.WORLD_WATER -> waterDrawable?.draw(ctx)
                 LumiyaRenderPass.WORLD_PARTICLES -> particleManager?.draw(ctx)
                 LumiyaRenderPass.HUD -> renderHudPass()

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
@@ -116,7 +116,16 @@ class LumiyaRenderer : RenderEngineProvider {
 
         val initStartedAt = System.currentTimeMillis()
         try {
+            // Probe the device's graphics drivers before we even
+            // touch GL state. The probe is purely PackageManager /
+            // ActivityManager — no GL calls — so a misconfigured
+            // device can't crash us here. The result is fed into
+            // the context so the resolved feature flags reflect
+            // both the pre-context platform info and the
+            // post-context extension list.
+            val driverProfile = com.linkpoint.render.driver.GraphicsDriverProbe.probe(context)
             ctx = LumiyaRenderContext { apiName -> requireGlThread("LumiyaRenderContext.$apiName") }
+            ctx.driverProfile = driverProfile
             if (!ctx.initialize()) {
                 Log.e(TAG, "Render context initialisation failed")
                 RenderDiagnostics.glInitFailed(
@@ -133,6 +142,28 @@ class LumiyaRenderer : RenderEngineProvider {
                 version = "GL ES ${ctx.glVersion}",
                 maxTextureSize = ctx.maxTextureSize
             )
+            // Detailed driver-capability summary (Vulkan, AEP,
+            // extension count) goes to its own diagnostic so the
+            // session log captures the device profile separately
+            // from the GL context info.
+            RenderDiagnostics.glDriverCapabilities(
+                profileSummary = driverProfile.summary(),
+                capsSummary = ctx.gpuCapabilities.summary(),
+                featureFlags = ctx.featureFlags.toString()
+            )
+
+            // Hard floor: refuse to spin up the renderer on a device
+            // that can't reach our minimum GLES level. The caller
+            // can fall back to a software path or display an
+            // unsupported-device message rather than ship a black
+            // frame.
+            if (ctx.gpuCapabilities.glVersion < 30) {
+                Log.e(TAG, "Device GLES version (${ctx.gpuCapabilities.glVersion}) below required 3.0; aborting")
+                RenderDiagnostics.glInitFailed(
+                    RuntimeException("GLES 3.0+ required; device reports ${ctx.gpuCapabilities.glVersion}")
+                )
+                return false
+            }
 
             viewportWidth = width
             viewportHeight = height
@@ -161,9 +192,19 @@ class LumiyaRenderer : RenderEngineProvider {
             // Clear colour – SL default sky blue
             GLES32.glClearColor(0.24f, 0.44f, 0.76f, 1.0f)
 
-            // Build FXAA FBO
-            if (ctx.fxaaEnabled) {
+            // Build FXAA FBO. The user toggle ([fxaaEnabled]) is the
+            // intent; the resolved feature flag is the floor — on a
+            // driver that can't deliver FXAA (no FBOs, tiny max
+            // texture), we silently disable the user's preference
+            // and leave the buffer never-created. The flag winning
+            // over the user toggle is intentional: enabling FXAA on
+            // a driver that can't do it would produce a black
+            // screen, which is strictly worse than aliased pixels.
+            if (ctx.fxaaEnabled && ctx.featureFlags.fxaa) {
                 ctx.createFXAAFramebuffer(width, height)
+            } else if (ctx.fxaaEnabled && !ctx.featureFlags.fxaa) {
+                Log.i(TAG, "FXAA requested but unsupported on this driver; running without")
+                ctx.fxaaEnabled = false
             }
 
             // Build full-screen quad for post-processing
@@ -210,11 +251,37 @@ class LumiyaRenderer : RenderEngineProvider {
      * non-zero and the water pass is free to bind them as samplers
      * for a mirror-reflection look. Mirrors LL viewer's
      * `RenderWaterReflections` debug setting.
+     *
+     * Returns true when the toggle took effect, false when the
+     * device's [com.linkpoint.render.driver.FeatureFlags] floor
+     * blocks the feature. UI surfaces should check the return value
+     * and reflect "unavailable" rather than silently lying to the
+     * user.
      */
-    fun setWaterPlanarReflectionsEnabled(enabled: Boolean) {
+    fun setWaterPlanarReflectionsEnabled(enabled: Boolean): Boolean {
         requireGlThread("setWaterPlanarReflectionsEnabled")
+        if (enabled && !ctx.featureFlags.waterPlanarReflections) {
+            Log.i(TAG, "Water planar reflections requested but unsupported on this driver; ignoring")
+            return false
+        }
         ctx.setWaterPlanarReflectionsEnabled(enabled, viewportWidth, viewportHeight)
+        return true
     }
+
+    /**
+     * Snapshot of the resolved driver capabilities. Read-only mirror
+     * of [LumiyaRenderContext.featureFlags] / [gpuCapabilities] so
+     * callers (settings UI, telemetry) can introspect what features
+     * are live without reaching into the context directly.
+     */
+    fun driverCapabilities(): com.linkpoint.render.driver.GpuCapabilities = ctx.gpuCapabilities
+
+    /**
+     * Snapshot of the resolved feature flags for this context.
+     * @see setWaterPlanarReflectionsEnabled for an example of how
+     *      a UI gate should consult these.
+     */
+    fun featureFlags(): com.linkpoint.render.driver.FeatureFlags = ctx.featureFlags
 
     override fun onSurfaceDestroyed() {
         requireGlThread("onSurfaceDestroyed")

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHoverText.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHoverText.kt
@@ -25,6 +25,44 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class DrawableHoverText {
 
+    companion object {
+        /**
+         * Distance (m) at which hover text starts to fade. Closer
+         * than this and labels render at full alpha. Mirrors the
+         * LL viewer hover-text dimensions: labels are crisp inside
+         * the conversation radius and fall off past 16m.
+         */
+        const val FADE_START_DISTANCE = 16.0f
+
+        /**
+         * Distance (m) at which hover text reaches zero alpha.
+         * Beyond this we skip the draw entirely. The LL viewer
+         * hard-cuts at the avatar chat radius (32m) to keep
+         * cluttered regions readable; matches our default.
+         */
+        const val FADE_END_DISTANCE = 32.0f
+
+        /**
+         * Linear distance fade in [0, 1]. The geometric scaling in
+         * [draw] keeps text legible up to ~4x the texture pixel size,
+         * but label clutter at long range is unreadable regardless —
+         * this tapers alpha to zero so the screen stays clean.
+         *
+         * Pure math; no Android dependency so it can be called from
+         * unit tests without instantiating a [DrawableHoverText]
+         * (whose `Paint` field requires the Android runtime).
+         */
+        @JvmStatic
+        fun fadeFactorAt(dist: Float): Float {
+            if (dist <= FADE_START_DISTANCE) return 1f
+            if (dist >= FADE_END_DISTANCE) return 0f
+            val span = FADE_END_DISTANCE - FADE_START_DISTANCE
+            return 1f - (dist - FADE_START_DISTANCE) / span
+        }
+
+        private val IDENTITY = FloatArray(16).also { Matrix.setIdentityM(it, 0) }
+    }
+
     private data class Label(
         val primId: Long,
         val text: String,
@@ -112,13 +150,25 @@ class DrawableHoverText {
             ensureLabelTexture(label)
             if (label.textureHandle == 0) continue
 
-            // Scale the billboard so the bitmap maps to a sensible
-            // world-size. 32px text ≈ 0.5m at the prim. Distance scaling
-            // keeps text legible far away (bounded between 0.5x and 4x).
+            // Distance from camera. Drives both geometric scaling
+            // and alpha fade.
             val dx = label.anchorX - ctx.cameraPositionX
             val dy = label.anchorY - ctx.cameraPositionY
             val dz = label.anchorZ - ctx.cameraPositionZ
             val dist = Math.sqrt((dx * dx + dy * dy + dz * dz).toDouble()).toFloat()
+
+            // Distance fade: 1 at FADE_START, 0 at FADE_END, linear
+            // in between. Skip the draw when fully faded — the
+            // texture stays cached so re-entering the radius doesn't
+            // re-rasterise. Mirrors LL viewer LLHUDText::draw which
+            // multiplies LLHUDObject::mUserAlpha by a distance term
+            // before issuing the quad.
+            val fadeAlpha = fadeFactorAt(dist)
+            if (fadeAlpha <= 0f) continue
+
+            // Scale the billboard so the bitmap maps to a sensible
+            // world-size. 32px text ≈ 0.5m at the prim. Distance scaling
+            // keeps text legible far away (bounded between 0.5x and 4x).
             val pixelSize = (dist * 0.0015f).coerceIn(0.4f, 4.0f)
             val halfW = label.textureWidth * pixelSize * 0.5f
             val halfH = label.textureHeight * pixelSize * 0.5f
@@ -135,7 +185,7 @@ class DrawableHoverText {
             m[14] = label.anchorZ
             m[15] = 1f
             program.setModelMatrix(m)
-            program.setColor(label.colorR, label.colorG, label.colorB, label.colorA)
+            program.setColor(label.colorR, label.colorG, label.colorB, label.colorA * fadeAlpha)
             program.setUseTexture(true)
             GLES32.glActiveTexture(GLES32.GL_TEXTURE0)
             GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, label.textureHandle)
@@ -225,7 +275,4 @@ class DrawableHoverText {
         }
     }
 
-    private companion object {
-        private val IDENTITY = FloatArray(16).also { Matrix.setIdentityM(it, 0) }
-    }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt
@@ -50,7 +50,14 @@ class DrawablePrimStore {
         var scaleT: Float = 1f,
         var offsetS: Float = 0f,
         var offsetT: Float = 0f,
-        var rotation: Float = 0f
+        var rotation: Float = 0f,
+        /**
+         * SL emissive "glow" intensity in the range 0..1. Faces with
+         * glow > [GLOW_THRESHOLD] participate in the emissive
+         * double-pass, where they are re-drawn with additive blending
+         * to brighten neighbouring pixels. 0 = no emissive.
+         */
+        var glow: Float = 0f
     )
 
     /** Per-prim instance data. */
@@ -71,6 +78,14 @@ class DrawablePrimStore {
     companion object {
         private val NULL_UUID = UUID(0L, 0L)
         private val IDENTITY_TEX = FloatArray(16).also { Matrix.setIdentityM(it, 0) }
+
+        /**
+         * Faces with [FaceMaterial.glow] strictly greater than this
+         * value are re-drawn in the emissive pass. The LL viewer also
+         * gates on a small epsilon — anything below ~1/255 is an
+         * encoder rounding artefact.
+         */
+        const val GLOW_THRESHOLD = 0.005f
     }
 
     private val prims = ConcurrentHashMap<Long, PrimInstance>()
@@ -117,9 +132,27 @@ class DrawablePrimStore {
         instance.scaleX = scaleX
         instance.scaleY = scaleY
         instance.scaleZ = scaleZ
-        instance.aabbHalfX = scaleX * 0.5f
-        instance.aabbHalfY = scaleY * 0.5f
-        instance.aabbHalfZ = scaleZ * 0.5f
+
+        // AABB: when the prim has a rotation, expand the local
+        // half-extents to a conservative world-space AABB. Spatial
+        // queries (frustum culling, picking) only have axis-aligned
+        // tests — without this widening a rotated long thin prim
+        // pops in/out of view as it crosses cell boundaries.
+        // Lineage: LL viewer LLXformMatrix::updateBoundingBoxes.
+        val localHalfX = scaleX * 0.5f
+        val localHalfY = scaleY * 0.5f
+        val localHalfZ = scaleZ * 0.5f
+        if (rotation != null && rotation.size >= 16) {
+            val (wx, wy, wz) = com.linkpoint.render.lumiya.spatial.SpatialEntry
+                .conservativeWorldHalfExtents(localHalfX, localHalfY, localHalfZ, rotation)
+            instance.aabbHalfX = wx
+            instance.aabbHalfY = wy
+            instance.aabbHalfZ = wz
+        } else {
+            instance.aabbHalfX = localHalfX
+            instance.aabbHalfY = localHalfY
+            instance.aabbHalfZ = localHalfZ
+        }
 
         Matrix.setIdentityM(instance.modelMatrix, 0)
         Matrix.translateM(instance.modelMatrix, 0, posX, posY, posZ)
@@ -361,9 +394,98 @@ class DrawablePrimStore {
             dst.offsetS = src.offsetS
             dst.offsetT = src.offsetT
             dst.rotation = src.rotation
+            dst.glow = src.glow
         }
         // Auto-flip transparent if any face has alpha < 1.
         instance.isTransparent = instance.faces.any { it.colorA < 0.999f }
+    }
+
+    /**
+     * True if [instance] has at least one face that should appear in
+     * the emissive double-pass. Used by [drawEmissive] to skip prims
+     * that have no glowy faces without iterating their face list.
+     */
+    private fun hasEmissive(instance: PrimInstance): Boolean {
+        for (face in instance.faces) {
+            if (face.glow > GLOW_THRESHOLD) return true
+        }
+        return false
+    }
+
+    /**
+     * Emissive / glow pass — re-draws every face with `glow > threshold`
+     * using additive blending so they brighten anything already drawn
+     * underneath. Run after the world's opaque + transparent passes
+     * have committed their colour into the FBO.
+     *
+     * Lineage: Lumiya's `DrawableStore.drawGlow` and the LL viewer's
+     * `LLDrawPoolGlow::render` both walk the live drawables a second
+     * time, multiply the base colour by the per-face glow intensity,
+     * and blend with `glBlendFunc(ONE, ONE)`. Z-write is disabled to
+     * keep the emissive layer from punching out subsequent passes.
+     */
+    fun drawEmissive(ctx: LumiyaRenderContext) {
+        ensureShapes(ctx)
+        val program = ctx.primProgram ?: return
+
+        val emissivePrims = prims.values.filter { primInFrustum(ctx, it) && hasEmissive(it) }
+        if (emissivePrims.isEmpty()) return
+
+        program.use()
+        // No directional / ambient contribution — the emissive value
+        // *is* the lighting. Diffuse + ambient zeroed; sun direction
+        // is irrelevant when nothing diffuses.
+        program.setLighting(0f, 0f, 1f, 0f, 0f, 0f, 1f, 1f, 1f)
+
+        // Additive blend, depth test on, depth write off. Mirrors the
+        // LL viewer LLGLBlend(GL_ONE, GL_ONE) state in LLDrawPoolGlow.
+        GLES32.glEnable(GLES32.GL_BLEND)
+        GLES32.glBlendFunc(GLES32.GL_ONE, GLES32.GL_ONE)
+        GLES32.glDepthMask(false)
+
+        val byShape = emissivePrims.groupBy { it.shape }
+        for ((shape, list) in byShape) {
+            val vao = shapeVAOs?.get(shape) ?: continue
+            GLES32.glBindVertexArray(vao.vao)
+            for (prim in list) {
+                drawPrimEmissive(program, prim, vao.indexCount)
+            }
+        }
+        GLES32.glBindVertexArray(0)
+
+        // Restore the renderer's standard separate-alpha blend so
+        // following passes don't inherit the additive setup.
+        GLES32.glBlendFuncSeparate(
+            GLES32.GL_SRC_ALPHA, GLES32.GL_ONE_MINUS_SRC_ALPHA,
+            GLES32.GL_ZERO, GLES32.GL_ONE_MINUS_SRC_ALPHA
+        )
+        GLES32.glDepthMask(true)
+    }
+
+    private fun drawPrimEmissive(
+        program: com.linkpoint.render.lumiya.shaders.PrimShaderProgram,
+        prim: PrimInstance,
+        totalIndexCount: Int
+    ) {
+        val face = prim.faces.firstOrNull { it.glow > GLOW_THRESHOLD } ?: return
+        program.setModelMatrix(prim.modelMatrix)
+        program.setTexMatrix(buildTexMatrix(face))
+
+        // Emissive output = base colour (or texture) * glow intensity.
+        // Multiplying alpha by glow so the additive blend's output is
+        // bounded by the face's own opacity — fully transparent
+        // glow=1 face still contributes nothing, matching SL.
+        val g = face.glow
+        program.setColor(face.colorR * g, face.colorG * g, face.colorB * g, face.colorA * g)
+        if (face.textureHandle != 0) {
+            program.setUseTexture(true)
+            GLES32.glActiveTexture(GLES32.GL_TEXTURE0)
+            GLES32.glBindTexture(GLES32.GL_TEXTURE_2D, face.textureHandle)
+            program.setTextureSampler(0)
+        } else {
+            program.setUseTexture(false)
+        }
+        GLES32.glDrawElements(GLES32.GL_TRIANGLES, totalIndexCount, GLES32.GL_UNSIGNED_SHORT, 0)
     }
 
     /**

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/FrustumCuller.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/FrustumCuller.kt
@@ -86,6 +86,55 @@ class FrustumCuller {
     }
 
     /**
+     * Tri-state classification of an AABB against the frustum.
+     *
+     * Lineage: LL viewer `LLVolumeOctree::cull` returns three states so an
+     * octree walk can short-circuit into "draw whole subtree, no further
+     * culling" once a node is fully inside the frustum. Lumiya kept the
+     * binary path because its draw lists were flat and the per-prim test
+     * was cheap; with our octree-backed [SpatialIndex], the savings come
+     * back as soon as the camera looks into a dense region.
+     *
+     * Returns:
+     *  - [FrustumResult.OUTSIDE]   – box is entirely on the negative side
+     *                                of at least one plane; whole subtree
+     *                                can be skipped
+     *  - [FrustumResult.INSIDE]    – box is entirely on the positive side
+     *                                of every plane; subtree can be drawn
+     *                                without further plane tests
+     *  - [FrustumResult.INTERSECTS] – box straddles at least one plane;
+     *                                child boxes must be tested
+     *
+     * Contract: when this returns INSIDE for a node, callers may treat
+     * every contained AABB as visible without re-testing — useful for
+     * tight inner loops over an octree leaf.
+     */
+    fun classifyAABB(
+        minX: Float, minY: Float, minZ: Float,
+        maxX: Float, maxY: Float, maxZ: Float
+    ): FrustumResult {
+        var allInside = true
+        for (p in planes) {
+            // Positive corner: maximises the plane's inside-ness.
+            val px = if (p[0] >= 0) maxX else minX
+            val py = if (p[1] >= 0) maxY else minY
+            val pz = if (p[2] >= 0) maxZ else minZ
+            if (p[0] * px + p[1] * py + p[2] * pz + p[3] < 0f) {
+                return FrustumResult.OUTSIDE
+            }
+            // Negative corner: minimises inside-ness. If it's also on
+            // the positive side, the whole box is on the positive side.
+            val nx = if (p[0] >= 0) minX else maxX
+            val ny = if (p[1] >= 0) minY else maxY
+            val nz = if (p[2] >= 0) minZ else maxZ
+            if (p[0] * nx + p[1] * ny + p[2] * nz + p[3] < 0f) {
+                allInside = false
+            }
+        }
+        return if (allInside) FrustumResult.INSIDE else FrustumResult.INTERSECTS
+    }
+
+    /**
      * Test whether a sphere is at least partially inside the frustum.
      */
     fun isSphereVisible(cx: Float, cy: Float, cz: Float, radius: Float): Boolean {
@@ -104,5 +153,18 @@ class FrustumCuller {
             if (p[0] * x + p[1] * y + p[2] * z + p[3] < 0f) return false
         }
         return true
+    }
+
+    /**
+     * Test seam — install a single plane equation directly so unit
+     * tests don't have to mock the GLES matrix multiply chain in
+     * [extractPlanes]. Production callers should always go through
+     * [extractPlanes].
+     */
+    @androidx.annotation.VisibleForTesting
+    internal fun setPlaneForTest(index: Int, a: Float, b: Float, c: Float, d: Float) {
+        require(index in 0..5) { "plane index out of range: $index" }
+        planes[index][0] = a; planes[index][1] = b
+        planes[index][2] = c; planes[index][3] = d
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/FrustumResult.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/FrustumResult.kt
@@ -1,0 +1,18 @@
+package com.linkpoint.render.lumiya.spatial
+
+/**
+ * Tri-state result of a frustum / AABB classification, matching the
+ * LL viewer convention used by `LLCamera::AABBInFrustum` and the LL
+ * volume octree walker.
+ *
+ *  - [OUTSIDE]    – the volume is entirely outside; skip it
+ *  - [INTERSECTS] – the volume straddles a plane; recurse / re-test
+ *                   children
+ *  - [INSIDE]     – the volume is entirely inside; descendants can be
+ *                   drawn without further plane tests
+ *
+ * Producers (octree walks, BVH walks) convert this into a per-node
+ * decision. Consumers that only care about visibility can keep using
+ * the existing binary `isAABBVisible` helper.
+ */
+enum class FrustumResult { OUTSIDE, INTERSECTS, INSIDE }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/OcclusionQuerySet.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/OcclusionQuerySet.kt
@@ -52,9 +52,27 @@ class OcclusionQuerySet {
 
     private val slots = HashMap<Long, Slot>()
     private var currentEntity: Long = -1L
-    private var enabled: Boolean = true
+    // Off by default to match the class docstring: occlusion query
+    // overhead is a net loss on tile-based mobile GPUs unless the
+    // scene is genuinely overdraw-bound. Producers must
+    // `setEnabled(true)` after confirming
+    // `LumiyaRenderer.featureFlags().occlusionQueries` is true so we
+    // never issue GL_ANY_SAMPLES_PASSED_CONSERVATIVE on a driver
+    // that lacks it.
+    private var enabled: Boolean = false
 
-    /** Toggle the entire system off (reverts to draw-everything). */
+    /**
+     * Toggle the entire system off (reverts to draw-everything).
+     *
+     * Caller responsibility: only flip this true when the driver
+     * actually supports `GL_ANY_SAMPLES_PASSED_CONSERVATIVE`. The
+     * canonical check is
+     * `LumiyaRenderer.featureFlags().occlusionQueries`. Calling
+     * `glBeginQuery` against an unsupported target on some drivers
+     * spams the log with `GL_INVALID_OPERATION` rather than failing
+     * silently, so we don't try to detect support inside this
+     * class — the renderer owns that decision.
+     */
     fun setEnabled(enabled: Boolean) {
         this.enabled = enabled
     }

--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/SpatialIndex.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/SpatialIndex.kt
@@ -75,6 +75,12 @@ class SpatialIndex {
 
 /**
  * A single spatial entry representing an object's bounding volume.
+ *
+ * The half-extents are always axis-aligned in world space. For prims
+ * with a non-identity rotation, callers should expand the local
+ * half-extents into a conservative world-space AABB via
+ * [SpatialEntry.fromOrientedBox] so a rotated long thin prim doesn't
+ * pop in/out of view as it crosses an octree boundary.
  */
 data class SpatialEntry(
     val id: Long,
@@ -96,6 +102,73 @@ data class SpatialEntry(
     val maxX get() = posX + halfExtentX
     val maxY get() = posY + halfExtentY
     val maxZ get() = posZ + halfExtentZ
+
+    companion object {
+        /**
+         * Build a [SpatialEntry] from an oriented box (local-space half
+         * extents + world rotation). The resulting AABB is the
+         * smallest axis-aligned box that fully contains the rotated
+         * box — an over-estimate, never under-estimate. Inserting
+         * rotated prims this way keeps frustum / octree queries
+         * correct without per-object OBB tests.
+         *
+         * Lineage: LL viewer `LLXformMatrix::updateBoundingBoxes` ->
+         * `LLDrawable::updateXform`. Singularity uses the same trick
+         * and notes "we over-estimate, conservative but works" — the
+         * exact phrase mirrored in the work-list this implements.
+         *
+         * @param posX/Y/Z World-space center of the box.
+         * @param halfX/Y/Z Local-space half-extents along the box's
+         *                  own axes.
+         * @param rotation 4x4 column-major rotation matrix; only the
+         *                 upper-left 3x3 is read. Translation columns
+         *                 are ignored — pass any matrix shaped like a
+         *                 GLES model matrix.
+         */
+        fun fromOrientedBox(
+            id: Long,
+            posX: Float, posY: Float, posZ: Float,
+            halfX: Float, halfY: Float, halfZ: Float,
+            rotation: FloatArray,
+            isAvatar: Boolean = false
+        ): SpatialEntry {
+            val (wx, wy, wz) = conservativeWorldHalfExtents(halfX, halfY, halfZ, rotation)
+            return SpatialEntry(
+                id = id,
+                posX = posX, posY = posY, posZ = posZ,
+                halfExtentX = wx, halfExtentY = wy, halfExtentZ = wz,
+                isAvatar = isAvatar
+            )
+        }
+
+        /**
+         * Conservative world-space half-extents of a local OBB.
+         *
+         * Computed as the absolute-value sum of each axis projected
+         * through the rotation: |R| * h. This is the standard OBB ->
+         * AABB widening: each world axis collects the absolute
+         * contribution from every local axis. It exactly bounds the
+         * rotated box's eight corners (no slack beyond what rotation
+         * introduces).
+         *
+         * Returns (halfX, halfY, halfZ) in world units.
+         */
+        fun conservativeWorldHalfExtents(
+            halfX: Float, halfY: Float, halfZ: Float,
+            rotation: FloatArray
+        ): Triple<Float, Float, Float> {
+            // Column-major: column k = rotation[k*4 .. k*4+2].
+            // World axis i contribution = |R[i,0]|*hx + |R[i,1]|*hy + |R[i,2]|*hz.
+            // R[i,k] in row-i, col-k = rotation[k*4 + i].
+            val ax0 = Math.abs(rotation[0]); val ax1 = Math.abs(rotation[4]); val ax2 = Math.abs(rotation[8])
+            val ay0 = Math.abs(rotation[1]); val ay1 = Math.abs(rotation[5]); val ay2 = Math.abs(rotation[9])
+            val az0 = Math.abs(rotation[2]); val az1 = Math.abs(rotation[6]); val az2 = Math.abs(rotation[10])
+            val wx = ax0 * halfX + ax1 * halfY + ax2 * halfZ
+            val wy = ay0 * halfX + ay1 * halfY + ay2 * halfZ
+            val wz = az0 * halfX + az1 * halfY + az2 * halfZ
+            return Triple(wx, wy, wz)
+        }
+    }
 }
 
 /**
@@ -145,16 +218,35 @@ class OctreeNode(
 
     fun queryFrustum(culler: FrustumCuller, result: MutableList<SpatialEntry>, maxResults: Int) {
         if (result.size >= maxResults) return
-        if (!culler.isAABBVisible(minX, minY, minZ, maxX, maxY, maxZ)) return
-
-        for (obj in objects) {
-            if (result.size >= maxResults) return
-            if (culler.isAABBVisible(obj.minX, obj.minY, obj.minZ, obj.maxX, obj.maxY, obj.maxZ)) {
-                result.add(obj)
+        when (culler.classifyAABB(minX, minY, minZ, maxX, maxY, maxZ)) {
+            FrustumResult.OUTSIDE -> return
+            FrustumResult.INSIDE -> collectAll(result, maxResults)
+            FrustumResult.INTERSECTS -> {
+                for (obj in objects) {
+                    if (result.size >= maxResults) return
+                    if (culler.isAABBVisible(obj.minX, obj.minY, obj.minZ, obj.maxX, obj.maxY, obj.maxZ)) {
+                        result.add(obj)
+                    }
+                }
+                children?.forEach { it?.queryFrustum(culler, result, maxResults) }
             }
         }
+    }
 
-        children?.forEach { it?.queryFrustum(culler, result, maxResults) }
+    /**
+     * Drain every object in this subtree into [result] without further
+     * frustum checks. Called once the parent tri-state classifier has
+     * proven the whole node sits inside the frustum.
+     */
+    private fun collectAll(result: MutableList<SpatialEntry>, maxResults: Int) {
+        for (obj in objects) {
+            if (result.size >= maxResults) return
+            result.add(obj)
+        }
+        children?.forEach { child ->
+            if (result.size >= maxResults) return
+            child?.collectAll(result, maxResults)
+        }
     }
 
     private fun subdivide() {

--- a/Linkpoint/src/main/java/com/linkpoint/render/water/WaterRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/water/WaterRenderer.kt
@@ -26,7 +26,7 @@ class WaterRenderer(
     private var vertexBuffer: VertexBuffer? = null
     private var indexBuffer: IndexBuffer? = null
     private var materialInstance: MaterialInstance? = null
-    
+
     // Water settings (Windlight)
     private var waterHeight = 20f
     private var waveDirection1 = LLVector3(1f, 0f, 0f)
@@ -38,7 +38,25 @@ class WaterRenderer(
     private var fresnelOffset = 0.5f
     private var normalScale = LLVector3(2f, 2f, 2f)
     private var normalMapTexture: Texture? = null
-    
+
+    /**
+     * Planar reflection target. Equivalent of LL viewer
+     * `LLPipeline::mWaterRef`. Producers render the world (with the
+     * camera mirrored across the water plane) into this texture, then
+     * the water shader samples it perturbed by the wave normal.
+     * Null when planar reflections are disabled.
+     */
+    private var mWaterRef: Texture? = null
+
+    /**
+     * Refraction / "distortion" target. Equivalent of
+     * `LLPipeline::mWaterDis`. Holds the under-water scene rendered
+     * with a clip plane at the water height. The water shader
+     * samples this with a UV offset to fake refraction. Null when
+     * planar reflections are disabled.
+     */
+    private var mWaterDis: Texture? = null
+
     private var time = 0f
     
     /**
@@ -81,6 +99,24 @@ class WaterRenderer(
      */
     fun setNormalMap(texture: Texture) {
         normalMapTexture = texture
+        updateMaterialParams()
+    }
+
+    /**
+     * Bind planar reflection ([mWaterRef]) and refraction ([mWaterDis])
+     * targets. Pass `null` for either to clear that channel — the
+     * material falls back to a plain Fresnel-tinted base colour, the
+     * same path the renderer takes when planar reflections are
+     * disabled at the device-tier level.
+     *
+     * Lineage: LLPipeline::generateWaterReflection writes mWaterRef
+     * + mWaterDis once per frame and binds them on the next water
+     * draw. Producers should follow the same one-shot-per-frame
+     * cadence; we don't otherwise hold a reference past the draw.
+     */
+    fun setReflectionRefractionTargets(reflection: Texture?, refraction: Texture?) {
+        mWaterRef = reflection
+        mWaterDis = refraction
         updateMaterialParams()
     }
     
@@ -200,6 +236,30 @@ class WaterRenderer(
                     TextureSampler.MagFilter.LINEAR,
                     TextureSampler.WrapMode.REPEAT
                 ))
+            }
+
+            // Planar reflection / refraction samplers. Material is
+            // expected to declare `reflectionMap` / `refractionMap`
+            // optional sampler2D parameters; when not declared the
+            // setParameter call is a silent no-op so older Filament
+            // material packages keep working.
+            mWaterRef?.let {
+                runCatching {
+                    setParameter("reflectionMap", it, TextureSampler(
+                        TextureSampler.MinFilter.LINEAR,
+                        TextureSampler.MagFilter.LINEAR,
+                        TextureSampler.WrapMode.CLAMP_TO_EDGE
+                    ))
+                }
+            }
+            mWaterDis?.let {
+                runCatching {
+                    setParameter("refractionMap", it, TextureSampler(
+                        TextureSampler.MinFilter.LINEAR,
+                        TextureSampler.MagFilter.LINEAR,
+                        TextureSampler.WrapMode.CLAMP_TO_EDGE
+                    ))
+                }
             }
         }
     }

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/driver/DriverProfileTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/driver/DriverProfileTest.kt
@@ -1,0 +1,101 @@
+package com.linkpoint.render.driver
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-data tests for [GraphicsDriverProbe.DriverProfile]. The
+ * production probe path needs an Android [Context] which isn't
+ * available under the JVM unit test runner, but the derived
+ * properties (vendor inference, GLES floor, summary) are pure
+ * functions on the data class and easy to exercise.
+ */
+class DriverProfileTest {
+
+    @Test
+    fun `hasVulkan reflects level not version`() {
+        val noVk = GraphicsDriverProbe.DriverProfile.from(glesMajor = 3, glesMinor = 1)
+        assertFalse(noVk.hasVulkan)
+
+        val level0 = GraphicsDriverProbe.DriverProfile.from(3, 1, vulkanLevel = 0)
+        assertTrue("Vulkan level 0 still counts as having a driver", level0.hasVulkan)
+
+        val level1 = GraphicsDriverProbe.DriverProfile.from(3, 1, vulkanLevel = 1)
+        assertTrue(level1.hasVulkan)
+    }
+
+    @Test
+    fun `meetsMinimumGles requires GLES 3_0`() {
+        assertFalse(GraphicsDriverProbe.DriverProfile.from(2, 0).meetsMinimumGles)
+        assertTrue(GraphicsDriverProbe.DriverProfile.from(3, 0).meetsMinimumGles)
+        assertTrue(GraphicsDriverProbe.DriverProfile.from(3, 2).meetsMinimumGles)
+        assertTrue(GraphicsDriverProbe.DriverProfile.from(4, 0).meetsMinimumGles)
+    }
+
+    @Test
+    fun `vendor family inference - Adreno`() {
+        val p = GraphicsDriverProbe.DriverProfile.from(
+            glesMajor = 3, glesMinor = 2,
+            hardware = "qcom", manufacturer = "Qualcomm"
+        )
+        assertEquals(GraphicsDriverProbe.VendorFamily.ADRENO, p.vendorFamily)
+    }
+
+    @Test
+    fun `vendor family inference - Mali`() {
+        val p = GraphicsDriverProbe.DriverProfile.from(
+            glesMajor = 3, glesMinor = 2,
+            hardware = "exynos", manufacturer = "ARM (Mali)"
+        )
+        assertEquals(GraphicsDriverProbe.VendorFamily.MALI, p.vendorFamily)
+    }
+
+    @Test
+    fun `vendor family inference - PowerVR`() {
+        val p = GraphicsDriverProbe.DriverProfile.from(
+            glesMajor = 3, glesMinor = 1,
+            hardware = "mediatek", manufacturer = "Imagination Technologies"
+        )
+        assertEquals(GraphicsDriverProbe.VendorFamily.POWERVR, p.vendorFamily)
+    }
+
+    @Test
+    fun `vendor family inference - Xclipse Samsung`() {
+        val p = GraphicsDriverProbe.DriverProfile.from(
+            glesMajor = 3, glesMinor = 2,
+            hardware = "exynos2200", manufacturer = "samsung"
+        )
+        assertEquals(GraphicsDriverProbe.VendorFamily.XCLIPSE, p.vendorFamily)
+    }
+
+    @Test
+    fun `vendor family inference - unknown`() {
+        val p = GraphicsDriverProbe.DriverProfile.from(
+            glesMajor = 3, glesMinor = 0,
+            hardware = "novel-soc", manufacturer = "future-corp"
+        )
+        assertEquals(GraphicsDriverProbe.VendorFamily.UNKNOWN, p.vendorFamily)
+    }
+
+    @Test
+    fun `summary mentions Vulkan presence and AEP`() {
+        val s = GraphicsDriverProbe.DriverProfile.from(
+            glesMajor = 3, glesMinor = 2,
+            vulkanLevel = 1, vulkanVersion = 0x40300, vulkanDeqp = 132317184,
+            aep = true,
+            hardware = "qcom", manufacturer = "qualcomm"
+        ).summary()
+        assertTrue(s, s.contains("GLES 3.2"))
+        assertTrue(s, s.contains("AEP"))
+        assertTrue(s, s.contains("Vulkan"))
+        assertTrue(s, s.contains("ADRENO"))
+    }
+
+    @Test
+    fun `UNKNOWN profile fails minimum check`() {
+        assertFalse(GraphicsDriverProbe.DriverProfile.UNKNOWN.meetsMinimumGles)
+        assertFalse(GraphicsDriverProbe.DriverProfile.UNKNOWN.hasVulkan)
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/driver/FeatureFlagsResolverTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/driver/FeatureFlagsResolverTest.kt
@@ -1,0 +1,166 @@
+package com.linkpoint.render.driver
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-math tests for [resolveFeatureFlags]. These exercise the
+ * actual decisions a real device would produce — capability flags
+ * are the floor under every optional render pass, so a regression
+ * here means the renderer would either crash on a low-end device or
+ * skip a feature it could otherwise have used.
+ */
+class FeatureFlagsResolverTest {
+
+    private val noVulkan = GraphicsDriverProbe.DriverProfile.from(glesMajor = 3, glesMinor = 1)
+    private val withVulkan = GraphicsDriverProbe.DriverProfile.from(
+        glesMajor = 3, glesMinor = 2,
+        vulkanLevel = 1, vulkanVersion = 0x40300, vulkanDeqp = 132317184
+    )
+
+    private fun caps(
+        glVersion: Int = 31,
+        vendor: GraphicsDriverProbe.VendorFamily = GraphicsDriverProbe.VendorFamily.ADRENO,
+        extensions: Set<String> = emptySet(),
+        maxTex: Int = 4096,
+        maxRb: Int = 4096,
+        maxAniso: Float = 1f
+    ): GpuCapabilities = GpuCapabilities(
+        glVersion = glVersion,
+        vendor = vendor,
+        rendererString = "test",
+        vendorString = "test",
+        versionString = "OpenGL ES $glVersion.0",
+        extensions = extensions,
+        maxTextureSize = maxTex,
+        maxRenderbufferSize = maxRb,
+        maxSamples = 4,
+        maxUniformBlockSize = 16384,
+        maxAnisotropy = maxAniso
+    )
+
+    @Test
+    fun `low end GLES 3_0 enables FXAA + occlusion but not reflections`() {
+        val flags = resolveFeatureFlags(noVulkan, caps(glVersion = 30, maxTex = 2048, maxRb = 2048))
+        assertTrue("FXAA needs only GLES 3.0 + 1024 max tex", flags.fxaa)
+        assertTrue("Occlusion queries are GLES 3.0 baseline", flags.occlusionQueries)
+        assertFalse("Reflections require GLES 3.1+", flags.waterPlanarReflections)
+        assertFalse("No compute on GLES 3.0", flags.computeShaders)
+    }
+
+    @Test
+    fun `GLES 3_1 with large max texture enables reflections and compute`() {
+        val flags = resolveFeatureFlags(noVulkan, caps(glVersion = 31, maxTex = 4096, maxRb = 4096))
+        assertTrue(flags.waterPlanarReflections)
+        assertTrue(flags.computeShaders)
+    }
+
+    @Test
+    fun `tiny max texture disables FXAA`() {
+        val flags = resolveFeatureFlags(noVulkan, caps(glVersion = 30, maxTex = 512))
+        assertFalse(flags.fxaa)
+    }
+
+    @Test
+    fun `pre-GLES 3_0 disables every optional pass`() {
+        val flags = resolveFeatureFlags(noVulkan, caps(glVersion = 20))
+        assertFalse(flags.fxaa)
+        assertFalse(flags.occlusionQueries)
+        assertFalse(flags.waterPlanarReflections)
+        assertFalse(flags.computeShaders)
+    }
+
+    @Test
+    fun `persistent mapped UBO enabled when extension present and vendor not powervr`() {
+        val flags = resolveFeatureFlags(
+            noVulkan,
+            caps(extensions = setOf("GL_EXT_buffer_storage"))
+        )
+        assertTrue(flags.persistentMappedUBO)
+    }
+
+    @Test
+    fun `persistent mapped UBO disabled on PowerVR even with extension`() {
+        val flags = resolveFeatureFlags(
+            noVulkan,
+            caps(
+                vendor = GraphicsDriverProbe.VendorFamily.POWERVR,
+                extensions = setOf("GL_EXT_buffer_storage")
+            )
+        )
+        assertFalse("PowerVR persistent maps were buggy through 2022", flags.persistentMappedUBO)
+    }
+
+    @Test
+    fun `persistent mapped UBO disabled when extension absent`() {
+        val flags = resolveFeatureFlags(noVulkan, caps(extensions = emptySet()))
+        assertFalse(flags.persistentMappedUBO)
+    }
+
+    @Test
+    fun `anisotropic filtering requires both extension and max gt 1`() {
+        val noExt = resolveFeatureFlags(noVulkan, caps(maxAniso = 16f))
+        assertFalse(noExt.anisotropicFiltering)
+
+        val noMax = resolveFeatureFlags(
+            noVulkan,
+            caps(extensions = setOf("GL_EXT_texture_filter_anisotropic"), maxAniso = 1f)
+        )
+        assertFalse(noMax.anisotropicFiltering)
+
+        val both = resolveFeatureFlags(
+            noVulkan,
+            caps(extensions = setOf("GL_EXT_texture_filter_anisotropic"), maxAniso = 16f)
+        )
+        assertTrue(both.anisotropicFiltering)
+    }
+
+    @Test
+    fun `Vulkan readiness reflects probe state only`() {
+        // No-Vulkan profile: false regardless of GLES caps.
+        val noVk = resolveFeatureFlags(noVulkan, caps(glVersion = 32))
+        assertFalse(noVk.vulkanReady)
+        // Vulkan-level-0 profile counts as not ready (limited driver).
+        val limited = GraphicsDriverProbe.DriverProfile.from(3, 2, vulkanLevel = 0)
+        assertFalse(resolveFeatureFlags(limited, caps()).vulkanReady)
+        // Full Vulkan: ready.
+        assertTrue(resolveFeatureFlags(withVulkan, caps()).vulkanReady)
+    }
+
+    @Test
+    fun `tile-based renderer flag matches mobile vendor families`() {
+        for (mobile in listOf(
+            GraphicsDriverProbe.VendorFamily.ADRENO,
+            GraphicsDriverProbe.VendorFamily.MALI,
+            GraphicsDriverProbe.VendorFamily.POWERVR,
+            GraphicsDriverProbe.VendorFamily.XCLIPSE
+        )) {
+            val flags = resolveFeatureFlags(noVulkan, caps(vendor = mobile))
+            assertTrue("$mobile should be tile-based", flags.tileBasedRenderer)
+        }
+        for (desktop in listOf(
+            GraphicsDriverProbe.VendorFamily.TEGRA,
+            GraphicsDriverProbe.VendorFamily.INTEL,
+            GraphicsDriverProbe.VendorFamily.UNKNOWN
+        )) {
+            val flags = resolveFeatureFlags(noVulkan, caps(vendor = desktop))
+            assertFalse("$desktop should not be tile-based", flags.tileBasedRenderer)
+        }
+    }
+
+    @Test
+    fun `ALL_OFF defaults safe`() {
+        // Sanity: every optional feature defaults to off when the
+        // renderer hasn't yet resolved a capability snapshot.
+        assertEquals(false, FeatureFlags.ALL_OFF.fxaa)
+        assertEquals(false, FeatureFlags.ALL_OFF.waterPlanarReflections)
+        assertEquals(false, FeatureFlags.ALL_OFF.occlusionQueries)
+        assertEquals(false, FeatureFlags.ALL_OFF.persistentMappedUBO)
+        assertEquals(false, FeatureFlags.ALL_OFF.anisotropicFiltering)
+        assertEquals(false, FeatureFlags.ALL_OFF.computeShaders)
+        assertEquals(false, FeatureFlags.ALL_OFF.vulkanReady)
+        assertEquals(false, FeatureFlags.ALL_OFF.tileBasedRenderer)
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt
@@ -9,6 +9,31 @@ import org.junit.Test
 class LumiyaFramePlannerTest {
 
     @Test
+    fun `emissive pass runs after transparent and before water in normal frames`() {
+        val plan = LumiyaFramePlanner.createPlan(
+            worldPassEnabled = true,
+            hasHudElements = false,
+            interactiveThrottle = false
+        )
+        val emissiveIdx = plan.indexOf(LumiyaRenderPass.WORLD_EMISSIVE)
+        val transparentIdx = plan.indexOf(LumiyaRenderPass.WORLD_TRANSPARENT)
+        val waterIdx = plan.indexOf(LumiyaRenderPass.WORLD_WATER)
+        assertTrue("emissive present", emissiveIdx >= 0)
+        assertTrue("emissive after transparent", emissiveIdx > transparentIdx)
+        assertTrue("emissive before water", emissiveIdx < waterIdx)
+    }
+
+    @Test
+    fun `interactive throttle drops the emissive pass`() {
+        val plan = LumiyaFramePlanner.createPlan(
+            worldPassEnabled = true,
+            hasHudElements = false,
+            interactiveThrottle = true
+        )
+        assertFalse(plan.contains(LumiyaRenderPass.WORLD_EMISSIVE))
+    }
+
+    @Test
     fun `includes HUD pass when world pass is disabled`() {
         val plan = LumiyaFramePlanner.createPlan(
             worldPassEnabled = false,

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/drawable/HoverTextDistanceFadeTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/drawable/HoverTextDistanceFadeTest.kt
@@ -1,0 +1,53 @@
+package com.linkpoint.render.lumiya.drawable
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Distance-fade math for [DrawableHoverText]. The geometric scaling
+ * keeps text legible up to ~4x the texture pixel size, but a separate
+ * distance-fade tapers alpha to zero past the chat radius so cluttered
+ * regions stay readable.
+ *
+ * The fade lives on [DrawableHoverText.Companion.fadeFactorAt] so it
+ * can be exercised without instantiating the class — the constructor
+ * builds an Android `Paint` which is unavailable under the JVM unit
+ * test runner.
+ */
+class HoverTextDistanceFadeTest {
+
+    @Test
+    fun `inside fade-start returns full alpha`() {
+        assertEquals(1f, DrawableHoverText.fadeFactorAt(0f), 1e-5f)
+        assertEquals(1f, DrawableHoverText.fadeFactorAt(DrawableHoverText.FADE_START_DISTANCE - 0.1f), 1e-5f)
+        assertEquals(1f, DrawableHoverText.fadeFactorAt(DrawableHoverText.FADE_START_DISTANCE), 1e-5f)
+    }
+
+    @Test
+    fun `past fade-end returns zero alpha`() {
+        assertEquals(0f, DrawableHoverText.fadeFactorAt(DrawableHoverText.FADE_END_DISTANCE), 1e-5f)
+        assertEquals(0f, DrawableHoverText.fadeFactorAt(DrawableHoverText.FADE_END_DISTANCE + 5f), 1e-5f)
+        assertEquals(0f, DrawableHoverText.fadeFactorAt(1000f), 1e-5f)
+    }
+
+    @Test
+    fun `midpoint reports half alpha`() {
+        val mid = (DrawableHoverText.FADE_START_DISTANCE + DrawableHoverText.FADE_END_DISTANCE) / 2f
+        assertEquals(0.5f, DrawableHoverText.fadeFactorAt(mid), 1e-5f)
+    }
+
+    @Test
+    fun `fade is monotonically non-increasing across the band`() {
+        val start = DrawableHoverText.FADE_START_DISTANCE
+        val end = DrawableHoverText.FADE_END_DISTANCE
+        var prev = 1f
+        var d = start
+        while (d <= end) {
+            val v = DrawableHoverText.fadeFactorAt(d)
+            assertTrue("fade should not increase: prev=$prev v=$v at d=$d", v <= prev + 1e-5f)
+            prev = v
+            d += (end - start) / 16f
+        }
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/spatial/FrustumCullerTriStateTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/spatial/FrustumCullerTriStateTest.kt
@@ -1,0 +1,88 @@
+package com.linkpoint.render.lumiya.spatial
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tri-state classification of AABBs against a hand-built unit frustum.
+ *
+ * The default [FrustumCuller.extractPlanes] runs a chain of GLES
+ * matrix multiplies that don't return useful values under the JVM
+ * unit test runner; using [FrustumCuller.setPlaneForTest] lets us
+ * verify the new tri-state logic directly.
+ *
+ * Frustum (axis-aligned cube from [-1, 1]^3 in world space):
+ *   plane 0: +x ≥ -1     (left)         (1,0,0,1)
+ *   plane 1: -x ≥ -1     (right)        (-1,0,0,1)
+ *   plane 2: +y ≥ -1     (bottom)       (0,1,0,1)
+ *   plane 3: -y ≥ -1     (top)          (0,-1,0,1)
+ *   plane 4: +z ≥ -1     (near)         (0,0,1,1)
+ *   plane 5: -z ≥ -1     (far)          (0,0,-1,1)
+ */
+class FrustumCullerTriStateTest {
+
+    private fun unitFrustum(): FrustumCuller {
+        val c = FrustumCuller()
+        c.setPlaneForTest(0,  1f,  0f,  0f, 1f)
+        c.setPlaneForTest(1, -1f,  0f,  0f, 1f)
+        c.setPlaneForTest(2,  0f,  1f,  0f, 1f)
+        c.setPlaneForTest(3,  0f, -1f,  0f, 1f)
+        c.setPlaneForTest(4,  0f,  0f,  1f, 1f)
+        c.setPlaneForTest(5,  0f,  0f, -1f, 1f)
+        return c
+    }
+
+    @Test
+    fun `box fully inside reports INSIDE`() {
+        val c = unitFrustum()
+        assertEquals(
+            FrustumResult.INSIDE,
+            c.classifyAABB(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f)
+        )
+    }
+
+    @Test
+    fun `box straddling a plane reports INTERSECTS`() {
+        val c = unitFrustum()
+        assertEquals(
+            FrustumResult.INTERSECTS,
+            c.classifyAABB(-2f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f)
+        )
+    }
+
+    @Test
+    fun `box completely outside reports OUTSIDE`() {
+        val c = unitFrustum()
+        assertEquals(
+            FrustumResult.OUTSIDE,
+            c.classifyAABB(2f, 2f, 2f, 3f, 3f, 3f)
+        )
+    }
+
+    @Test
+    fun `box exactly tangent to a plane is INTERSECTS not OUTSIDE`() {
+        val c = unitFrustum()
+        // maxX == 1 (right plane), positive corner gives 0, negative
+        // corner gives 1 → straddles.
+        assertEquals(
+            FrustumResult.INTERSECTS,
+            c.classifyAABB(0.5f, -0.5f, -0.5f, 1f, 0.5f, 0.5f)
+        )
+    }
+
+    @Test
+    fun `binary helper agrees with non-OUTSIDE classification`() {
+        val c = unitFrustum()
+        val inside = c.classifyAABB(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f)
+        val intersects = c.classifyAABB(-2f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f)
+        val outside = c.classifyAABB(2f, 2f, 2f, 3f, 3f, 3f)
+        assertEquals(true, c.isAABBVisible(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f))
+        assertEquals(true, c.isAABBVisible(-2f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f))
+        assertEquals(false, c.isAABBVisible(2f, 2f, 2f, 3f, 3f, 3f))
+        // Sanity: the tri-state result should never disagree with the
+        // binary visible test in either direction.
+        assertEquals(inside != FrustumResult.OUTSIDE, true)
+        assertEquals(intersects != FrustumResult.OUTSIDE, true)
+        assertEquals(outside == FrustumResult.OUTSIDE, true)
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/spatial/SpatialEntryRotatedAabbTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/spatial/SpatialEntryRotatedAabbTest.kt
@@ -1,0 +1,96 @@
+package com.linkpoint.render.lumiya.spatial
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Conservative OBB → AABB widening for [SpatialEntry.fromOrientedBox].
+ * Pure math; no GLES dependency.
+ */
+class SpatialEntryRotatedAabbTest {
+
+    private fun identity4(): FloatArray = floatArrayOf(
+        1f, 0f, 0f, 0f,
+        0f, 1f, 0f, 0f,
+        0f, 0f, 1f, 0f,
+        0f, 0f, 0f, 1f
+    )
+
+    /** Column-major rotation about the world Z axis. */
+    private fun rotZ(rad: Float): FloatArray {
+        val c = cos(rad)
+        val s = sin(rad)
+        return floatArrayOf(
+            c,  s, 0f, 0f,
+           -s,  c, 0f, 0f,
+            0f, 0f, 1f, 0f,
+            0f, 0f, 0f, 1f
+        )
+    }
+
+    @Test
+    fun `identity rotation leaves half extents unchanged`() {
+        val (wx, wy, wz) = SpatialEntry.conservativeWorldHalfExtents(
+            halfX = 2f, halfY = 1f, halfZ = 0.5f,
+            rotation = identity4()
+        )
+        assertEquals(2f, wx, 1e-5f)
+        assertEquals(1f, wy, 1e-5f)
+        assertEquals(0.5f, wz, 1e-5f)
+    }
+
+    @Test
+    fun `45 degree rotation about Z over-estimates conservatively`() {
+        // 2x1x0.5 prim rotated 45 degrees about Z. The XY footprint
+        // becomes the diagonal of the local 2x1 rectangle projected
+        // onto each axis: |cos|*hx + |sin|*hy = (|cos|*2 + |sin|*1).
+        val rad = (PI / 4).toFloat()
+        val (wx, wy, wz) = SpatialEntry.conservativeWorldHalfExtents(
+            halfX = 2f, halfY = 1f, halfZ = 0.5f,
+            rotation = rotZ(rad)
+        )
+        val expectedXY = (sqrt(2.0) / 2.0).toFloat() * 2f + (sqrt(2.0) / 2.0).toFloat() * 1f
+        assertEquals(expectedXY, wx, 1e-5f)
+        assertEquals(expectedXY, wy, 1e-5f)
+        // Z is unaffected by Z-axis rotation.
+        assertEquals(0.5f, wz, 1e-5f)
+        // The over-estimate must always cover the local extents.
+        assertTrue("rotated XY width must be ≥ original max half extent",
+            wx >= 2f - 1e-5f)
+    }
+
+    @Test
+    fun `90 degree rotation swaps X and Y extents`() {
+        val rad = (PI / 2).toFloat()
+        val (wx, wy, wz) = SpatialEntry.conservativeWorldHalfExtents(
+            halfX = 3f, halfY = 1f, halfZ = 0.5f,
+            rotation = rotZ(rad)
+        )
+        assertEquals(1f, wx, 1e-5f)
+        assertEquals(3f, wy, 1e-5f)
+        assertEquals(0.5f, wz, 1e-5f)
+    }
+
+    @Test
+    fun `fromOrientedBox factory preserves position and applies widening`() {
+        val rad = (PI / 4).toFloat()
+        val entry = SpatialEntry.fromOrientedBox(
+            id = 7L,
+            posX = 100f, posY = 50f, posZ = 25f,
+            halfX = 2f, halfY = 1f, halfZ = 0.5f,
+            rotation = rotZ(rad)
+        )
+        assertEquals(100f, entry.posX, 0f)
+        assertEquals(50f, entry.posY, 0f)
+        assertEquals(25f, entry.posZ, 0f)
+        // World-space half extent must exceed the original max
+        // half-extent along the rotated axis.
+        assertTrue(entry.halfExtentX > 2f - 1e-5f)
+        assertTrue(entry.halfExtentY > 1f - 1e-5f)
+    }
+}


### PR DESCRIPTION
## Summary

Two commits, focused on the GL ES (Lumiya) renderer:

**1. Singularity-alignment work-list items** (`154db7f4`)
- Spatial bridges for rotated AABBs — `SpatialEntry.fromOrientedBox` / `conservativeWorldHalfExtents` widens local OBBs into a conservative world-space AABB so rotated long thin prims don't pop in/out of frustum / octree cells.
- Tri-state frustum result (`FrustumResult.OUTSIDE/INTERSECTS/INSIDE`) + `FrustumCuller.classifyAABB`. `SpatialIndex` octree drains whole subtrees when a parent node is fully inside, matching `LLVolumeOctree::cull`.
- Glow / emissive double-pass — `TextureEntryParser` now decodes the per-face glow byte; `DrawablePrimStore.drawEmissive` re-draws glowing faces with additive blend; new `WORLD_EMISSIVE` slot in the frame planner; skipped during interactive throttle.
- Water reflection / refraction FBOs (`mWaterRef` / `mWaterDis`) on `LumiyaRenderContext`, half-resolution by default, toggled via `setWaterPlanarReflectionsEnabled`. Filament `WaterRenderer.setReflectionRefractionTargets` for binding.
- Hover text distance fade — `DrawableHoverText.fadeFactorAt` tapers alpha 16m → 32m alongside the existing geometric scaling.

**2. Driver capability probe + feature gates** (`f179ad28`)
- New `com.linkpoint.render.driver` package with `GraphicsDriverProbe` (pre-context: PackageManager + ActivityManager — captures Vulkan level / version / dEQP, OpenGL ES AEP, vendor family from `Build.HARDWARE`/`MANUFACTURER`) and `GpuCapabilities` (post-context: GL version, refined vendor, full extension set, max texture / renderbuffer / sample / anisotropy limits).
- `resolveFeatureFlags(profile, caps)` is the single source of truth for `persistentMappedUBO`, `occlusionQueries`, `fxaa`, `waterPlanarReflections`, `anisotropicFiltering`, `computeShaders`, `vulkanReady`, `tileBasedRenderer`. Includes the PowerVR persistent-map workaround.
- `LumiyaRenderer.initialize()` probes the device, hard-aborts below GLES 3.0, silently downgrades `fxaaEnabled` if the driver can't deliver; `setWaterPlanarReflectionsEnabled` returns whether the toggle took effect; `OcclusionQuerySet` defaults to disabled (matching its docstring); `RenderDiagnostics.glDriverCapabilities` writes profile + caps + flags to the session log.

## Test plan
- [ ] `./gradlew :Linkpoint:test` — runs the new pure-math test suites: `FrustumCullerTriStateTest`, `SpatialEntryRotatedAabbTest`, `HoverTextDistanceFadeTest`, plus emissive-pass ordering in `LumiyaFramePlannerTest`, plus `FeatureFlagsResolverTest` and `DriverProfileTest`.
- [ ] On-device smoke test: install on a Snapdragon (Adreno) and a Mali device, confirm `RenderDiagnostics` `driver_caps` entry shows the expected vendor family and the rendered scene matches the previous build.
- [ ] On-device check that `setWaterPlanarReflectionsEnabled(true)` returns `true` on a GLES 3.1+ device and `false` on a GLES 3.0-only device, and that the FBOs are/aren't actually allocated.
- [ ] Confirm a Vulkan-capable device logs `vulkanReady=true` in the `driver_caps` line (no Vulkan backend yet — flag is informational for now).

https://claude.ai/code/session_01Tj4SqCa4SV67jhRpvG8bzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj4SqCa4SV67jhRpvG8bzE)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the Android GL ES renderer with sophisticated graphics driver capability detection and several rendering improvements aligned with Singularity viewer features. The **first major component** introduces a comprehensive driver capability system (`GraphicsDriverProbe`, `GpuCapabilities`, `FeatureFlags`) that probes devices before and after GL context creation to determine which optional rendering features are safe to enable, including vendor-specific workarounds (e.g., PowerVR persistent-map issues). The **second major component** implements five Singularity-alignment rendering features: rotated AABB spatial bridges to prevent frustum culling artifacts on rotated prims, tri-state frustum classification for efficient octree traversal, an emissive/glow double-pass with additive blending, water reflection/refraction FBOs at half-resolution, and distance-based hover text alpha fading. The capability gates ensure features like FXAA and water reflections are only enabled when the driver can actually support them, preventing context loss on low-end devices.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/driver/GraphicsDriverProbe.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/driver/GpuCapabilities.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/render/driver/DriverProfileTest.kt` |
| 4 | `Linkpoint/src/test/kotlin/com/linkpoint/render/driver/FeatureFlagsResolverTest.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderContext.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/render/RenderDiagnostics.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/FrustumResult.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/FrustumCuller.kt` |
| 10 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/spatial/FrustumCullerTriStateTest.kt` |
| 11 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/SpatialIndex.kt` |
| 12 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/spatial/SpatialEntryRotatedAabbTest.kt` |
| 13 | `Linkpoint/src/main/java/com/linkpoint/protocol/textures/TextureEntryParser.kt` |
| 14 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaFramePlanner.kt` |
| 15 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawablePrimStore.kt` |
| 16 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/core/LumiyaFramePlannerTest.kt` |
| 17 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/drawable/DrawableHoverText.kt` |
| 18 | `Linkpoint/src/test/kotlin/com/linkpoint/render/lumiya/drawable/HoverTextDistanceFadeTest.kt` |
| 19 | `Linkpoint/src/main/java/com/linkpoint/render/water/WaterRenderer.kt` |
| 20 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/spatial/OcclusionQuerySet.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-face glow and emissive rendering with a dedicated render pass.
  * Added planar water reflection and refraction support with configurable framebuffers.
  * Added distance-based fading for hover text labels.
  * Enhanced frustum culling with tri-state AABB classification for improved visibility detection.

* **Tests**
  * Added comprehensive test coverage for graphics driver detection, feature flags, emissive rendering, water systems, frustum culling, and hover text fading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->