### PR TITLE
Harden Filament surface lifecycle and swapchain diagnostics

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt
@@ -245,6 +245,7 @@ class RenderManager(private val context: Context) {
                     override fun onDetachedFromSurface() {
                         dispatcher.post(Runnable {
                             Log.w(TAG, "UiHelper.onDetachedFromSurface - Surface lost")
+                            setSurfaceState(RenderSurfaceState.DESTROYED, source = "UiHelper.onDetachedFromSurface")
                             RenderDiagnostics.filamentSurfaceDetached("UiHelper.onDetachedFromSurface")
                             displayHelper?.detach()
                             synchronized(swapChainLock) {
@@ -615,7 +616,7 @@ class RenderManager(private val context: Context) {
                 null
             }
             if (swapChain != null) {
-                Log.i(TAG, "✓ SwapChain created eagerly during initialize")
+                Log.i(TAG, "SwapChain created (initialize/eager) dims=${sv.width}x${sv.height} backend=Filament")
                 attachDisplayHelper()
                 applyViewportFromSurface("rebuildSwapChainForCurrentSurface")
             }
@@ -717,6 +718,7 @@ class RenderManager(private val context: Context) {
                     Log.i(TAG, "║ ✓ SwapChain created successfully via ensureSwapChain!")
                     Log.i(TAG, "║ Frame count: ${frameCount.get()}")
                     Log.i(TAG, "╚══════════════════════════════════════════════════════════════════")
+                    Log.i(TAG, "SwapChain created (ensure) dims=${viewportWidth}x${viewportHeight} backend=Filament")
                     attachDisplayHelper()
                     applyViewportFromSurface("ensureSwapChain")
                 }
@@ -767,6 +769,12 @@ class RenderManager(private val context: Context) {
             RenderDiagnostics.filamentSwapChainFailed("surface invalid")
             return
         }
+        setSurfaceState(
+            if (explicitWidth > 0 && explicitHeight > 0) RenderSurfaceState.RESIZED else RenderSurfaceState.CREATED,
+            explicitWidth,
+            explicitHeight,
+            "recreateSwapChainInternal"
+        )
 
         Log.i(TAG, "╔══════════════════════════════════════════════════════════════════")
         Log.i(TAG, "║ 🔄 Recreating SwapChain (manual call)...")
@@ -779,6 +787,7 @@ class RenderManager(private val context: Context) {
                 try {
                     waitForGpuIdle("recreateSwapChain")
                     engine.destroySwapChain(oldSwapChain)
+                    Log.i(TAG, "SwapChain destroyed (recreate) dims=${viewportWidth}x${viewportHeight} backend=Filament")
                     RenderDiagnostics.filamentSwapChainDestroyed("recreate")
                 } catch (e: Exception) {
                     Log.w(TAG, "║ Warning: Error destroying old SwapChain: ${e.message}")
@@ -792,6 +801,9 @@ class RenderManager(private val context: Context) {
                 swapChain = engine.createSwapChain(surface)
                 if (swapChain != null) {
                     Log.i(TAG, "║ ✓ SwapChain recreated successfully")
+                    val logWidth = if (explicitWidth > 0) explicitWidth else viewportWidth
+                    val logHeight = if (explicitHeight > 0) explicitHeight else viewportHeight
+                    Log.i(TAG, "SwapChain created (recreate) dims=${logWidth}x${logHeight} backend=Filament")
                     RenderDiagnostics.filamentSwapChainCreated(explicitWidth, explicitHeight)
                     attachDisplayHelper()
                     if (explicitWidth > 0 && explicitHeight > 0) {
@@ -1197,6 +1209,33 @@ class RenderManager(private val context: Context) {
     @Volatile private var displayAttachWarningLogged: Boolean = false
     @Volatile private var lastSwapChainWarningTime: Long = 0
     private val firstFrameLogged = AtomicBoolean(false)
+    @Volatile private var renderSurfaceState: RenderSurfaceState = RenderSurfaceState.DESTROYED
+    @Volatile private var appLifecycleState: AppLifecycleState = AppLifecycleState.RESUMED
+
+    enum class RenderSurfaceState { CREATED, RESIZED, DESTROYED }
+    enum class AppLifecycleState { RESUMED, PAUSED }
+
+    private fun setSurfaceState(state: RenderSurfaceState, width: Int = -1, height: Int = -1, source: String) {
+        renderSurfaceState = state
+        Log.i(
+            TAG,
+            "Surface transition -> $state (${if (width > 0 && height > 0) "${width}x${height}" else "size=unknown"}) source=$source backend=Filament"
+        )
+    }
+
+    fun onAppResumed() {
+        appLifecycleState = AppLifecycleState.RESUMED
+        Log.i(TAG, "App lifecycle transition -> RESUMED backend=Filament")
+    }
+
+    fun onAppPaused() {
+        appLifecycleState = AppLifecycleState.PAUSED
+        Log.i(TAG, "App lifecycle transition -> PAUSED backend=Filament")
+    }
+
+    fun onSurfaceDestroyed() {
+        setSurfaceState(RenderSurfaceState.DESTROYED, source = "backend.onSurfaceDestroyed")
+    }
     
     /**
      * Get comprehensive diagnostic data for debug reports
@@ -1220,6 +1259,8 @@ class RenderManager(private val context: Context) {
             hasCamera = camera != null,
             hasSwapChain = hasSwapChainNow,
             isSurfaceReady = surfaceReady,
+            surfaceState = renderSurfaceState.name,
+            appLifecycleState = appLifecycleState.name,
             isDrawingEnabled = drawingEnabled.get(),
             viewportWidth = viewportWidth,
             viewportHeight = viewportHeight,
@@ -1247,6 +1288,8 @@ class RenderManager(private val context: Context) {
         val hasCamera: Boolean,
         val hasSwapChain: Boolean,
         val isSurfaceReady: Boolean,
+        val surfaceState: String,
+        val appLifecycleState: String,
         val isDrawingEnabled: Boolean,
         val viewportWidth: Int,
         val viewportHeight: Int,

--- a/Linkpoint/src/main/java/com/linkpoint/render/backend/FilamentBackend.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/backend/FilamentBackend.kt
@@ -22,17 +22,20 @@ class FilamentBackend(
     }
 
     override fun onSurfaceDestroyed() {
+        renderManager.onSurfaceDestroyed()
         renderManager.pauseDrawing("surface_destroyed")
     }
 
     override fun onResume() {
         renderManager.dispatcher.post(Runnable {
+            renderManager.onAppResumed()
             renderManager.resumeDrawing("activity_resumed")
             renderManager.recreateSwapChain()
         })
     }
 
     override fun onPause() {
+        renderManager.onAppPaused()
         renderManager.pauseDrawing("activity_paused")
     }
 

--- a/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt
@@ -999,6 +999,7 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine("XR Mode: ${renderDiag.isXRMode}")
                         appendLine("Viewport: ${renderDiag.viewportWidth} x ${renderDiag.viewportHeight}")
                         appendLine("Frame Count: ${renderDiag.frameCount}")
+                        appendLine("Lifecycle: app=${renderDiag.appLifecycleState} surface=${renderDiag.surfaceState}")
                         renderDiag.timeSinceLastFrame?.let {
                             appendLine("Time Since Last Frame: ${formatDuration(it)}")
                         }
@@ -1014,6 +1015,11 @@ class DebugReportService private constructor(private val context: Context) {
                         appendLine("  SwapChain: ${if (renderDiag.hasSwapChain) "✓" else "✗"}")
                         appendLine("  Surface Ready: ${if (renderDiag.isSurfaceReady) "✓" else "✗ (e.g. on Settings, app backgrounded)"}")
                         appendLine("  Drawing Enabled: ${if (renderDiag.isDrawingEnabled) "✓" else "✗ (paused — panel open / activity backgrounded)"}")
+                        appendLine()
+                        appendLine("Smoke Validation:")
+                        appendLine("  Surface Status: ${if (renderDiag.isSurfaceReady) "READY (${renderDiag.surfaceState})" else "NOT_READY (${renderDiag.surfaceState})"}")
+                        appendLine("  SwapChain Status: ${if (renderDiag.hasSwapChain) "READY" else "MISSING"}")
+                        appendLine("  Frame Submit Count: ${renderDiag.frameCount}")
                         appendLine()
                         appendLine("Visible Entity Counts:")
                         appendLine("  Avatars: ${renderDiag.visibleAvatarCount}")


### PR DESCRIPTION
### Motivation
- Make swap chain creation/destruction strictly tied to surface lifecycle so frames are only submitted when the surface is valid, avoiding missing-swapchain/black-screen failures. 
- Provide explicit, observable state transitions for surface and app lifecycle to aid debugging and avoid races between UI callbacks and manual swapchain recreation. 
- Surface/swapchain failures must be visible in debug reports via a simple smoke validation to speed triage.

### Description
- Introduced `RenderSurfaceState` and `AppLifecycleState` enums and state fields in `RenderManager` with `setSurfaceState`, `onAppResumed`, `onAppPaused`, and `onSurfaceDestroyed` to track transitions. 
- Logged swap chain creation/destruction with dimensions and backend context in eager initialization (`rebuildSwapChainForCurrentSurface`), `ensureSwapChain`, and `recreateSwapChainInternal`, and recorded surface-created vs resized transitions. 
- Forwarded lifecycle events from `FilamentBackend` into `RenderManager` (call `onAppResumed`, `onAppPaused`, and `onSurfaceDestroyed`) so pause/resume and surface-destroy are centralized. 
- Extended `RenderManager.getDiagnostics()` to include `surfaceState` and `appLifecycleState` and updated `DebugReportService` to add a smoke-validation block that reports surface status, swapchain status, and frame submit count. 

### Testing
- Ran a local Kotlin compile attempt with `./gradlew :Linkpoint:compileDebugKotlin` to validate build integration and it failed due to the environment missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir`), so no successful bytecode verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f807a260288323be49ecf320985b45)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the Filament rendering surface lifecycle by introducing explicit state tracking for both render surface (`RenderSurfaceState`) and app lifecycle (`AppLifecycleState`) to ensure swapchain operations only occur when the surface is valid. It adds comprehensive logging for swapchain creation and destruction with backend context and dimensions, forwards lifecycle events from `FilamentBackend` to `RenderManager` for centralized state management, and extends diagnostics with surface/lifecycle state information plus a smoke validation section in debug reports to help identify rendering failures and black screen issues.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/RenderManager.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/render/backend/FilamentBackend.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/utils/DebugReportService.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->