### PR TITLE
fix(protocol): six UDP-circuit issues found in 2026-05-06/07 captures

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt
@@ -729,7 +729,7 @@ object NetworkLogger {
         if (!isVerbosePacketLoggingEnabled()) return
         val message = buildString {
             append("📤 UDP Sent: $messageName\n")
-            append("  Message ID: 0x${messageId.toString(16).uppercase()}\n")
+            append("  Message ID: 0x${com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(messageId)}\n")
             append("  Sequence: $sequenceNumber\n")
             append("  Size: $sizeBytes bytes\n")
             append("  Target: $targetAddress:$targetPort")
@@ -753,7 +753,7 @@ object NetworkLogger {
         val handlerInfo = if (hasHandler) "" else " [NO HANDLER]"
         val message = buildString {
             append("📥 UDP Received $statusIcon: $messageName$handlerInfo\n")
-            append("  Message ID: 0x${messageId.toString(16).uppercase()}\n")
+            append("  Message ID: 0x${com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(messageId)}\n")
             append("  Sequence: $sequenceNumber\n")
             append("  Size: $sizeBytes bytes")
             sourceAddress?.let { append("\n  Source: $it") }

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointThreadedCircuit.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointThreadedCircuit.kt
@@ -1068,7 +1068,7 @@ class LinkpointThreadedCircuit(
             LinkpointConstants.MSG_COMPLETE_AGENT_MOVEMENT -> "CompleteAgentMovement"
             LinkpointConstants.MSG_REGION_HANDSHAKE -> "RegionHandshake"
             LinkpointConstants.MSG_REGION_HANDSHAKE_REPLY -> "RegionHandshakeReply"
-            else -> "0x${messageId.toString(16).uppercase()}"
+            else -> "0x${com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(messageId)}"
         }
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/EnhancedPacketLogger.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/EnhancedPacketLogger.kt
@@ -203,7 +203,7 @@ object EnhancedPacketLogger {
         fun formatForDisplay(): String {
             val timeStr = SimpleDateFormat("HH:mm:ss.SSS", Locale.US).format(Date(timestamp))
             val seqInfo = sequenceNumber?.let { " seq=$it" } ?: ""
-            val msgIdInfo = messageId?.let { " msgId=0x${it.toString(16).uppercase()}" } ?: ""
+            val msgIdInfo = messageId?.let { " msgId=0x${MessageIdNameRegistry.formatHex(it)}" } ?: ""
             return "[$timeStr] ⚠️ MALFORMED: $reason (${size}B)$seqInfo$msgIdInfo\n    Details: $details\n    Hex: $hexPreview"
         }
     }
@@ -432,7 +432,7 @@ object EnhancedPacketLogger {
      */
     fun logHandlerRegistered(messageId: Int, messageName: String) {
         registeredHandlers[messageId] = messageName
-        Log.d(TAG, "📝 Handler registered: $messageName (0x${messageId.toString(16).uppercase()})")
+        Log.d(TAG, "📝 Handler registered: $messageName (0x${MessageIdNameRegistry.formatHex(messageId)})")
     }
     
     /**
@@ -537,7 +537,7 @@ object EnhancedPacketLogger {
         Log.w(TAG, "  Details: $details")
         rawFlags?.let { Log.w(TAG, "  Raw Flags: 0x${it.toString(16).uppercase().padStart(2, '0')}") }
         sequenceNumber?.let { Log.w(TAG, "  Sequence: $it") }
-        messageId?.let { Log.w(TAG, "  Message ID: 0x${it.toString(16).uppercase()}") }
+        messageId?.let { Log.w(TAG, "  Message ID: 0x${MessageIdNameRegistry.formatHex(it)}") }
         Log.w(TAG, "  Hex Preview: $hexPreview")
     }
     
@@ -913,7 +913,7 @@ object EnhancedPacketLogger {
             appendLine("│ REGISTERED HANDLERS (${stats.registeredHandlerCount})                                     │")
             appendLine("└──────────────────────────────────────────────────────────────────┘")
             registeredHandlers.entries.forEach { (id, name) ->
-                appendLine("  - $name (0x${id.toString(16).uppercase()})")
+                appendLine("  - $name (0x${MessageIdNameRegistry.formatHex(id)})")
             }
             if (registeredHandlers.isEmpty()) {
                 appendLine("  ⚠️ No handlers registered!")

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIdNameRegistry.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIdNameRegistry.kt
@@ -6,17 +6,42 @@ internal object MessageIdNameRegistry {
     }
 
     fun formatUnknownMessageId(messageId: Int): String {
+        return "Unknown(0x${formatHex(messageId)})"
+    }
+
+    /**
+     * Format a Second Life message ID as an unsigned hex string suitable for
+     * logs and debug reports.
+     *
+     * SL message IDs span three frequency classes that all share a single
+     * Kotlin `Int` slot:
+     *   - High   (1 byte):  0x01..0xFE        -> positive 1..254
+     *   - Medium (2 bytes): 0xFF01..0xFFFE    -> positive 65281..65534
+     *   - Low    (4 bytes): 0xFFFF0001..0xFFFFFFFE
+     *
+     * Low-frequency IDs are produced by `(short or 0xFFFF0000)`. Since Kotlin's
+     * `Int` is signed, ORing in the top 16 bits flips the sign — for example
+     * RegionHandshake (0xFFFF0094) lands as -65388. Calling `toString(16)` on
+     * that prints `"-ffff0094"`, which is how user-visible logs ended up
+     * showing IDs like `0x-FFFD` or `(ID: -65452)`.
+     *
+     * Masking through `Long and 0xFFFFFFFFL` reinterprets the bits as unsigned
+     * before formatting, recovering the protocol-correct value. Width is
+     * chosen per band so the output matches the on-wire encoding length.
+     */
+    fun formatHex(messageId: Int): String {
         return when {
-            messageId in 1..254 -> "Unknown(0x${messageId.toString(16).uppercase().padStart(2, '0')})"
+            messageId in 1..254 ->
+                messageId.toString(16).uppercase().padStart(2, '0')
             messageId in 65280..65535 -> {
                 val lowByte = messageId and 0xFF
-                "Unknown(0xFF${lowByte.toString(16).uppercase().padStart(2, '0')})"
+                "FF${lowByte.toString(16).uppercase().padStart(2, '0')}"
             }
             messageId < 0 -> {
                 val unsignedVal = messageId.toLong() and 0xFFFFFFFFL
-                "Unknown(0x${unsignedVal.toString(16).uppercase().padStart(8, '0')})"
+                unsignedVal.toString(16).uppercase().padStart(8, '0')
             }
-            else -> "Unknown(0x${messageId.toString(16).uppercase()})"
+            else -> messageId.toString(16).uppercase()
         }
     }
 }

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageRouter.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageRouter.kt
@@ -122,6 +122,21 @@ class MessageRouter {
     }
 
     /**
+     * Drop every handler registered for [messageId]. Used by
+     * UDPConnectionFixed.unregisterMessageHandler() — that API takes only an
+     * id, but the router's per-handler unregister needs the original Handler
+     * reference (which the lambda-wrapping registerHandler() never exposes).
+     * Removing all handlers for the id is the correct one-arg semantics.
+     */
+    @Synchronized
+    fun unregisterAllHandlersFor(messageId: Int) {
+        if (handlers.remove(messageId) != null) {
+            NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
+                "Unregistered all handlers for message $messageId")
+        }
+    }
+
+    /**
      * Route a message to its handlers. Called from the I/O thread; handlers
      * run synchronously on the caller's thread (Lumiya's pattern).
      */

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -965,6 +965,20 @@ class UDPConnectionFixed(
      */
     suspend fun connect(): Boolean = withContext(CircuitDispatcher.dispatcher) {
         try {
+            // Defensive: if a previous I/O thread is still alive (e.g.
+            // higher-level recovery path called connect() without an
+            // intervening disconnect()), interrupt it before we open a
+            // new socket. Letting two I/O threads race over the same
+            // @Volatile selector/channel/key fields produces the
+            // "I/O Thread Alive: false but selector wakeups still
+            // climbing" inconsistency seen in the 2026-05-07 00:35 capture.
+            ioThread?.takeIf { it.isAlive }?.let { stale ->
+                NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
+                    "connect(): previous I/O thread '${stale.name}' still alive — interrupting before re-creating")
+                stale.interrupt()
+            }
+            ioThread = null
+
             connectAttemptCount.incrementAndGet()
             // Record connection attempt time and reset ALL statistics for new session
             connectionAttemptTime = System.currentTimeMillis()
@@ -1315,7 +1329,7 @@ class UDPConnectionFixed(
                                 NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
                                     "📦 PACKET RECEIVED #${packetsReceived.get()}: $bytesRead bytes${if (isZerocoded) " (decoded to ${data.size})" else ""}")
                                 NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-                                    "   Message: $messageName (ID: 0x${messageId.toString(16).uppercase()}, seq: $seqNum)")
+                                    "   Message: $messageName (ID: 0x${MessageIdNameRegistry.formatHex(messageId)}, seq: $seqNum)")
 
                                 // Record in packet history
                                 recordPacketEvent(
@@ -1383,7 +1397,7 @@ class UDPConnectionFixed(
                                         else NetworkLogger.Level.WARN
                                     val tag = if (packetFlags.resent) "↻ duplicate-resend" else "⚠ duplicate-not-marked-resend"
                                     NetworkLogger.log(level, NetworkLogger.Category.UDP,
-                                        "$tag seq=$seqNum messageId=0x${messageId.toString(16)} ($messageName) — skipping handler dispatch")
+                                        "$tag seq=$seqNum messageId=0x${MessageIdNameRegistry.formatHex(messageId)} ($messageName) — skipping handler dispatch")
                                 } else {
                                     // Inbound seq-gap detector (ELN approximation). If the
                                     // simulator's stream skipped one or more sequence
@@ -1548,33 +1562,48 @@ class UDPConnectionFixed(
      */
     private fun dispatchMessageDirect(messageId: Int, data: ByteArray) {
         try {
-            // Internal PacketAck handling (processes ACK callbacks for reliable messaging)
+            // Internal PacketAck bookkeeping. This is NOT a public handler —
+            // it walks the inflight-reliable map and the pendingCallbacks map
+            // so reliable sends complete and resends stop. Public app
+            // handlers for PACKET_ACK (e.g. LinkpointApp's
+            // CompleteAgentMovement-after-circuit-ack hook) are dispatched
+            // by the router below; this internal call must always run, even
+            // when no app handler is registered.
             if (messageId == MessageIdRegistry.PACKET_ACK) {
                 handlePacketAck(data)
             }
 
-            // Dispatch to all registered handlers (from LinkpointApp and managers)
-            val handler = messageHandlers[messageId]
-            if (handler != null) {
-                try {
-                    handler.handle(messageId, data)
-                } catch (e: Exception) {
-                    NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
-                        "Handler error for ${getMessageName(messageId)}: ${e.message}")
-                }
-                messagesRouted.incrementAndGet()
-            } else if (messageId != MessageIdRegistry.PACKET_ACK) {
-                // Only log unhandled messages if not PacketAck (which is handled internally)
-                NetworkLogger.log(NetworkLogger.Level.VERBOSE, NetworkLogger.Category.UDP,
-                    "No handler for ${getMessageName(messageId)} (ID: $messageId)")
-            }
-
-            // Also try to route through messageRouter for any handlers only registered there
-            try {
+            // Single dispatch path: messageRouter. registerHandler() puts
+            // every callback into both `messageHandlers` (for diagnostics —
+            // counts and the registered-id list in the debug report) AND the
+            // router (for actual dispatch). AgentCircuit.kt registers
+            // LAYER_DATA / OBJECT_UPDATE / OBJECT_PROPERTIES directly with
+            // the router only, so the router is the strict superset and the
+            // canonical dispatch site.
+            //
+            // The previous implementation dispatched through both
+            // `messageHandlers` AND `messageRouter`, which fired every
+            // app-registered handler twice. That's the root cause of the
+            // 2× CompletePingCheck pattern in session_log_2026-05-06_21-55
+            // (822 inbound StartPingCheck → 1348 outbound CompletePingCheck)
+            // and would have silently double-applied chat / IM / money /
+            // inventory handlers as well.
+            val handled = try {
                 messageRouter.routeMessageSync(messageId, data)
             } catch (e: Exception) {
                 NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
                     "Router error for ${getMessageName(messageId)}: ${e.message}")
+                false
+            }
+
+            if (handled) {
+                messagesRouted.incrementAndGet()
+            } else if (messageId != MessageIdRegistry.PACKET_ACK) {
+                // PACKET_ACK handled internally above so absence of an app
+                // handler is fine; everything else with no handler is a
+                // protocol gap worth logging at VERBOSE.
+                NetworkLogger.log(NetworkLogger.Level.VERBOSE, NetworkLogger.Category.UDP,
+                    "No handler for ${getMessageName(messageId)} (ID: 0x${MessageIdNameRegistry.formatHex(messageId)})")
             }
         } catch (e: Exception) {
             NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
@@ -2133,6 +2162,16 @@ class UDPConnectionFixed(
         //    callback API gets a single onMessageTimeout instead of looping.
         var resends = 0
         var giveups = 0
+        // If UseCircuitCode itself runs out of retries we've lost the
+        // handshake — there's no point re-sending CompleteAgentMovement /
+        // AgentUpdate / AgentSetAppearance into a circuit the simulator
+        // never accepted. Capture this and escalate AFTER the iteration so
+        // we don't recurse into reconnect() from inside `removeIf`. Without
+        // this, the 2026-05-07 00:35 capture happens: 4 UseCircuitCode
+        // attempts, then the entry vanishes from inflightReliablePackets,
+        // then the rest of the app keeps sending packets onto a dead circuit
+        // until the ping watchdog finally trips ~25 s later.
+        var useCircuitCodeAbandoned = false
         inflightReliablePackets.entries.removeIf { (seqNum, inflight) ->
             val age = now - inflight.lastSentTime
             if (age <= timeout) return@removeIf false
@@ -2140,6 +2179,9 @@ class UDPConnectionFixed(
             if (inflight.retries >= maxRetries) {
                 giveups++
                 pendingCallbacks.remove(seqNum)
+                if (inflight.messageId == MessageIdRegistry.USE_CIRCUIT_CODE) {
+                    useCircuitCodeAbandoned = true
+                }
                 try {
                     inflight.listener?.onMessageTimeout(seqNum, inflight.messageId)
                 } catch (e: Exception) {
@@ -2153,7 +2195,7 @@ class UDPConnectionFixed(
                     NetworkLogger.Level.WARN,
                     NetworkLogger.Category.UDP,
                     "✗ Reliable message timed out after $maxRetries resends: " +
-                        "seqNum=$seqNum, messageId=0x${inflight.messageId.toString(16)} " +
+                        "seqNum=$seqNum, messageId=0x${MessageIdNameRegistry.formatHex(inflight.messageId)} " +
                         "(${getMessageName(inflight.messageId)})"
                 )
                 true // remove from inflight
@@ -2190,7 +2232,7 @@ class UDPConnectionFixed(
                     NetworkLogger.Level.WARN,
                     NetworkLogger.Category.UDP,
                     "⟳ Reliable resend (${inflight.retries}/$maxRetries): " +
-                        "seqNum=$seqNum, messageId=0x${inflight.messageId.toString(16)} " +
+                        "seqNum=$seqNum, messageId=0x${MessageIdNameRegistry.formatHex(inflight.messageId)} " +
                         "(${getMessageName(inflight.messageId)})"
                 )
                 false // keep in inflight; ACK will remove, or next pass times out again
@@ -2202,6 +2244,35 @@ class UDPConnectionFixed(
             // waiting for the next select() timeout.
             selector?.wakeup()
             packetsResentCount.addAndGet(resends)
+        }
+
+        if (useCircuitCodeAbandoned) {
+            // Handshake failure. Escalate to the higher-level reconnect
+            // coordinator so the user sees "reconnecting" rather than
+            // "connecting forever", and tear our own circuit down so any
+            // subsequent send() returns immediately instead of pushing
+            // bytes into a sim that doesn't have a circuit for us.
+            NetworkLogger.log(
+                NetworkLogger.Level.ERROR,
+                NetworkLogger.Category.UDP,
+                "✗ UseCircuitCode handshake exhausted retries — circuit faulted, requesting full re-login"
+            )
+            emitNetworkState(NetworkStateTransition.FAULTED)
+            scope.launch {
+                // Fire the higher-level callback first so the app can
+                // start its login flow. disconnect() flips _isConnected
+                // and tears down the channel; doing it second means the
+                // callback can still inspect the previous state if it
+                // wants to (it can read _isConnected.value before
+                // disconnect runs because we're on a different coroutine).
+                try {
+                    reconnectionCallback?.invoke()
+                } catch (e: Exception) {
+                    NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
+                        "reconnectionCallback threw: ${e.message}")
+                }
+                disconnect()
+            }
         }
     }
     
@@ -2316,7 +2387,22 @@ class UDPConnectionFixed(
      * Handler is ready immediately when this method returns.
      */
     fun registerHandler(messageId: Int, handler: (Int, ByteArray) -> Unit) {
-        // Register in messageHandlers for diagnostics (using SAM conversion for functional interface)
+        // Two registrations with intentionally different roles:
+        //
+        //   1. messageHandlers — diagnostic shadow map. Read by
+        //      getRegisteredHandlerIds() and getRegisteredHandlerCount() for
+        //      the debug report's "Registered Message Handlers" section.
+        //      NOT used for dispatch (see dispatchMessageDirect for the
+        //      reason — dispatching through both maps caused every handler
+        //      to fire twice).
+        //
+        //   2. messageRouter — canonical dispatch path. Every inbound packet
+        //      lands here exactly once via dispatchMessageDirect.
+        //
+        // If you ever change this, do NOT also dispatch through
+        // messageHandlers — the duplicate-handler regression is silent for
+        // idempotent updates (ObjectUpdate) but corrupts state for chat /
+        // IM / money / inventory.
         messageHandlers[messageId] = MessageHandler { msgId, data ->
             handler(msgId, data)
         }
@@ -3196,7 +3282,7 @@ class UDPConnectionFixed(
 
                     val piggybackedAcks = wireBytes.size - pkt.data.size
                     NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-                        "→ Sent packet: ${wireBytes.size} bytes (ID: ${pkt.messageId}, reliable: ${pkt.reliable}" +
+                        "→ Sent packet: ${wireBytes.size} bytes (ID: 0x${MessageIdNameRegistry.formatHex(pkt.messageId)}, reliable: ${pkt.reliable}" +
                             (if (piggybackedAcks > 0) ", +${piggybackedAcks}B ACK appendix" else "") + ")")
                     NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
                         "   Message: $messageName (seq: ${pkt.seqNum})")
@@ -3430,14 +3516,32 @@ class UDPConnectionFixed(
     }
     
     /**
-     * Disconnect
+     * Disconnect.
+     *
+     * Idempotent: a CAS on `_isConnected` from true→false guards the body.
+     * Concurrent or repeated calls observe the post-CAS value and return
+     * silently. Pre-fix, the receive-loop exit path called disconnect() on
+     * its way out *and* the higher-level reconnect-failed path called it
+     * again, producing the duplicate `=== DISCONNECTING ===` /
+     * `=== DISCONNECTED ===` log pair plus two
+     * `ConnectionStateChangedEvent(CONNECTED, DISCONNECTED)` publishes seen
+     * in the 2026-05-07 00:35 capture. Doubled events fan out to every
+     * EventBus subscriber; for state-machine subscribers (UI navigator,
+     * autoreconnect, network-state manager) that means doubled re-login
+     * attempts.
      */
     fun disconnect() {
+        if (!_isConnected.compareAndSet(expect = true, update = false)) {
+            // Either we were never connected, or another caller already
+            // ran the teardown. Either way, nothing to do.
+            return
+        }
+
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "=== DISCONNECTING ===")
 
-        _isConnected.value = false
-
-        // Stop the dedicated I/O thread first (it checks _isConnected in its loop)
+        // Stop the dedicated I/O thread first (it re-checks _isConnected
+        // each iteration; flipping it above guarantees the loop exits next
+        // iteration even without the interrupt).
         ioThread?.interrupt()
         ioThread = null
 
@@ -3713,10 +3817,17 @@ class UDPConnectionFixed(
     }
     
     /**
-     * Unregister a message handler
+     * Unregister a message handler.
+     *
+     * Removes from BOTH the diagnostic shadow map and the canonical router.
+     * Pre-fix this only touched `messageHandlers`, which used to be the
+     * dispatch source — now that dispatch goes through `messageRouter`, the
+     * old behaviour silently kept stale handlers running. See registerHandler
+     * for the dual-bookkeeping rationale.
      */
     fun unregisterMessageHandler(messageId: Int) {
         messageHandlers.remove(messageId)
+        messageRouter.unregisterAllHandlersFor(messageId)
     }
     
     /**
@@ -3773,7 +3884,7 @@ class UDPConnectionFixed(
                 MessageIdRegistry.START_PING_CHECK -> "START_PING_CHECK"
                 MessageIdRegistry.PACKET_ACK -> "PACKET_ACK"
                 MessageIdRegistry.SOUND_TRIGGER -> "SOUND_TRIGGER"
-                else -> "0x${id.toString(16).uppercase()}"
+                else -> "0x${MessageIdNameRegistry.formatHex(id)}"
             }
         }
     }
@@ -4134,9 +4245,23 @@ class UDPConnectionFixed(
     /**
      * Get packet history for debugging.
      * Returns the list of recent packet events including raw hex data.
+     *
+     * Reads from the live `recentPacketHistory` ConcurrentLinkedQueue that
+     * recordPacketEvent() / recordAckReceived() write to. The previous
+     * implementation read from `packetDiagnosticsRecorder.snapshot()` — a
+     * separate ArrayDeque that nothing in this class ever writes to — so
+     * the debug report's "UDP PACKET HISTORY" and "INCOMING PACKET DETAILS"
+     * sections always rendered "No packet history recorded yet" even when
+     * dozens of packets had moved across the wire. Visible in the
+     * 2026-05-07 00:35 capture.
+     *
+     * Snapshot is taken via `toList()` which copies under
+     * ConcurrentLinkedQueue's weakly-consistent iterator, so concurrent
+     * writes from the I/O thread can't ConcurrentModificationException
+     * us — at worst we miss an entry that arrived mid-snapshot.
      */
     fun getPacketHistory(): List<PacketHistoryEntry> {
-        return packetDiagnosticsRecorder.snapshot()
+        return recentPacketHistory.toList()
     }
     
     /**

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/translation/MessageTranslation.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/translation/MessageTranslation.kt
@@ -315,7 +315,7 @@ object MessageTranslation {
         val hexEncoded = encoded.joinToString(" ") { "%02X".format(it) }
         
         Log.d(TAG, "Message ID Diagnostics [$operation]:")
-        Log.d(TAG, "  ID: $messageId (0x${messageId.toString(16).uppercase()})")
+        Log.d(TAG, "  ID: $messageId (0x${com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(messageId)})")
         Log.d(TAG, "  Name: $name")
         Log.d(TAG, "  Frequency: $frequency")
         Log.d(TAG, "  Encoded: $hexEncoded")

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/translation/ProtocolDiagnostics.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/translation/ProtocolDiagnostics.kt
@@ -220,7 +220,7 @@ object ProtocolDiagnostics {
         unknownMessages.incrementAndGet()
         unknownMessageIds.getOrPut(messageId) { AtomicInteger(0) }.incrementAndGet()
         
-        Log.w(TAG, "Unknown message ID: $messageId (0x${messageId.toString(16).uppercase()})")
+        Log.w(TAG, "Unknown message ID: $messageId (0x${com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(messageId)})")
         
         // Log additional context for debugging
         if (rawBytes != null && rawBytes.size >= 4) {
@@ -231,7 +231,7 @@ object ProtocolDiagnostics {
             val protocolDecoded = MessageTranslation.decodeMessageId(rawBytes, 0)
             if (protocolDecoded != null) {
                 val (decodedId, _) = protocolDecoded
-                Log.d(TAG, "  SL protocol decode: $decodedId (0x${decodedId.toString(16).uppercase()})")
+                Log.d(TAG, "  SL protocol decode: $decodedId (0x${com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(decodedId)})")
                 Log.d(TAG, "  SL protocol name: ${MessageTranslation.KnownMessages.getName(decodedId)}")
             }
         }
@@ -323,7 +323,7 @@ object ProtocolDiagnostics {
                 .sortedByDescending { it.value.get() }
                 .take(10)
                 .forEach { (id, count) ->
-                    val hex = id.toString(16).uppercase()
+                    val hex = com.linkpoint.protocol.messages.MessageIdNameRegistry.formatHex(id)
                     sb.appendLine("  0x$hex ($id): ${count.get()} occurrences")
                 }
         }

--- a/Linkpoint/src/main/java/com/linkpoint/utils/SessionLogRecorder.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/utils/SessionLogRecorder.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.util.Log
 import com.linkpoint.network.NetworkLogger
 import com.linkpoint.protocol.messages.EnhancedPacketLogger
+import com.linkpoint.protocol.messages.MessageIdNameRegistry
 import kotlinx.coroutines.*
 import java.io.BufferedWriter
 import java.io.File
@@ -341,13 +342,13 @@ object SessionLogRecorder {
         
         val message = buildString {
             append("→ SENT: $messageName")
-            append(" (ID: 0x${messageId.toString(16).uppercase()}")
+            append(" (ID: 0x${MessageIdNameRegistry.formatHex(messageId)}")
             append(", seq: $sequenceNumber")
             append(", size: ${data.size}B")
             if (reliable) append(", RELIABLE")
             append(")")
         }
-        
+
         logWithHex(EntryType.PACKET_SENT, "UDP", message, data)
     }
     
@@ -366,7 +367,7 @@ object SessionLogRecorder {
         val handlerStatus = if (handlerFound) "✓" else "⚠️ NO HANDLER"
         val message = buildString {
             append("← RECV: $messageName $handlerStatus")
-            append(" (ID: 0x${messageId.toString(16).uppercase()}")
+            append(" (ID: 0x${MessageIdNameRegistry.formatHex(messageId)}")
             append(", seq: $sequenceNumber")
             append(", size: ${data.size}B)")
         }


### PR DESCRIPTION
Five reproducible bugs surfaced in two Linkpoint debug captures:

1. Every app-registered handler fired twice. registerHandler() populated
   both messageHandlers and messageRouter; dispatchMessageDirect dispatched
   through both. Visible as 822 inbound StartPingCheck → 1348 outbound
   CompletePingCheck (~1.6:1). Same pathology silently doubled chat / IM /
   money / inventory handlers. Fix: route only through messageRouter; keep
   messageHandlers as a diagnostic shadow map for the debug report.
   unregisterMessageHandler now also clears the router.

2. Packet IDs printed as negative hex / negative decimal in user-facing
   logs ("ID: 0x-FFFD", "ID: -65452"). SL low-frequency IDs are produced
   by `(short or 0xFFFF0000)` which flips the sign of a Kotlin Int.
   toString(16) on a negative Int emits the minus sign verbatim. Added
   MessageIdNameRegistry.formatHex(Int) that masks through unsigned
   Long, applied at every message-ID logging site
   (UDPConnectionFixed, SessionLogRecorder, EnhancedPacketLogger,
   NetworkLogger, LinkpointThreadedCircuit, ProtocolDiagnostics,
   MessageTranslation).

3. Debug report always rendered "No packet history recorded yet" /
   "No incoming packets recorded yet" even after dozens of packets.
   recordPacketEvent() / recordAckReceived() wrote to recentPacketHistory,
   but getPacketHistory() read from packetDiagnosticsRecorder.snapshot()
   which nothing in the class ever populated. Fixed reader to use the
   live ConcurrentLinkedQueue.

4. disconnect() ran twice on every circuit teardown — receive-loop exit
   path and higher-level recovery path both called it, producing
   duplicate "DISCONNECTING" / "DISCONNECTED" log pairs and two
   ConnectionStateChangedEvent publishes per disconnect (the latter
   double-fanned reconnect attempts to all subscribers). Added
   compareAndSet(true, false) guard on _isConnected so the body runs at
   most once per real transition.

5. UseCircuitCode timeout silently abandoned the handshake. The reliable-
   resend loop dropped the entry from inflightReliablePackets after
   MAX_RETRIES with no circuit-state change, leaving the rest of the app
   sending AgentSetAppearance / AgentUpdate / pings into a circuit the
   simulator never accepted; the ping watchdog finally tripped 25+s
   later. Now if the timed-out message is USE_CIRCUIT_CODE we emit
   FAULTED, invoke reconnectionCallback, and disconnect() — surfacing
   "Reconnecting…" to the UI immediately and stopping further sends.

6. connect() defensively interrupts any pre-existing alive I/O thread
   before opening a new socket, so stacked recovery attempts can't end
   up with two threads racing the same volatile selector/channel/key
   fields.

Each fix carries inline comments explaining what the original bug was
and why the new code is correct, so the rationale survives future
refactors.

Compile verified via `./gradlew compileStableDebugKotlin` (BUILD
SUCCESSFUL, only pre-existing UI-deprecation warnings).

https://claude.ai/code/session_01QZBf7nRWUVnv1uqX3wPR9B

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes six UDP protocol circuit bugs discovered through debug captures. The fixes address: duplicate handler invocations (every registered handler fired twice due to dispatch through both `messageHandlers` and `messageRouter`), negative hex formatting in logs for low-frequency message IDs (caused by signed Int representation), broken debug report packet history (reading from an unpopulated data structure), double disconnect calls producing duplicate events, silent `UseCircuitCode` timeout failures leaving circuits in limbo, and race conditions from stacked I/O threads. Each fix includes inline documentation explaining the root cause and correctness rationale.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageIdNameRegistry.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/MessageRouter.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/network/NetworkLogger.kt` |
| 5 | `Linkpoint/src/main/java/com/linkpoint/utils/SessionLogRecorder.kt` |
| 6 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/EnhancedPacketLogger.kt` |
| 7 | `Linkpoint/src/main/java/com/linkpoint/protocol/circuit/LinkpointThreadedCircuit.kt` |
| 8 | `Linkpoint/src/main/java/com/linkpoint/protocol/translation/MessageTranslation.kt` |
| 9 | `Linkpoint/src/main/java/com/linkpoint/protocol/translation/ProtocolDiagnostics.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to unregister all message handlers for a specific message ID.

* **Bug Fixes**
  * Fixed connection threading issues preventing duplicate I/O threads.
  * Corrected message dispatch to prevent duplicate handler invocations.
  * Fixed reconnection logic for failed handshakes with proper error escalation.
  * Made disconnect operation idempotent to prevent duplicate teardown events.
  * Fixed packet history retrieval to return live diagnostic data.

* **Improvements**
  * Standardized message ID formatting across all logging and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->