### PR TITLE
Harden Android backup/data-extraction rules; add validation and security notes

### DIFF
--- a/Linkpoint/SECURITY_NOTES_BACKUP.md
+++ b/Linkpoint/SECURITY_NOTES_BACKUP.md
@@ -1,0 +1,41 @@
+# Backup & data-extraction security policy
+
+This project now uses **allowlist-first backup rules** for Android Auto Backup and data extraction.
+
+## Included in backup (safe user settings only)
+
+- `shared_prefs/com.linkpoint_preferences.xml` (general app settings)
+- `shared_prefs/theme_manager.xml` (theme/UI customization)
+- `shared_prefs/cache_settings.xml` (cache size/location preferences only)
+- `shared_prefs/destination_guide.xml` (destination browsing preferences)
+
+## Explicitly excluded sensitive app-private data
+
+### Tokens / credentials
+- `shared_prefs/com_linkpoint_mfa_hashes.xml`
+- `shared_prefs/com_linkpoint_mfa_hashes_encrypted.xml`
+- `shared_prefs/device.xml` (device identity metadata)
+
+### Session state / user world data
+- `databases/inventory.db`
+- `databases/inventory.db-wal`
+- `databases/inventory.db-shm`
+
+### Logs
+- `files/crash_logs/`
+- `files/Linkpoint Logs/` (network/session diagnostics)
+
+### Caches with personal/world data
+- `cache/` (entire internal app cache domain)
+
+## Verification
+
+Run:
+
+```bash
+python3 Linkpoint/tools/check_backup_sensitive_excludes.py
+```
+
+The check fails if:
+- any known sensitive path is not explicitly excluded, or
+- includes are broadened beyond the approved safe shared-preference allowlist.

--- a/Linkpoint/src/main/res/xml/backup_rules.xml
+++ b/Linkpoint/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <include domain="sharedpref" path="."/>
+    <!-- Allowlist only non-sensitive user settings/preferences. -->
+    <include domain="sharedpref" path="com.linkpoint_preferences.xml"/>
+    <include domain="sharedpref" path="theme_manager.xml"/>
+    <include domain="sharedpref" path="cache_settings.xml"/>
+    <include domain="sharedpref" path="destination_guide.xml"/>
+
+    <!-- Explicitly exclude app-private secrets/session/log/cache data. -->
+    <exclude domain="sharedpref" path="com_linkpoint_mfa_hashes.xml"/>
+    <exclude domain="sharedpref" path="com_linkpoint_mfa_hashes_encrypted.xml"/>
     <exclude domain="sharedpref" path="device.xml"/>
+
+    <exclude domain="file" path="crash_logs/"/>
+    <exclude domain="file" path="Linkpoint Logs/"/>
+
+    <exclude domain="database" path="inventory.db"/>
+    <exclude domain="database" path="inventory.db-shm"/>
+    <exclude domain="database" path="inventory.db-wal"/>
+
+    <exclude domain="root" path="cache/"/>
 </full-backup-content>

--- a/Linkpoint/src/main/res/xml/data_extraction_rules.xml
+++ b/Linkpoint/src/main/res/xml/data_extraction_rules.xml
@@ -1,7 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <include domain="sharedpref" path="."/>
+        <!-- Allowlist only non-sensitive user settings/preferences. -->
+        <include domain="sharedpref" path="com.linkpoint_preferences.xml"/>
+        <include domain="sharedpref" path="theme_manager.xml"/>
+        <include domain="sharedpref" path="cache_settings.xml"/>
+        <include domain="sharedpref" path="destination_guide.xml"/>
+
+        <!-- Explicitly exclude app-private secrets/session/log/cache data. -->
+        <exclude domain="sharedpref" path="com_linkpoint_mfa_hashes.xml"/>
+        <exclude domain="sharedpref" path="com_linkpoint_mfa_hashes_encrypted.xml"/>
         <exclude domain="sharedpref" path="device.xml"/>
+
+        <exclude domain="file" path="crash_logs/"/>
+        <exclude domain="file" path="Linkpoint Logs/"/>
+
+        <exclude domain="database" path="inventory.db"/>
+        <exclude domain="database" path="inventory.db-shm"/>
+        <exclude domain="database" path="inventory.db-wal"/>
+
+        <exclude domain="root" path="cache/"/>
     </cloud-backup>
