### PR TITLE
Enable strict Android Lint release gates and add CI reporting

### DIFF
--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -1,0 +1,42 @@
+name: Android Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Run lint (strict)
+        run: ./gradlew :Linkpoint:lint
+
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports-${{ github.run_id }}
+          path: |
+            Linkpoint/build/reports/lint-results-*.html
+            Linkpoint/build/reports/lint-results-*.xml
+            Linkpoint/build/reports/lint-results-*.sarif
+            Linkpoint/lint-baseline.xml
+          if-no-files-found: warn

--- a/Linkpoint/build.gradle.kts
+++ b/Linkpoint/build.gradle.kts
@@ -222,8 +222,14 @@ android {
     }
     
     lint {
-        abortOnError = false
-        checkReleaseBuilds = false
+        // Strict release safety gates: release and CI builds must fail on new
+        // error/fatal findings.
+        checkReleaseBuilds = true
+        abortOnError = true
+
+        // Baseline is allowed for legacy debt only. Any additions/changes must
+        // include an owner + expiry in docs/lint-exceptions.md.
+        baseline = file("lint-baseline.xml")
     }
     
     testOptions {

--- a/Linkpoint/docs/lint-exceptions.md
+++ b/Linkpoint/docs/lint-exceptions.md
@@ -1,0 +1,19 @@
+# Lint Temporary Exceptions Register
+
+This project runs Android Lint in strict mode (`abortOnError=true`, `checkReleaseBuilds=true`) and publishes lint reports in CI for pull requests and release branches.
+
+## Policy
+- Temporary exceptions are allowed only for unblockers with a named owner and fixed expiry date.
+- Expired exceptions must be removed or renewed (with rationale) in the same pull request.
+- Any baseline additions must reference a tracking issue and follow this register format.
+
+## Active Exceptions
+
+| ID | Scope | Reason | Owner | Expires On (UTC) | Tracking |
+| --- | --- | --- | --- | --- | --- |
+| _None_ | - | - | - | - | - |
+
+## How to update
+1. Add/adjust the lint suppression/baseline entry in code.
+2. Add a row above with owner + explicit expiry date (YYYY-MM-DD).
+3. Link the tracking issue and cleanup plan.

--- a/Linkpoint/lint-baseline.xml
+++ b/Linkpoint/lint-baseline.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.6.1" client="gradle" variant="all" />


### PR DESCRIPTION
### Motivation
- Ensure release builds and CI fail on new Android Lint error/fatal findings to prevent regressions. 
- Allow legacy lint debt to be tracked safely via a baseline while preventing new high-severity issues from sneaking in. 
- Prevent ad-hoc permanent suppressions by requiring temporary exceptions to include an owner, expiry, and tracking information.

### Description
- Updated `Linkpoint/build.gradle.kts` lint configuration to set `checkReleaseBuilds = true`, `abortOnError = true`, and to load a baseline via `baseline = file("lint-baseline.xml")` so releases and CI are gated by lint. 
- Added a minimal baseline file at `Linkpoint/lint-baseline.xml` to represent existing known issues. 
- Added a GitHub Actions workflow `.github/workflows/android-lint.yml` that runs `./gradlew :Linkpoint:lint` for pull requests and pushes to `main` and `release/**`, and uploads lint reports (HTML/XML/SARIF and the baseline) as artifacts. 
- Added `Linkpoint/docs/lint-exceptions.md` documenting the temporary-exception policy requiring explicit owner, expiry date, and tracking information for any baseline/suppression changes.

### Testing
- Attempted a local Gradle invocation (`./gradlew -q :Linkpoint:tasks --all`) which failed in this environment due to a missing Android SDK location (`sdk.dir`/`ANDROID_HOME`), so lint could not be executed locally. 
- CI lint execution will be performed by the added GitHub Actions workflow (reports are uploaded as artifacts); the workflow has not yet run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f807bf81f88323949241419c3477a6)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enforces strict Android Lint checks on release builds and CI pipelines to prevent new high-severity issues from being introduced. It enables `abortOnError` and `checkReleaseBuilds` in the Gradle configuration, introduces a minimal baseline file to track existing lint debt, adds a GitHub Actions workflow to run lint checks and upload reports on pull requests and key branches, and establishes a policy document requiring temporary exceptions to have an explicit owner, expiry date, and tracking information.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/docs/lint-exceptions.md` |
| 2 | `Linkpoint/lint-baseline.xml` |
| 3 | `Linkpoint/build.gradle.kts` |
| 4 | `.github/workflows/android-lint.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->