### PR TITLE
Instrument ObjectUpdate flows and add integration coverage

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt
@@ -28,6 +28,19 @@ import java.util.concurrent.ConcurrentHashMap
 class ObjectManager(
     private val udpConnection: UDPConnectionFixed
 ) {
+    enum class RejectReason {
+        ZERO_FULL_ID,
+        ZERO_LOCAL_ID,
+        LOCAL_ID_UUID_MISMATCH,
+        UNKNOWN_LOCAL_ID
+    }
+    data class UpdateCounters(
+        val packetsReceived: Long,
+        val packetsParsed: Long,
+        val objectsCreatedOrUpdated: Long,
+        val sceneInsertedOrUpdated: Long,
+        val rejected: Map<RejectReason, Long>
+    )
     companion object {
         private const val TAG = "ObjectManager"
         private val MESSAGE_BYTE_ORDER = ByteOrder.LITTLE_ENDIAN
@@ -68,6 +81,17 @@ class ObjectManager(
     }
     
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    @Volatile private var packetsReceived = 0L
+    @Volatile private var packetsParsed = 0L
+    @Volatile private var objectsCreatedOrUpdated = 0L
+    @Volatile private var sceneInsertedOrUpdated = 0L
+    private val rejected = ConcurrentHashMap<RejectReason, Long>()
+    private fun markRejected(reason: RejectReason) {
+        rejected.compute(reason) { _, v -> (v ?: 0L) + 1L }
+    }
+    fun getUpdateCounters(): UpdateCounters = UpdateCounters(
+        packetsReceived, packetsParsed, objectsCreatedOrUpdated, sceneInsertedOrUpdated, rejected.toMap()
+    )
     
     // All objects in scene
     private val objects = ConcurrentHashMap<Int, SceneObject>()
@@ -103,9 +127,26 @@ class ObjectManager(
      * Handle object update from simulator
      */
     fun handleObjectUpdate(data: ObjectUpdateData) {
-        if (data.fullId == ZERO_UUID) {
+        packetsReceived++
+        packetsParsed++
+        if (data.localId == 0) {
+            markRejected(RejectReason.ZERO_LOCAL_ID)
             ScenePopulationDiagnostics.markManagerApplied(ScenePopulationDiagnostics.EntityType.OBJECT, false)
-            Log.w(TAG, "Dropped object update localId=${data.localId} due to zero fullId")
+            Log.w(TAG, "Rejected object update: reason=ZERO_LOCAL_ID fullId=${data.fullId}")
+            return
+        }
+        if (data.fullId == ZERO_UUID) {
+            markRejected(RejectReason.ZERO_FULL_ID)
+            ScenePopulationDiagnostics.markManagerApplied(ScenePopulationDiagnostics.EntityType.OBJECT, false)
+            Log.w(TAG, "Rejected object update: reason=ZERO_FULL_ID localId=${data.localId}")
+            return
+        }
+
+        val existingByLocal = objects[data.localId]
+        if (existingByLocal != null && existingByLocal.fullId != data.fullId) {
+            markRejected(RejectReason.LOCAL_ID_UUID_MISMATCH)
+            ScenePopulationDiagnostics.markManagerApplied(ScenePopulationDiagnostics.EntityType.OBJECT, false)
+            Log.w(TAG, "Rejected object update: reason=LOCAL_ID_UUID_MISMATCH localId=${data.localId} expected=${existingByLocal.fullId} got=${data.fullId}")
             return
         }
 
@@ -136,6 +177,8 @@ class ObjectManager(
         }
         
         objectsByUUID[data.fullId] = obj
+        objectsCreatedOrUpdated++
+        sceneInsertedOrUpdated++
         ScenePopulationDiagnostics.markManagerApplied(ScenePopulationDiagnostics.EntityType.OBJECT, true)
 
         // Apply any ObjectProperties that arrived before this ObjectUpdate.
@@ -146,12 +189,24 @@ class ObjectManager(
      * Handle terse position update
      */
     fun handleTerseUpdate(data: TerseUpdateData) {
+        packetsReceived++
+        packetsParsed++
+        if (data.localId == 0) {
+            markRejected(RejectReason.ZERO_LOCAL_ID)
+            Log.w(TAG, "Rejected terse update: reason=ZERO_LOCAL_ID")
+            return
+        }
         objects[data.localId]?.apply {
             position = data.position
             rotation = data.rotation
             velocity = data.velocity
             angularVelocity = data.angularVelocity
             lastUpdate = System.currentTimeMillis()
+            objectsCreatedOrUpdated++
+            sceneInsertedOrUpdated++
+        } ?: run {
+            markRejected(RejectReason.UNKNOWN_LOCAL_ID)
+            Log.w(TAG, "Rejected terse update: reason=UNKNOWN_LOCAL_ID localId=${data.localId}")
         }
     }
     

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/ObjectMessageParsers.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/ObjectMessageParsers.kt
@@ -9,16 +9,48 @@ import java.nio.ByteOrder
 
 internal object ObjectMessageParsers {
     private const val TAG = "ObjectMessageParsers"
+    enum class RejectReason {
+        TRUNCATED_PACKET,
+        INVALID_BLOCK_LENGTH,
+        ZERO_LOCAL_ID,
+        ZERO_FULL_ID,
+        EXCEPTION
+    }
+    data class ParseCounters(
+        val packetsReceived: Int,
+        val packetsParsed: Int,
+        val objectsCreatedOrUpdated: Int,
+        val rejected: Map<RejectReason, Int>
+    )
+    private val rejectedCounters = mutableMapOf<RejectReason, Int>()
+    @Volatile private var packetsReceived = 0
+    @Volatile private var packetsParsed = 0
+    @Volatile private var objectsCreatedOrUpdated = 0
+    @Synchronized private fun markRejected(reason: RejectReason) {
+        rejectedCounters[reason] = (rejectedCounters[reason] ?: 0) + 1
+    }
+    private fun validateObjectIds(localId: Int, fullId: java.util.UUID): RejectReason? = when {
+        localId == 0 -> RejectReason.ZERO_LOCAL_ID
+        fullId == java.util.UUID(0L, 0L) -> RejectReason.ZERO_FULL_ID
+        else -> null
+    }
+    fun getCounters(): ParseCounters = synchronized(this) {
+        ParseCounters(packetsReceived, packetsParsed, objectsCreatedOrUpdated, rejectedCounters.toMap())
+    }
 
     fun parseObjectUpdate(data: ByteArray): List<ObjectUpdateData> {
         val results = mutableListOf<ObjectUpdateData>()
+        packetsReceived++
         val buffer = ByteBuffer.wrap(data).order(MESSAGE_BYTE_ORDER)
         try {
             val regionHandle = buffer.long
             buffer.short
             val numBlocks = buffer.get().toInt() and 0xFF
             repeat(numBlocks) { parseObjectBlock(buffer, regionHandle)?.let(results::add) }
+            packetsParsed++
+            objectsCreatedOrUpdated += results.size
         } catch (e: Exception) {
+            markRejected(RejectReason.TRUNCATED_PACKET)
             Log.e(TAG, "Failed to parse ObjectUpdate", e)
         }
         return results
@@ -26,13 +58,17 @@ internal object ObjectMessageParsers {
 
     fun parseObjectUpdateCompressed(data: ByteArray): List<ObjectUpdateData> {
         val results = mutableListOf<ObjectUpdateData>()
+        packetsReceived++
         val buffer = ByteBuffer.wrap(data).order(MESSAGE_BYTE_ORDER)
         try {
             val regionHandle = buffer.long
             buffer.short
             val numBlocks = buffer.get().toInt() and 0xFF
             repeat(numBlocks) { parseCompressedBlock(buffer, regionHandle)?.let(results::add) }
+            packetsParsed++
+            objectsCreatedOrUpdated += results.size
         } catch (e: Exception) {
+            markRejected(RejectReason.TRUNCATED_PACKET)
             Log.e(TAG, "Failed to parse ObjectUpdateCompressed", e)
         }
         return results
@@ -40,6 +76,7 @@ internal object ObjectMessageParsers {
 
     fun parseTerseObjectUpdate(data: ByteArray): List<TerseUpdateData> {
         val results = mutableListOf<TerseUpdateData>()
+        packetsReceived++
         val buffer = ByteBuffer.wrap(data).order(MESSAGE_BYTE_ORDER)
         try {
             buffer.long
@@ -53,7 +90,10 @@ internal object ObjectMessageParsers {
                     parseTerseBlock(blockData)?.let(results::add)
                 }
             }
+            packetsParsed++
+            objectsCreatedOrUpdated += results.size
         } catch (e: Exception) {
+            markRejected(RejectReason.TRUNCATED_PACKET)
             Log.e(TAG, "Failed to parse TerseObjectUpdate", e)
         }
         return results
@@ -64,6 +104,11 @@ internal object ObjectMessageParsers {
             val localId = buffer.int
             buffer.get()
             val fullId = buffer.readUuid()
+            validateObjectIds(localId, fullId)?.let {
+                markRejected(it)
+                Log.w(TAG, "Rejected ObjectUpdate block: reason=$it localId=$localId fullId=$fullId")
+                return null
+            }
             buffer.int
             val pcode = buffer.get().toInt() and 0xFF
             val material = buffer.get().toInt() and 0xFF
@@ -129,6 +174,7 @@ internal object ObjectMessageParsers {
                 String(nameValueBytes, Charsets.UTF_8), regionHandle, extraParams, shapeParams
             )
         } catch (e: Exception) {
+            markRejected(RejectReason.EXCEPTION)
             Log.e(TAG, "Failed to parse object block", e)
             null
         }
@@ -142,6 +188,11 @@ internal object ObjectMessageParsers {
 
             val fullId = cb.readUuid()
             val localId = cb.int
+            validateObjectIds(localId, fullId)?.let {
+                markRejected(it)
+                Log.w(TAG, "Rejected ObjectUpdateCompressed block: reason=$it localId=$localId fullId=$fullId")
+                return null
+            }
             val pcode = cb.get().toInt() and 0xFF
             cb.get(); cb.int
             val material = cb.get().toInt() and 0xFF
@@ -173,13 +224,17 @@ internal object ObjectMessageParsers {
                 regionHandle = regionHandle
             )
         } catch (e: Exception) {
+            markRejected(RejectReason.EXCEPTION)
             Log.e(TAG, "Failed to parse compressed block", e)
             null
         }
     }
 
     private fun parseTerseBlock(data: ByteArray): TerseUpdateData? {
-        if (data.size < 30) return null
+        if (data.size < 30) {
+            markRejected(RejectReason.INVALID_BLOCK_LENGTH)
+            return null
+        }
         val bb = ByteBuffer.wrap(data).order(MESSAGE_BYTE_ORDER)
         val localId = bb.int
         val state = bb.get().toInt() and 0xFF
@@ -195,6 +250,11 @@ internal object ObjectMessageParsers {
         bb.position(bb.position() + 8)
         val angularVelocity = if (bb.remaining() >= 6) LLVector3.fromTerse(data, bb.position(), 256f) else LLVector3.zero()
 
+        if (localId == 0) {
+            markRejected(RejectReason.ZERO_LOCAL_ID)
+            Log.w(TAG, "Rejected ImprovedTerseObjectUpdate block: reason=ZERO_LOCAL_ID")
+            return null
+        }
         return TerseUpdateData(localId, isAvatar, position, velocity, acceleration, rotation, angularVelocity)
     }
 

--- a/Linkpoint/src/test/kotlin/com/linkpoint/objects/ObjectUpdateFlowIntegrationTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/objects/ObjectUpdateFlowIntegrationTest.kt
@@ -1,0 +1,81 @@
+package com.linkpoint.objects
+
+import com.linkpoint.protocol.messages.MESSAGE_BYTE_ORDER
+import com.linkpoint.protocol.messages.ObjectMessageParsers
+import com.linkpoint.protocol.messages.UDPConnectionFixed
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.util.UUID
+
+class ObjectUpdateFlowIntegrationTest {
+    @Test
+    fun objectUpdateCompressedAndTerse_endToEnd_insertsObjectIntoSceneState() {
+        val objectManager = ObjectManager(UDPConnectionFixed())
+        val fullId = UUID.fromString("11111111-2222-3333-4444-555555555555")
+        val localId = 9001
+
+        val parsedCompressed = ObjectMessageParsers.parseObjectUpdateCompressed(buildObjectUpdateCompressedPacket(localId, fullId))
+        assertTrue(parsedCompressed.isNotEmpty())
+        parsedCompressed.forEach { objectManager.handleObjectUpdate(it) }
+
+        val parsedTerse = ObjectMessageParsers.parseTerseObjectUpdate(buildImprovedTersePacket(localId))
+        assertTrue(parsedTerse.isNotEmpty())
+        parsedTerse.forEach { objectManager.handleTerseUpdate(it) }
+
+        assertTrue(objectManager.getAllObjects().isNotEmpty())
+        val inserted = objectManager.getObject(localId)
+        assertNotNull(inserted)
+        assertEquals(fullId, inserted?.fullId)
+
+        val counters = objectManager.getUpdateCounters()
+        assertTrue(counters.packetsReceived >= 2)
+        assertTrue(counters.packetsParsed >= 2)
+        assertTrue(counters.objectsCreatedOrUpdated >= 2)
+        assertTrue(counters.sceneInsertedOrUpdated >= 2)
+    }
+
+    private fun buildObjectUpdateCompressedPacket(localId: Int, fullId: UUID): ByteArray {
+        val compressedBlock = ByteBuffer.allocate(62).order(MESSAGE_BYTE_ORDER).apply {
+            putLong(fullId.mostSignificantBits)
+            putLong(fullId.leastSignificantBits)
+            putInt(localId)
+            put(9)
+            put(0)
+            putInt(0)
+            put(3)
+            put(0)
+            repeat(3) { putFloat(1f) }
+            repeat(3) { putFloat(10f) }
+            putFloat(0f); putFloat(0f); putFloat(0f)
+            putInt(0)
+        }.array()
+
+        return ByteBuffer.allocate(8 + 2 + 1 + 4 + 2 + compressedBlock.size).order(MESSAGE_BYTE_ORDER).apply {
+            putLong(0L)
+            putShort(0)
+            put(1)
+            putInt(0)
+            putShort(compressedBlock.size.toShort())
+            put(compressedBlock)
+        }.array()
+    }
+
+    private fun buildImprovedTersePacket(localId: Int): ByteArray {
+        val block = ByteBuffer.allocate(30).order(MESSAGE_BYTE_ORDER).apply {
+            putInt(localId)
+            put(0)
+            repeat(26) { put(0) }
+        }.array()
+
+        return ByteBuffer.allocate(8 + 2 + 1 + 1 + block.size).order(MESSAGE_BYTE_ORDER).apply {
+            putLong(0L)
+            putShort(0)
+            put(1)
+            put(block.size.toByte())
+            put(block)
+        }.array()
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve observability and correctness of the end-to-end object update pipeline for `ObjectUpdate`, `ObjectUpdateCompressed`, and `ImprovedTerseObjectUpdate` by adding counters and explicit rejection handling. 
- Normalize local ID vs full UUID handling so terse updates and compressed updates map to the same object model instead of silently dropping or corrupting state. 
- Provide an integration-level assertion that exercising parser + manager code with packet fixtures results in at least one object present in scene state.

### Description
- Added parser-side instrumentation and structured reject reasons in `ObjectMessageParsers` including `RejectReason` enum, packet/object counters, and `getCounters()` with explicit logging on rejections, and per-block validation for `ObjectUpdate`, `ObjectUpdateCompressed`, and terse blocks (file: `protocol/messages/ObjectMessageParsers.kt`).
- Added update-flow counters and structured rejection handling in `ObjectManager` including `RejectReason` enum, `UpdateCounters`, `getUpdateCounters()` and counters for `packetsReceived`, `packetsParsed`, `objectsCreatedOrUpdated`, and `sceneInsertedOrUpdated`, plus localId/fullId consistency checks and clear logging when rejecting malformed updates (file: `objects/ObjectManager.kt`).
- Replaced silent drops with explicit `markRejected(...)` calls and warnings in both parser and manager code paths, and ensured pending object properties are still applied after successful upserts (files above). 
- Added an integration test `ObjectUpdateFlowIntegrationTest` that constructs packet fixtures for a compressed object update and an improved terse update and verifies the `ObjectManager` contains the expected object after processing (file: `src/test/kotlin/com/linkpoint/objects/ObjectUpdateFlowIntegrationTest.kt`).

### Testing
- Added the automated integration test `ObjectUpdateFlowIntegrationTest` which parses a synthetic `ObjectUpdateCompressed` packet and an `ImprovedTerseObjectUpdate` packet and exercises `ObjectManager` handling to assert an object exists in scene state. 
- Attempted to run the new test with `./gradlew test --tests com.linkpoint.objects.ObjectUpdateFlowIntegrationTest`, but the build failed in this environment due to a missing Android SDK configuration (`ANDROID_HOME` / `sdk.dir`), so tests could not be executed here. 
- No other automated test runs were executed in this environment; the changes are limited to `protocol/messages/ObjectMessageParsers.kt`, `objects/ObjectManager.kt`, and the new test at `src/test/kotlin/com/linkpoint/objects/ObjectUpdateFlowIntegrationTest.kt`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8079897b88323a4fe2b9f63e45b6e)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances observability and correctness of the object update pipeline by adding instrumentation counters, structured rejection handling, and validation logic across `ObjectMessageParsers` and `ObjectManager`. The changes ensure that object updates (`ObjectUpdate`, `ObjectUpdateCompressed`, and `ImprovedTerseObjectUpdate`) are validated for zero IDs and local ID/UUID consistency, with explicit logging when updates are rejected instead of silent drops. An integration test verifies end-to-end functionality by parsing synthetic packet fixtures and asserting that objects appear correctly in scene state after processing.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/ObjectMessageParsers.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/objects/ObjectManager.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/objects/ObjectUpdateFlowIntegrationTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->