+
+    <device-transfer>
+        <include domain="sharedpref" path="com.linkpoint_preferences.xml"/>
+        <include domain="sharedpref" path="theme_manager.xml"/>
+        <include domain="sharedpref" path="cache_settings.xml"/>
+        <include domain="sharedpref" path="destination_guide.xml"/>
+
+        <exclude domain="sharedpref" path="com_linkpoint_mfa_hashes.xml"/>
+        <exclude domain="sharedpref" path="com_linkpoint_mfa_hashes_encrypted.xml"/>
+        <exclude domain="sharedpref" path="device.xml"/>
+
+        <exclude domain="file" path="crash_logs/"/>
+        <exclude domain="file" path="Linkpoint Logs/"/>
+
+        <exclude domain="database" path="inventory.db"/>
+        <exclude domain="database" path="inventory.db-shm"/>
+        <exclude domain="database" path="inventory.db-wal"/>
+
+        <exclude domain="root" path="cache/"/>
+    </device-transfer>
 </data-extraction-rules>

--- a/Linkpoint/tools/check_backup_sensitive_excludes.py
+++ b/Linkpoint/tools/check_backup_sensitive_excludes.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+RULE_FILES=[Path('Linkpoint/src/main/res/xml/backup_rules.xml'),Path('Linkpoint/src/main/res/xml/data_extraction_rules.xml')]
+REQ={("sharedpref","com_linkpoint_mfa_hashes.xml"),("sharedpref","com_linkpoint_mfa_hashes_encrypted.xml"),("sharedpref","device.xml"),("file","crash_logs/"),("file","Linkpoint Logs/"),("database","inventory.db"),("database","inventory.db-shm"),("database","inventory.db-wal"),("root","cache/")}
+ALLOW={("sharedpref","com.linkpoint_preferences.xml"),("sharedpref","theme_manager.xml"),("sharedpref","cache_settings.xml"),("sharedpref","destination_guide.xml")}
+def pairs(p,t):
+ r=ET.parse(p).getroot();return {(e.attrib.get('domain',''),e.attrib.get('path','')) for e in r.iter(t)}
+fail=False
+for f in RULE_FILES:
+ ex=pairs(f,'exclude');inc=pairs(f,'include');miss=sorted(REQ-ex);unsafe=sorted(x for x in inc if x not in ALLOW)
+ if miss or unsafe: fail=True
+ if miss:
+  print(f'ERROR: {f} missing excludes:');[print(f'  - domain={d} path={p}') for d,p in miss]
+ if unsafe:
+  print(f'ERROR: {f} has non-allowlisted includes:');[print(f'  - domain={d} path={p}') for d,p in unsafe]
+ if not miss and not unsafe: print(f'OK: {f}')
+sys.exit(1 if fail else 0)


### PR DESCRIPTION
### Motivation
- Reduce risk of sensitive data being included in Android Auto Backup or data extraction by moving to an allowlist-first policy for shared preferences.
- Ensure tokens/credentials, session/world-state databases, logs, and caches are explicitly excluded from backups.
- Provide a small automated check to prevent accidental re-introduction of unsafe includes or removal of required excludes.

### Description
- Replace broad `include domain="sharedpref" path="."` with an explicit allowlist in `Linkpoint/src/main/res/xml/backup_rules.xml` and mirror the same allowlist+excludes in `Linkpoint/src/main/res/xml/data_extraction_rules.xml` for both `cloud-backup` and `device-transfer` blocks.
- Add explicit excludes for sensitive app-private paths including `shared_prefs/com_linkpoint_mfa_hashes*.xml`, `shared_prefs/device.xml`, `files/crash_logs/`, `files/Linkpoint Logs/`, `databases/inventory.db*`, and the `cache/` domain.
- Add security documentation `Linkpoint/SECURITY_NOTES_BACKUP.md` enumerating what is allowed and what is explicitly excluded, plus the verification command.
- Add an automated validation script `Linkpoint/tools/check_backup_sensitive_excludes.py` that verifies the XML rules contain the required excludes and that `include` entries are constrained to the approved allowlist.

### Testing
- Ran the validation script with `python3 Linkpoint/tools/check_backup_sensitive_excludes.py`, which reported `OK` for both `backup_rules.xml` and `data_extraction_rules.xml` and exited successfully.
- No automated test failures were observed from the added check; the script will surface missing excludes or unsafe includes if introduced later.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f807e6b5fc8323a6b257af8a73a9eb)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens Android backup and data extraction security by replacing broad include rules with an explicit allowlist of safe shared preferences while explicitly excluding sensitive data such as MFA tokens, credentials, session databases, crash logs, and caches. It adds security documentation detailing what is allowed and excluded, plus an automated validation script to prevent accidental reintroduction of unsafe backup configurations in the future.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/SECURITY_NOTES_BACKUP.md` |
| 2 | `Linkpoint/src/main/res/xml/backup_rules.xml` |
| 3 | `Linkpoint/src/main/res/xml/data_extraction_rules.xml` |
| 4 | `Linkpoint/tools/check_backup_sensitive_excludes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->