### PR TITLE
Map RegionHandshake fields into canonical session state with validation/logging

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt
@@ -1318,6 +1318,7 @@ class LinkpointApp : Application() {
             Log.i(TAG, "║ ⭐ REGION_HANDSHAKE RECEIVED (CRITICAL MESSAGE)")
             Log.i(TAG, "╚══════════════════════════════════════════════════════════════════")
             Log.d(TAG, "RegionHandshake raw packet size: ${rawPacket.size} bytes")
+            val packetSequence = com.linkpoint.protocol.messages.MessageParser.extractSequenceNumber(rawPacket)
             try {
                 // Extract payload from raw packet (skip header and message ID)
                 val payload = com.linkpoint.protocol.messages.MessageParser.extractPayload(rawPacket)
@@ -1333,21 +1334,24 @@ class LinkpointApp : Application() {
                 
                 val regionData = com.linkpoint.protocol.messages.MessageParser.parseRegionHandshake(payload)
                 if (regionData != null) {
-                    Log.i(TAG, "RegionHandshake parsed: simName='${regionData.simName}'")
+                    Log.i(
+                        TAG,
+                        "RegionHandshake accepted seq=$packetSequence simName='${regionData.simName}' regionId=${regionData.regionId} flags=${regionData.regionFlags} flagsExt=${regionData.regionFlagsExtended}"
+                    )
                     com.linkpoint.utils.InitializationTracker.logInfo("Region: ${regionData.simName}")
-                    
-                    // Update session with region info
-                    // Parser already trims null padding; trim whitespace for display safety.
-                    val regionName = regionData.simName.trim()
-                    if (regionName.isNotEmpty()) {
-                        sessionManager.updateRegionName(regionName)
-                        Log.d(TAG, "Session region name updated to: $regionName")
-                        com.linkpoint.utils.SessionLogRecorder.logRegionChange(
-                            regionName, null, null
-                        )
-                    } else {
-                        Log.w(TAG, "RegionHandshake simName was empty after trimming")
-                    }
+
+                    // Canonical handshake -> session mapping
+                    sessionManager.updateFromRegionHandshake(
+                        simName = regionData.simName,
+                        regionId = regionData.regionId,
+                        regionFlags = regionData.regionFlags,
+                        regionFlagsExtended = regionData.regionFlagsExtended,
+                        simAccess = regionData.simAccess
+                    )
+                    Log.d(TAG, "Session region state updated from RegionHandshake")
+                    com.linkpoint.utils.SessionLogRecorder.logRegionChange(
+                        regionData.simName, null, null
+                    )
                     
                     // Update terrain manager with water height
                     if (::terrainManager.isInitialized) {
@@ -1412,7 +1416,7 @@ class LinkpointApp : Application() {
                     }
                 } else {
                     com.linkpoint.utils.InitializationTracker.logWarning("RegionHandshake parse returned null")
-                    Log.w(TAG, "RegionHandshake parse returned null - payload may be malformed")
+                    Log.w(TAG, "RegionHandshake rejected seq=$packetSequence payloadBytes=${payload.size}")
                 }
             } catch (e: Exception) {
                 com.linkpoint.utils.InitializationTracker.failPhase(

--- a/Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt
@@ -30,6 +30,9 @@ class SessionManager(private val context: Context) {
     
     private val _currentRegion = MutableStateFlow<RegionInfo?>(null)
     val currentRegion: StateFlow<RegionInfo?> = _currentRegion
+
+    private val _regionSessionState = MutableStateFlow(RegionSessionState())
+    val regionSessionState: StateFlow<RegionSessionState> = _regionSessionState
     
     // Teleport history
     private val _teleportHistory = MutableStateFlow<List<TeleportHistoryEntry>>(emptyList())
@@ -119,6 +122,30 @@ class SessionManager(private val context: Context) {
             _currentRegion.value = current.copy(name = regionName)
             Log.i(TAG, "Region name updated: ${current.name} -> $regionName")
         }
+        _regionSessionState.value = _regionSessionState.value.copy(simName = regionName)
+    }
+
+    /**
+     * Canonical mapping from RegionHandshake fields into a single session object.
+     */
+    fun updateFromRegionHandshake(
+        simName: String,
+        regionId: UUID?,
+        regionFlags: Int,
+        regionFlagsExtended: Long?,
+        simAccess: Int
+    ) {
+        val trimmedName = simName.trim()
+        if (trimmedName.isNotEmpty()) {
+            updateRegionName(trimmedName)
+        }
+        _regionSessionState.value = _regionSessionState.value.copy(
+            simName = trimmedName,
+            regionId = regionId,
+            regionFlags = regionFlags,
+            regionFlagsExtended = regionFlagsExtended,
+            simAccess = simAccess
+        )
     }
     
     /**
@@ -428,6 +455,14 @@ data class RegionInfo(
     val simPort: Int,
     val seedCapability: String? = null,
     val waterHeight: Float = 20f
+)
+
+data class RegionSessionState(
+    val simName: String = "",
+    val regionId: UUID? = null,
+    val regionFlags: Int = 0,
+    val regionFlagsExtended: Long? = null,
+    val simAccess: Int = 0
 )
 
 data class TeleportHistoryEntry(

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt
@@ -25,6 +25,7 @@ object MessageParser {
     
     /** Packet header size: flags (1) + sequence (4) + extra (1) = 6 bytes */
     private const val PACKET_HEADER_SIZE = 6
+    private const val REGION_HANDSHAKE_MIN_BYTES = 189
     
     /**
      * Extract the payload portion from a raw UDP packet.
@@ -149,6 +150,14 @@ object MessageParser {
         val shortValue = ((byte3 shl 8) or byte4).toShort().toInt()
 
         return shortValue or -65536
+    }
+
+    fun extractSequenceNumber(rawPacket: ByteArray): Int {
+        if (rawPacket.size < 5) return -1
+        return ((rawPacket[1].toInt() and 0xFF) shl 24) or
+            ((rawPacket[2].toInt() and 0xFF) shl 16) or
+            ((rawPacket[3].toInt() and 0xFF) shl 8) or
+            (rawPacket[4].toInt() and 0xFF)
     }
     
 
@@ -700,6 +709,10 @@ enum class ChatType(val value: Int) {
  *   - RegionProtocols (U64)
  */
 fun MessageParser.parseRegionHandshake(data: ByteArray): RegionHandshakeData? {
+    if (data.size < REGION_HANDSHAKE_MIN_BYTES) {
+        Log.w(TAG, "RegionHandshake payload too short: ${data.size} bytes (min=$REGION_HANDSHAKE_MIN_BYTES)")
+        return null
+    }
     val buffer = ByteBuffer.wrap(data).order(MESSAGE_BYTE_ORDER)
     
     try {
@@ -711,7 +724,11 @@ fun MessageParser.parseRegionHandshake(data: ByteArray): RegionHandshakeData? {
         val simNameLen = buffer.get().toInt() and 0xFF
         val simNameBytes = ByteArray(simNameLen)
         buffer.get(simNameBytes)
-        val simName = String(simNameBytes, Charsets.UTF_8).trimEnd('\u0000')
+        val simName = String(simNameBytes, Charsets.UTF_8).trimEnd('\u0000').trim()
+        if (simName.isEmpty()) {
+            Log.w(TAG, "RegionHandshake payload rejected: empty SimName")
+            return null
+        }
         
         // SimOwner UUID
         val simOwnerBytes = ByteArray(16)

--- a/Linkpoint/src/test/kotlin/com/linkpoint/core/RegionHandshakeSessionMappingTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/core/RegionHandshakeSessionMappingTest.kt
@@ -1,0 +1,69 @@
+package com.linkpoint.core
+
+import androidx.test.core.app.ApplicationProvider
+import com.linkpoint.protocol.messages.MessageParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.UUID
+
+class RegionHandshakeSessionMappingTest {
+
+    @Test
+    fun `region handshake maps to canonical session and ui state without Unknown fallback`() {
+        val payload = buildRegionHandshakePayload("New Region")
+        val parsed = MessageParser.parseRegionHandshake(payload)
+        assertNotNull(parsed)
+
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val sessionManager = SessionManager(context)
+        sessionManager.updateRegionInfo(regionHandle = 123L, x = 128, y = 128) // seeds "Unknown"
+        sessionManager.updateFromRegionHandshake(
+            simName = parsed!!.simName,
+            regionId = parsed.regionId,
+            regionFlags = parsed.regionFlags,
+            regionFlagsExtended = parsed.regionFlagsExtended,
+            simAccess = parsed.simAccess
+        )
+
+        val canonicalName = sessionManager.regionSessionState.value.simName
+        val regionName = sessionManager.currentRegion.value?.name ?: "Unknown"
+        val uiName = sessionManager.currentRegion.value?.name ?: "Unknown Region"
+
+        assertFalse(canonicalName.isBlank())
+        assertEquals(canonicalName, regionName)
+        assertEquals(canonicalName, uiName)
+        assertFalse(regionName == "Unknown")
+        assertFalse(uiName == "Unknown Region")
+    }
+
+    private fun buildRegionHandshakePayload(simName: String): ByteArray {
+        val simNameBytes = simName.toByteArray(Charsets.UTF_8)
+        val buffer = ByteBuffer.allocate(1024).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.putInt(0xABCD) // RegionFlags
+        buffer.put(13) // SimAccess
+        buffer.put(simNameBytes.size.toByte())
+        buffer.put(simNameBytes)
+        buffer.put(UUID(0L, 1L).toBytes()) // SimOwner
+        buffer.put(0) // IsEstateManager
+        buffer.putFloat(20f)
+        buffer.putFloat(1f)
+        buffer.put(UUID(2L, 3L).toBytes()) // CacheID
+        repeat(8) { buffer.put(UUID(it.toLong(), (it + 1).toLong()).toBytes()) }
+        repeat(4) { buffer.putFloat(0f) }
+        repeat(4) { buffer.putFloat(0f) }
+        buffer.put(UUID(9L, 10L).toBytes()) // RegionID
+        return buffer.array().copyOf(buffer.position())
+    }
+
+    private fun UUID.toBytes(): ByteArray {
+        val bytes = ByteArray(16)
+        val bb = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+        bb.putLong(this.mostSignificantBits)
+        bb.putLong(this.leastSignificantBits)
+        return bytes
+    }
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/RegionHandshakeParserTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/RegionHandshakeParserTest.kt
@@ -2,6 +2,7 @@ package com.linkpoint.protocol.messages
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -15,6 +16,12 @@ class RegionHandshakeParserTest {
         val parsed = MessageParser.parseRegionHandshake(data)
         assertNotNull(parsed)
         assertEquals("TestRegion", parsed?.simName)
+    }
+
+    @Test
+    fun `parseRegionHandshake rejects partial or empty payload`() {
+        assertNull(MessageParser.parseRegionHandshake(byteArrayOf()))
+        assertNull(MessageParser.parseRegionHandshake(ByteArray(10)))
     }
 
     private fun buildRegionHandshakePayload(simName: String): ByteArray {


### PR DESCRIPTION
### Motivation
- Prevent malformed or partial `RegionHandshake` packets from silently updating session/UI state and provide a single authoritative mapping of handshake fields into session state.
- Improve diagnostics by including UDP packet sequence and region identifiers/flags in structured logs to aid troubleshooting during world load.
- Ensure UI/diagnostics and internal canonical session state agree once a valid handshake is received, avoiding fallbacks to placeholder names like `Unknown`.

### Description
- Add a canonical handshake state: introduced `RegionSessionState` and a `regionSessionState` `StateFlow` in `SessionManager`, plus `updateFromRegionHandshake(...)` to map `SimName`, `RegionID`, `RegionFlags`, `RegionFlagsExtended`, and `SimAccess` into one source of truth, and make `updateRegionName` sync the canonical state (`Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt`).
- Harden `RegionHandshake` parsing in `MessageParser` by adding `REGION_HANDSHAKE_MIN_BYTES`, rejecting payloads below the minimum and rejecting empty `SimName` values, and exposing `extractSequenceNumber(rawPacket)` for packet-level diagnostics (`Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt`).
- Add structured logging and canonical mapping in the UDP handler: `LinkpointApp` now extracts packet sequence, logs accepted/rejected handshakes with sequence + region id/flags, routes handshake fields into `SessionManager.updateFromRegionHandshake(...)`, and records region change events (`Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt`).
- Tests: added `RegionHandshakeSessionMappingTest` to assert canonical name mapping and UI/diagnostics alignment, and extended `RegionHandshakeParserTest` to verify parser rejects empty/partial payloads (`Linkpoint/src/test/...`).

### Testing
- Ran targeted unit tests via Gradle for the new/modified parser and mapping tests using `./gradlew -p Linkpoint test --tests com.linkpoint.protocol.messages.RegionHandshakeParserTest --tests com.linkpoint.core.RegionHandshakeSessionMappingTest`, which failed to execute due to the build environment lacking Android SDK configuration (missing `ANDROID_HOME` / `local.properties` `sdk.dir`).
- Local unit test assertions added: parser rejects empty/too-short payloads (`RegionHandshakeParserTest`), and canonical session mapping test asserts non-empty canonical `simName`, that `currentRegion.name` matches canonical name, and that no fallback to `Unknown` occurs (`RegionHandshakeSessionMappingTest`).
- No other automated test runs completed in this environment due to the SDK configuration limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f807902aa883238fd22749729afd95)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a canonical mapping layer for `RegionHandshake` packet fields into session state with enhanced validation and diagnostics. It adds a new `RegionSessionState` data class and `updateFromRegionHandshake` method in `SessionManager` to serve as a single source of truth for region metadata (sim name, region ID, flags, access level). The `MessageParser` now validates `RegionHandshake` packets by rejecting payloads that are too short or contain empty region names, and exposes `extractSequenceNumber` for packet-level diagnostics. The UDP handler in `LinkpointApp` now logs accepted/rejected handshakes with packet sequence numbers and region identifiers, routes validated handshake data through the canonical mapping method, and records region change events. Unit tests were added to verify parser rejection of malformed payloads and canonical mapping behavior, ensuring UI and internal state agree without fallback to placeholder names like `Unknown`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageParser.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/LinkpointApp.kt` |
| 4 | `Linkpoint/src/test/kotlin/com/linkpoint/core/RegionHandshakeSessionMappingTest.kt` |
| 5 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/messages/RegionHandshakeParserTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for region connection handshakes with stricter validation of incoming data
  * Enhanced logging for accepted and rejected region connections to aid diagnostics
  * Better region information reliability through improved data parsing and validation

* **Tests**
  * Added test coverage for region handshake parsing and session state mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->