### PR TITLE
Harden SLURL parsing and add fuzz-style tests

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/ui/slurl/SLURLActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/slurl/SLURLActivity.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.linkpoint.LinkpointApp
@@ -18,100 +19,75 @@ import kotlinx.coroutines.launch
  * Handles secondlife:// and https://maps.secondlife.com URLs
  */
 class SLURLActivity : AppCompatActivity() {
-    
+
     companion object {
         private const val TAG = "SLURLActivity"
     }
-    
+
     private val app by lazy { LinkpointApp.getInstance() }
-    
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_slurl)
-        
+
         handleIntent(intent)
     }
-    
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
     }
-    
+
     private fun handleIntent(intent: Intent) {
         val uri = intent.data ?: run {
             finish()
             return
         }
-        
-        val slurl = parseSLURL(uri)
-        
+
+        val slurl = SLURLParser.parse(uri)
+
         if (slurl != null) {
             showTeleportDialog(slurl)
         } else {
             showErrorDialog("Invalid SLURL format")
         }
     }
-    
-    private fun parseSLURL(uri: Uri): SLURLData? {
-        return try {
-            when (uri.scheme) {
-                "secondlife" -> parseSecondLifeScheme(uri)
-                "http", "https" -> parseHttpScheme(uri)
-                else -> null
-            }
-        } catch (e: Exception) {
-            null
-        }
-    }
-    
-    private fun parseSecondLifeScheme(uri: Uri): SLURLData? {
-        // secondlife://RegionName/x/y/z
-        val pathSegments = uri.pathSegments
-        if (pathSegments.isEmpty()) return null
-        
-        val regionName = uri.host ?: return null
-        val x = pathSegments.getOrNull(0)?.toFloatOrNull() ?: 128f
-        val y = pathSegments.getOrNull(1)?.toFloatOrNull() ?: 128f
-        val z = pathSegments.getOrNull(2)?.toFloatOrNull() ?: 0f
-        
-        return SLURLData(regionName, x, y, z)
-    }
-    
-    private fun parseHttpScheme(uri: Uri): SLURLData? {
-        // https://maps.secondlife.com/secondlife/RegionName/x/y/z
-        val pathSegments = uri.pathSegments
-        if (pathSegments.size < 2) return null
-        if (pathSegments[0] != "secondlife") return null
-        
-        val regionName = pathSegments[1]
-        val x = pathSegments.getOrNull(2)?.toFloatOrNull() ?: 128f
-        val y = pathSegments.getOrNull(3)?.toFloatOrNull() ?: 128f
-        val z = pathSegments.getOrNull(4)?.toFloatOrNull() ?: 0f
-        
-        return SLURLData(regionName, x, y, z)
-    }
-    
+
     private fun showTeleportDialog(slurl: SLURLData) {
         val titleText = findViewById<TextView>(R.id.titleText)
         val locationText = findViewById<TextView>(R.id.locationText)
         val teleportButton = findViewById<Button>(R.id.teleportButton)
         val cancelButton = findViewById<Button>(R.id.cancelButton)
-        
+
         titleText.text = "Teleport to Location"
         locationText.text = "${slurl.regionName}\n(${slurl.x.toInt()}, ${slurl.y.toInt()}, ${slurl.z.toInt()})"
-        
+
         teleportButton.setOnClickListener {
-            performTeleport(slurl)
+            if (isExternalLaunch()) {
+                showSensitiveActionConfirmation(slurl)
+            } else {
+                performTeleport(slurl)
+            }
         }
-        
+
         cancelButton.setOnClickListener {
             finish()
         }
     }
