### PR TITLE
Add bounded exponential retransmit backoff, duplicate-ACK suppression and transport metrics

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointConstants.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointConstants.kt
@@ -23,6 +23,12 @@ object LinkpointConstants {
     
     /** Message timeout - 5 seconds matches the reference viewer exactly */
     const val MESSAGE_TIMEOUT_MS = 5000L
+
+    /** Max backoff delay for reliable retransmits to stay mobile-friendly */
+    const val MESSAGE_RETRY_BACKOFF_MAX_MS = 30000L
+
+    /** Absolute packet lifetime for reliable sends before forced expiration */
+    const val RELIABLE_PACKET_EXPIRY_MS = 90000L
     
     /** Time without packets before sending a ping to keep connection alive */
     const val NEED_PING_TIMEOUT_MS = 10000L

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointThreadedCircuit.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointThreadedCircuit.kt
@@ -147,6 +147,8 @@ class LinkpointThreadedCircuit(
     
     /** Registered message handlers by message ID */
     private val messageHandlers = ConcurrentHashMap<Int, MessageHandler>()
+
+    private val transportPolicy = ReliableTransportPolicy()
     
     /** Listener for message ACK/timeout events (proven pattern) */
     interface MessageEventListener {
@@ -180,6 +182,7 @@ class LinkpointThreadedCircuit(
         val messageId: Int,
         val data: ByteArray,
         val sentTime: Long,
+        val firstSentTime: Long = sentTime,
         var retryCount: Int = 0,
         val listener: MessageEventListener? = null
     )
@@ -366,6 +369,9 @@ class LinkpointThreadedCircuit(
      * Check if fully connected (world data flowing)
      */
     fun isFullyConnected(): Boolean = fullyConnected.get()
+
+    fun getTransportMetrics(): TransportMetricsSnapshot =
+        transportPolicy.metrics(pendingReliableMessages.size)
     
     // ==================== MAIN CIRCUIT LOOP ====================
     
@@ -538,8 +544,11 @@ class LinkpointThreadedCircuit(
                 NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
                     "LinkpointCircuit: ACK received for seq=$ackedSeq msg=${messageIdToName(pending.messageId)}")
                 
-                pending.listener?.onMessageAcknowledged(ackedSeq, pending.messageId)
-                messageEventListener?.onMessageAcknowledged(ackedSeq, pending.messageId)
+                val ackLatency = System.currentTimeMillis() - pending.firstSentTime
+                if (transportPolicy.onAck(ackedSeq, ackLatency)) {
+                    pending.listener?.onMessageAcknowledged(ackedSeq, pending.messageId)
+                    messageEventListener?.onMessageAcknowledged(ackedSeq, pending.messageId)
+                }
                 
                 // Special handling for UseCircuitCode ACK
                 if (pending.messageId == LinkpointConstants.MSG_USE_CIRCUIT_CODE) {
@@ -604,8 +613,11 @@ class LinkpointThreadedCircuit(
             if (pending != null) {
                 NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
                     "LinkpointCircuit: Appended ACK for seq=$ackedSeq")
-                pending.listener?.onMessageAcknowledged(ackedSeq, pending.messageId)
-                messageEventListener?.onMessageAcknowledged(ackedSeq, pending.messageId)
+                val ackLatency = System.currentTimeMillis() - pending.firstSentTime
+                if (transportPolicy.onAck(ackedSeq, ackLatency)) {
+                    pending.listener?.onMessageAcknowledged(ackedSeq, pending.messageId)
+                    messageEventListener?.onMessageAcknowledged(ackedSeq, pending.messageId)
+                }
             }
         }
     }
@@ -734,19 +746,19 @@ class LinkpointThreadedCircuit(
         val toTimeout = mutableListOf<PendingMessage>()
         
         pendingReliableMessages.values.forEach { pending ->
-            val elapsed = now - pending.sentTime
-            if (elapsed > LinkpointConstants.MESSAGE_TIMEOUT_MS) {
-                if (pending.retryCount < LinkpointConstants.MESSAGE_MAX_RETRIES) {
-                    toRetry.add(pending)
-                } else {
-                    toTimeout.add(pending)
-                }
+            if (transportPolicy.isExpired(pending.firstSentTime) ||
+                pending.retryCount >= LinkpointConstants.MESSAGE_MAX_RETRIES
+            ) {
+                toTimeout.add(pending)
+            } else if (transportPolicy.shouldRetry(pending.sentTime, pending.retryCount)) {
+                toRetry.add(pending)
             }
         }
         
         // Process retries
         for (pending in toRetry) {
             pending.retryCount++
+            transportPolicy.markRetransmit()
             NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
                 "LinkpointCircuit: Retry ${pending.retryCount}/${LinkpointConstants.MESSAGE_MAX_RETRIES} " +
                 "for seq=${pending.sequenceNumber} msg=${messageIdToName(pending.messageId)}")
@@ -779,6 +791,7 @@ class LinkpointThreadedCircuit(
         // Process timeouts
         for (pending in toTimeout) {
             pendingReliableMessages.remove(pending.sequenceNumber)
+            transportPolicy.markExpiredDrop()
             NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
                 "LinkpointCircuit: Message timeout seq=${pending.sequenceNumber} msg=${messageIdToName(pending.messageId)}")
             

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/ReliableTransportPolicy.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/ReliableTransportPolicy.kt
@@ -1,0 +1,97 @@
+package com.linkpoint.protocol.circuit
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.min
+import kotlin.random.Random
+
+internal interface TimeSource {
+    fun nowMs(): Long
+}
+
+internal object SystemTimeSource : TimeSource {
+    override fun nowMs(): Long = System.currentTimeMillis()
+}
+
+internal data class AckLatencyHistogram(
+    val under250ms: Int,
+    val from250To500ms: Int,
+    val from500To1000ms: Int,
+    val from1000To2000ms: Int,
+    val over2000ms: Int
+)
+
+internal data class TransportMetricsSnapshot(
+    val outstandingReliablePackets: Int,
+    val retransmitCount: Long,
+    val droppedExpiredPacketCount: Long,
+    val ackLatencyHistogram: AckLatencyHistogram
+)
+
+internal class ReliableTransportPolicy(
+    private val timeSource: TimeSource = SystemTimeSource,
+    private val jitterRandom: Random = Random.Default,
+    private val baseTimeoutMs: Long = LinkpointConstants.MESSAGE_TIMEOUT_MS,
+    private val maxBackoffMs: Long = LinkpointConstants.MESSAGE_RETRY_BACKOFF_MAX_MS,
+    private val expiryMs: Long = LinkpointConstants.RELIABLE_PACKET_EXPIRY_MS
+) {
+    private val duplicateAckGuard = ConcurrentHashMap.newKeySet<Int>()
+    private val ackUnder250 = AtomicInteger(0)
+    private val ack250to500 = AtomicInteger(0)
+    private val ack500to1000 = AtomicInteger(0)
+    private val ack1000to2000 = AtomicInteger(0)
+    private val ackOver2000 = AtomicInteger(0)
+
+    private val retransmitCount = java.util.concurrent.atomic.AtomicLong(0)
+    private val droppedExpiredCount = java.util.concurrent.atomic.AtomicLong(0)
+
+    fun shouldRetry(sentTimeMs: Long, retryCount: Int): Boolean {
+        val elapsed = timeSource.nowMs() - sentTimeMs
+        return elapsed >= computeRetryDelayMs(retryCount)
+    }
+
+    fun isExpired(firstSentTimeMs: Long): Boolean =
+        timeSource.nowMs() - firstSentTimeMs >= expiryMs
+
+    fun computeRetryDelayMs(retryCount: Int): Long {
+        val shift = retryCount.coerceIn(0, 8)
+        val expDelay = min(maxBackoffMs, baseTimeoutMs shl shift)
+        val jitterSpan = (expDelay / 4).coerceAtLeast(1L)
+        val jitter = jitterRandom.nextLong(-jitterSpan, jitterSpan + 1)
+        return (expDelay + jitter).coerceIn(baseTimeoutMs, maxBackoffMs)
+    }
+
+    fun markRetransmit() {
+        retransmitCount.incrementAndGet()
+    }
+
+    fun markExpiredDrop() {
+        droppedExpiredCount.incrementAndGet()
+    }
+
+    fun onAck(sequenceNumber: Int, ackLatencyMs: Long): Boolean {
+        val firstTime = duplicateAckGuard.add(sequenceNumber)
+        if (!firstTime) return false
+        when {
+            ackLatencyMs < 250 -> ackUnder250.incrementAndGet()
+            ackLatencyMs < 500 -> ack250to500.incrementAndGet()
+            ackLatencyMs < 1000 -> ack500to1000.incrementAndGet()
+            ackLatencyMs < 2000 -> ack1000to2000.incrementAndGet()
+            else -> ackOver2000.incrementAndGet()
+        }
+        return true
+    }
+
+    fun metrics(outstandingReliablePackets: Int): TransportMetricsSnapshot = TransportMetricsSnapshot(
+        outstandingReliablePackets = outstandingReliablePackets,
+        retransmitCount = retransmitCount.get(),
+        droppedExpiredPacketCount = droppedExpiredCount.get(),
+        ackLatencyHistogram = AckLatencyHistogram(
+            under250ms = ackUnder250.get(),
+            from250To500ms = ack250to500.get(),
+            from500To1000ms = ack500to1000.get(),
+            from1000To2000ms = ack1000to2000.get(),
+            over2000ms = ackOver2000.get()
+        )
+    )
+}

--- a/Linkpoint/src/test/kotlin/com/linkpoint/protocol/circuit/ReliableTransportPolicyTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/protocol/circuit/ReliableTransportPolicyTest.kt
@@ -1,0 +1,63 @@
+package com.linkpoint.protocol.circuit
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReliableTransportPolicyTest {
+
+    private class FakeTime(var now: Long) : TimeSource {
+        override fun nowMs(): Long = now
+    }
+
+    @Test
+    fun `bounded exponential backoff with jitter stays within caps`() {
+        val policy = ReliableTransportPolicy(
+            timeSource = FakeTime(0),
+            jitterRandom = Random(1234),
+            baseTimeoutMs = 1_000,
+            maxBackoffMs = 8_000,
+            expiryMs = 60_000
+        )
+
+        repeat(8) { retry ->
+            val delay = policy.computeRetryDelayMs(retry)
+            assertTrue(delay in 1_000..8_000)
+        }
+    }
+
+    @Test
+    fun `retry and expiry decisions are deterministic with fake clock`() {
+        val time = FakeTime(0)
+        val policy = ReliableTransportPolicy(timeSource = time, jitterRandom = Random(1), baseTimeoutMs = 1_000, maxBackoffMs = 4_000, expiryMs = 10_000)
+
+        assertFalse(policy.shouldRetry(sentTimeMs = 0, retryCount = 0))
+        time.now = 1_500
+        assertTrue(policy.shouldRetry(sentTimeMs = 0, retryCount = 0))
+
+        assertFalse(policy.isExpired(0))
+        time.now = 10_001
+        assertTrue(policy.isExpired(0))
+    }
+
+    @Test
+    fun `duplicate ack handling and metrics remain stable`() {
+        val policy = ReliableTransportPolicy(timeSource = FakeTime(0), jitterRandom = Random(7))
+
+        assertTrue(policy.onAck(10, 100))
+        assertFalse(policy.onAck(10, 120))
+        assertTrue(policy.onAck(11, 600))
+        policy.markRetransmit()
+        policy.markRetransmit()
+        policy.markExpiredDrop()
+
+        val metrics = policy.metrics(outstandingReliablePackets = 3)
+        assertEquals(3, metrics.outstandingReliablePackets)
+        assertEquals(2, metrics.retransmitCount)
+        assertEquals(1, metrics.droppedExpiredPacketCount)
+        assertEquals(1, metrics.ackLatencyHistogram.under250ms)
+        assertEquals(1, metrics.ackLatencyHistogram.from500To1000ms)
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve reliable UDP behavior: bound exponential backoff with jitter, explicit packet expiry, and stronger duplicate-ACK handling to be mobile-friendly and more deterministic.
- Provide visibility into transport health via metrics (outstanding reliable packets, retransmits, ACK latency buckets, dropped/expired counts).
- Make retry/expiry logic testable and deterministic using a mockable clock and seeded randomness for unit tests.

### Description
- Added a new `ReliableTransportPolicy` helper that centralizes retry timing, jittered bounded exponential backoff, packet expiry, duplicate-ACK suppression, and ACK-latency histogram buckets (`src/main/java/com/linkpoint/protocol/circuit/ReliableTransportPolicy.kt`).
- Introduced two new timing constants in `LinkpointConstants`: `MESSAGE_RETRY_BACKOFF_MAX_MS` and `RELIABLE_PACKET_EXPIRY_MS` to cap backoff and set absolute reliable-packet lifetime.
- Integrated the policy into `LinkpointThreadedCircuit`: pending reliable messages now track `firstSentTime`, ACK handling records ACK latency and uses the policy to suppress duplicate ACK accounting, idle retry logic now consults `shouldRetry`/`isExpired`, and retransmit/expired-drop counters are incremented via policy hooks; added `getTransportMetrics()` to expose a `TransportMetricsSnapshot`.
- Added deterministic unit tests that use a fake clock and seeded RNG to validate bounded backoff, deterministic retry/expiry decisions, and duplicate-ACK/metrics behavior (`src/test/kotlin/com/linkpoint/protocol/circuit/ReliableTransportPolicyTest.kt`).

### Testing
- Added unit tests for `ReliableTransportPolicy` validating: bounded exponential backoff with jitter, deterministic `shouldRetry`/`isExpired` with a fake clock, and duplicate-ACK handling plus metrics aggregation; tests are in `com.linkpoint.protocol.circuit.ReliableTransportPolicyTest`.
- An attempt to run `./gradlew test --tests com.linkpoint.protocol.circuit.ReliableTransportPolicyTest` in this environment failed during Gradle configuration due to missing Android SDK configuration (`sdk.dir` / `ANDROID_HOME`), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f807b49d848323a365a2393266bb76)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the reliability and observability of the UDP transport layer by introducing a bounded exponential backoff strategy with jitter, explicit packet expiration, and duplicate-ACK suppression. A new `ReliableTransportPolicy` class centralizes retry timing logic, tracks transport health metrics (retransmit counts, ACK latency histograms, dropped packets), and uses mockable time sources for deterministic testing. The existing `LinkpointThreadedCircuit` is refactored to use this policy for retry decisions, ACK handling, and packet lifecycle management, while two new constants (`MESSAGE_RETRY_BACKOFF_MAX_MS` and `RELIABLE_PACKET_EXPIRY_MS`) define backoff caps and absolute packet lifetimes to make the transport more mobile-friendly and predictable.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointConstants.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/circuit/ReliableTransportPolicy.kt` |
| 3 | `Linkpoint/src/test/kotlin/com/linkpoint/protocol/circuit/ReliableTransportPolicyTest.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointThreadedCircuit.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->