-    
+
+    private fun isExternalLaunch(): Boolean = intent?.action == Intent.ACTION_VIEW
+
+    private fun showSensitiveActionConfirmation(slurl: SLURLData) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirm external SLURL action")
+            .setMessage("This link can change your login context and teleport location. Continue?")
+            .setNegativeButton("Cancel") { _, _ -> }
+            .setPositiveButton("Continue") { _, _ -> performTeleport(slurl) }
+            .show()
+    }
+
     private fun performTeleport(slurl: SLURLData) {
         if (!app.isConnected()) {
-            // Not logged in - go to login first
             val loginIntent = Intent(this, ComposeLoginActivity::class.java).apply {
                 putExtra("slurl_region", slurl.regionName)
                 putExtra("slurl_x", slurl.x)
@@ -122,40 +98,91 @@ class SLURLActivity : AppCompatActivity() {
             finish()
             return
         }
-        
-        // Already logged in - teleport directly
+
         lifecycleScope.launch {
-            val result = app.protocol.teleport(
-                slurl.regionName,
-                slurl.x,
-                slurl.y,
-                slurl.z
-            )
-            
+            val result = app.protocol.teleport(slurl.regionName, slurl.x, slurl.y, slurl.z)
             when (result) {
-                is TeleportResult.Success -> {
-                    finish()
-                }
-                is TeleportResult.Failure -> {
-                    showErrorDialog(result.message)
-                }
+                is TeleportResult.Success -> finish()
+                is TeleportResult.Failure -> showErrorDialog(result.message)
             }
         }
     }
-    
+
     private fun showErrorDialog(message: String) {
         val titleText = findViewById<TextView>(R.id.titleText)
         val locationText = findViewById<TextView>(R.id.locationText)
         val teleportButton = findViewById<Button>(R.id.teleportButton)
         val cancelButton = findViewById<Button>(R.id.cancelButton)
-        
+
         titleText.text = "Error"
         locationText.text = message
         teleportButton.visibility = android.view.View.GONE
         cancelButton.text = "Close"
-        cancelButton.setOnClickListener {
-            finish()
+        cancelButton.setOnClickListener { finish() }
+    }
+}
+
+internal object SLURLParser {
+    private const val MAX_URI_LENGTH = 2048
+    private const val MAX_COMPONENT_LENGTH = 128
+    private const val DEFAULT_X = 128f
+    private const val DEFAULT_Y = 128f
+    private const val DEFAULT_Z = 0f
+    private val ALLOWED_HTTP_HOSTS = setOf("maps.secondlife.com")
+
+    fun parse(uri: Uri): SLURLData? {
+        if (uri.toString().length > MAX_URI_LENGTH) return null
+        return try {
+            when (uri.scheme?.lowercase()) {
+                "secondlife" -> parseSecondLifeScheme(uri)
+                "http", "https" -> parseHttpScheme(uri)
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
         }
+    }
+
+    private fun parseSecondLifeScheme(uri: Uri): SLURLData? {
+        if (!uri.userInfo.isNullOrBlank() || uri.port != -1) return null
+        if (!uri.query.isNullOrBlank() || !uri.fragment.isNullOrBlank()) return null
+        val regionName = sanitizeComponent(uri.host) ?: return null
+        val segments = uri.pathSegments
+        if (segments.size > 3) return null
+        return buildSlurl(regionName, segments)
+    }
+
+    private fun parseHttpScheme(uri: Uri): SLURLData? {
+        val host = uri.host?.lowercase() ?: return null
+        if (host !in ALLOWED_HTTP_HOSTS) return null
+        if (!uri.userInfo.isNullOrBlank() || !uri.fragment.isNullOrBlank()) return null
+        val segments = uri.pathSegments
+        if (segments.size < 2 || segments.size > 5) return null
+        val root = sanitizeComponent(segments[0]) ?: return null
+        if (root.lowercase() != "secondlife") return null
+        val regionName = sanitizeComponent(segments[1]) ?: return null
+        return buildSlurl(regionName, segments.drop(2))
+    }
+
+    private fun buildSlurl(regionName: String, coordinates: List<String>): SLURLData? {
+        val x = parseCoordinate(coordinates.getOrNull(0), DEFAULT_X) ?: return null
+        val y = parseCoordinate(coordinates.getOrNull(1), DEFAULT_Y) ?: return null
+        val z = parseCoordinate(coordinates.getOrNull(2), DEFAULT_Z) ?: return null
+        return SLURLData(regionName, x, y, z)
+    }
+
+    private fun parseCoordinate(raw: String?, fallback: Float): Float? {
+        if (raw == null) return fallback
+        val sanitized = sanitizeComponent(raw) ?: return null
+        return sanitized.toFloatOrNull()
+    }
+
+    private fun sanitizeComponent(value: String?): String? {
+        val trimmed = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        if (trimmed.length > MAX_COMPONENT_LENGTH) return null
+        val cleaned = trimmed.filterNot { it.isISOControl() }
+        if (cleaned.isBlank() || cleaned.length > MAX_COMPONENT_LENGTH) return null
+        return cleaned
     }
 }
 

--- a/Linkpoint/src/test/kotlin/com/linkpoint/ui/slurl/SLURLParserFuzzTest.kt
+++ b/Linkpoint/src/test/kotlin/com/linkpoint/ui/slurl/SLURLParserFuzzTest.kt
@@ -1,0 +1,52 @@
+package com.linkpoint.ui.slurl
+
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SLURLParserFuzzTest {
+
+    @Test
+    fun `accepts valid secondlife uri`() {
+        val parsed = SLURLParser.parse(Uri.parse("secondlife://Linkpoint%20Bay/128/64/24"))
+        assertNotNull(parsed)
+        assertEquals("Linkpoint Bay", parsed?.regionName)
+    }
+
+    @Test
+    fun `rejects malformed and oversized inputs without crash`() {
+        val oversized = "secondlife://" + "A".repeat(3000)
+        val malformedInputs = listOf(
+            "",
+            "not a uri",
+            "ftp://maps.secondlife.com/secondlife/Region/1/2/3",
+            "https://evil.example/secondlife/Region/128/128/0",
+            "secondlife://Region/1/2/3/4",
+            "secondlife://Region/1/two/3",
+            "secondlife://user@Region/1/2/3",
+            "secondlife://Region/1/2/3?x=y",
+            "https://maps.secondlife.com/elsewhere/Region/1/2/3",
+            "https://maps.secondlife.com/secondlife/",
+            "https://maps.secondlife.com/secondlife/Region/1/2/3/4",
+            "secondlife://Reg%00ion/1/2/3",
+            oversized
+        )
+
+        malformedInputs.forEach { raw ->
+            val result = SLURLParser.parse(Uri.parse(raw))
+            assertNull("Expected null for input: $raw", result)
+        }
+    }
+
+    @Test
+    fun `sanitizes decoded path components and defaults coordinates`() {
+        val parsed = SLURLParser.parse(Uri.parse("https://maps.secondlife.com/secondlife/%20My%20Region%20"))
+        assertNotNull(parsed)
+        assertEquals("My Region", parsed?.regionName)
+        assertEquals(128f, parsed?.x)
+        assertEquals(128f, parsed?.y)
+        assertEquals(0f, parsed?.z)
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent crashes and unintended navigation from crafted or malformed SLURL inputs by enforcing stricter validation and early rejection. 
- Normalize and sanitize decoded path/query components to avoid control characters or oversized values being used as navigation/login context. 
- Require explicit user confirmation for sensitive actions (teleport/login-context changes) when an SLURL originates from an external source. 

### Description
- Centralized parsing into a new `SLURLParser` and switched `SLURLActivity` to use `SLURLParser.parse(uri)` for all URI handling. 
- Added early-rejection rules and limits such as `MAX_URI_LENGTH`, `MAX_COMPONENT_LENGTH`, an HTTP host allowlist (`maps.secondlife.com`), disallowing `userInfo`, fragments or query on sensitive schemes, and path-segment count checks. 
- Normalized/sanitized decoded components by trimming, removing ISO control characters, and enforcing per-component length caps and safer coordinate parsing with explicit fallbacks. 
- Added an explicit confirmation dialog for externally launched SLURLs (`Intent.ACTION_VIEW`) before performing teleport or login-context changes. 
- Added fuzz-style unit tests in `Linkpoint/src/test/kotlin/com/linkpoint/ui/slurl/SLURLParserFuzzTest.kt` to cover malformed, oversized, and sanitized SLURL inputs and assert no crashes or unintended parsing. 

### Testing
- Added unit tests `com.linkpoint.ui.slurl.SLURLParserFuzzTest` that assert valid parsing, rejection of malformed/oversized inputs, and sanitization/defaulting behavior. 
- Attempted to run `./gradlew testDebugUnitTest --tests com.linkpoint.ui.slurl.SLURLParserFuzzTest` but the run failed in this environment due to missing Android SDK configuration (`sdk.dir`/`ANDROID_HOME`), so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f807efb5348323a28616413a131f7c)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens SLURL (Second Life URL) parsing to prevent crashes and unintended navigation from malformed or crafted inputs. A new `SLURLParser` object is introduced with strict validation rules including URI length limits, component sanitization to remove control characters, HTTP host allowlisting for `maps.secondlife.com`, and rejection of userInfo/fragments/queries on sensitive schemes. The parser now normalizes decoded path components and enforces safer coordinate parsing with explicit fallbacks. Additionally, an explicit user confirmation dialog is shown when SLURLs originate from external sources (`Intent.ACTION_VIEW`) before performing teleports or login-context changes. Fuzz-style unit tests verify that the parser correctly handles malformed, oversized, and sanitized inputs without crashing.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/test/kotlin/com/linkpoint/ui/slurl/SLURLParserFuzzTest.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/slurl/SLURLActivity.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->