### PR TITLE
Improve UDP routing, handler registration and connection robustness

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt
@@ -1553,25 +1553,18 @@ class UDPConnectionFixed(
                 handlePacketAck(data)
             }
 
-            // Dispatch to all registered handlers (from LinkpointApp and managers)
-            val handler = messageHandlers[messageId]
-            if (handler != null) {
-                try {
-                    handler.handle(messageId, data)
-                } catch (e: Exception) {
-                    NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
-                        "Handler error for ${getMessageName(messageId)}: ${e.message}")
-                }
-                messagesRouted.incrementAndGet()
-            } else if (messageId != MessageIdRegistry.PACKET_ACK) {
+            // Route exactly once through MessageRouter; keep messageHandlers as
+            // a diagnostic shadow map used by debug report stats.
+            val hasRegisteredHandler = messageHandlers.containsKey(messageId)
+            if (!hasRegisteredHandler && messageId != MessageIdRegistry.PACKET_ACK) {
                 // Only log unhandled messages if not PacketAck (which is handled internally)
                 NetworkLogger.log(NetworkLogger.Level.VERBOSE, NetworkLogger.Category.UDP,
                     "No handler for ${getMessageName(messageId)} (ID: $messageId)")
             }
 
-            // Also try to route through messageRouter for any handlers only registered there
             try {
                 messageRouter.routeMessageSync(messageId, data)
+                if (hasRegisteredHandler) messagesRouted.incrementAndGet()
             } catch (e: Exception) {
                 NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
                     "Router error for ${getMessageName(messageId)}: ${e.message}")
@@ -2156,6 +2149,16 @@ class UDPConnectionFixed(
                         "seqNum=$seqNum, messageId=0x${inflight.messageId.toString(16)} " +
                         "(${getMessageName(inflight.messageId)})"
                 )
+                if (inflight.messageId == MessageIdRegistry.USE_CIRCUIT_CODE) {
+                    NetworkLogger.log(
+                        NetworkLogger.Level.ERROR,
+                        NetworkLogger.Category.UDP,
+                        "UseCircuitCode timed out; faulting and requesting reconnect"
+                    )
+                    _connectionState.value = ConnectionState.FAULTED
+                    reconnectionCallback?.invoke()
+                    disconnect()
+                }
                 true // remove from inflight
             } else {
                 inflight.retries++
@@ -2316,6 +2319,7 @@ class UDPConnectionFixed(
      * Handler is ready immediately when this method returns.
      */
     fun registerHandler(messageId: Int, handler: (Int, ByteArray) -> Unit) {
+        messageRouter.unregisterHandler(messageId)
         // Register in messageHandlers for diagnostics (using SAM conversion for functional interface)
         messageHandlers[messageId] = MessageHandler { msgId, data ->
             handler(msgId, data)
@@ -3433,9 +3437,10 @@ class UDPConnectionFixed(
      * Disconnect
      */
     fun disconnect() {
+        if (!_isConnected.compareAndSet(true, false)) {
+            return
+        }
         NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP, "=== DISCONNECTING ===")
-
-        _isConnected.value = false
 
         // Stop the dedicated I/O thread first (it checks _isConnected in its loop)
         ioThread?.interrupt()
@@ -3709,7 +3714,16 @@ class UDPConnectionFixed(
      * Register a message handler for a specific message ID
      */
     fun registerMessageHandler(messageId: Int, handler: MessageHandler) {
+        messageRouter.unregisterHandler(messageId)
         messageHandlers[messageId] = handler
+        val messageName = MessageIdRegistry.getMessageName(messageId)
+        EnhancedPacketLogger.logHandlerRegistered(messageId, messageName)
+        messageRouter.registerHandler(messageId, object : MessageRouter.Handler {
+            override fun handleMessage(messageId: Int, data: ByteArray): Boolean {
+                handler.handle(messageId, data)
+                return true
+            }
+        })
     }
     
     /**
@@ -3717,6 +3731,7 @@ class UDPConnectionFixed(
      */
     fun unregisterMessageHandler(messageId: Int) {
         messageHandlers.remove(messageId)
+        messageRouter.unregisterHandler(messageId)
     }
     
     /**
@@ -4136,7 +4151,7 @@ class UDPConnectionFixed(
      * Returns the list of recent packet events including raw hex data.
      */
     fun getPacketHistory(): List<PacketHistoryEntry> {
-        return packetDiagnosticsRecorder.snapshot()
+        return recentPacketHistory.toList()
     }
     
     /**

--- a/src/main/java/com/linkpoint/protocol/messages/RobustUDPConnection.kt
+++ b/src/main/java/com/linkpoint/protocol/messages/RobustUDPConnection.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.flow.StateFlow
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
-import java.util.concurrent.TimeUnit
+import java.nio.channels.SelectionKey
+import java.nio.channels.Selector
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -42,6 +43,11 @@ class RobustUDPConnection(
         
         // Heartbeat settings
         private const val HEARTBEAT_INTERVAL_MS = 30000L
+        private const val RECEIVE_SELECT_TIMEOUT_MS = 1000L
+        private const val SEND_RETRY_DELAY_MS = 20L
+        private const val MAX_SEND_RETRIES = 3
+        private const val INITIAL_INBOUND_GRACE_MS = 45000L
+        private const val MAX_MISSED_HEARTBEATS = 3
 
         // Packet buffering
         private const val PACKET_CHANNEL_CAPACITY = 512
@@ -71,6 +77,9 @@ class RobustUDPConnection(
     // Reconnection tracking
     private val reconnectAttempts = AtomicInteger(0)
     private val isShuttingDown = AtomicBoolean(false)
+    private val missedHeartbeats = AtomicInteger(0)
+    private val firstInboundReceived = AtomicBoolean(false)
+    @Volatile private var connectedAtMs: Long = 0L
     
     // Coroutine scope
     private val scope = CoroutineScope(
@@ -106,11 +115,14 @@ class RobustUDPConnection(
             
             val address = InetSocketAddress(simIP, simPort)
             datagramChannel = DatagramChannel.open()
-            datagramChannel?.configureBlocking(true)
+            datagramChannel?.configureBlocking(false)
             datagramChannel?.connect(address)
             
             _connectionState.value = ConnectionState.CONNECTED
             reconnectAttempts.set(0)
+            missedHeartbeats.set(0)
+            firstInboundReceived.set(false)
+            connectedAtMs = System.currentTimeMillis()
 
             // Start loops after state is CONNECTED so their guards are true
             startReceiveLoop()
@@ -180,9 +192,24 @@ class RobustUDPConnection(
         }
         
         try {
+            val channel = datagramChannel ?: return@withContext false
             val buffer = ByteBuffer.wrap(data)
-            datagramChannel?.write(buffer)
-            true
+            var attempt = 0
+            while (attempt <= MAX_SEND_RETRIES) {
+                val bytesWritten = channel.write(buffer)
+                if (!buffer.hasRemaining() && bytesWritten > 0) {
+                    return@withContext true
+                }
+
+                if (attempt == MAX_SEND_RETRIES) {
+                    val sent = data.size - buffer.remaining()
+                    Log.w(TAG, "UDP send incomplete after retries: sent $sent of ${data.size} bytes")
+                    return@withContext false
+                }
+                attempt++
+                delay(SEND_RETRY_DELAY_MS)
+            }
+            false
         } catch (e: Exception) {
             Log.e(TAG, "Failed to send data", e)
             handleConnectionError("Send error: ${e.message}")
@@ -196,30 +223,50 @@ class RobustUDPConnection(
     private fun startReceiveLoop() {
         receiveJob = scope.launch {
             val buffer = ByteBuffer.allocate(4096)
-            
-            while (isActive && _connectionState.value == ConnectionState.CONNECTED) {
-                try {
-                    buffer.clear()
-                    val bytesRead = datagramChannel?.read(buffer) ?: -1
-                    
-                    if (bytesRead > 0) {
-                        buffer.flip()
-                        val data = ByteArray(bytesRead)
-                        buffer.get(data)
-                        
-                        // Send to packet channel
-                        val sendResult = packetChannel.trySend(PacketData(data, System.currentTimeMillis()))
-                        if (!sendResult.isSuccess) {
-                            Log.w(TAG, "Dropped incoming packet due to channel backpressure")
+
+            val selector = Selector.open()
+            datagramChannel?.register(selector, SelectionKey.OP_READ)
+
+            try {
+                while (isActive && _connectionState.value == ConnectionState.CONNECTED) {
+                    try {
+                        val ready = selector.select(RECEIVE_SELECT_TIMEOUT_MS)
+                        if (ready <= 0) continue
+
+                        val keys = selector.selectedKeys().iterator()
+                        while (keys.hasNext()) {
+                            val key = keys.next()
+                            keys.remove()
+                            if (!key.isValid || !key.isReadable) continue
+
+                            buffer.clear()
+                            val bytesRead = datagramChannel?.read(buffer) ?: -1
+                            if (bytesRead > 0) {
+                                firstInboundReceived.set(true)
+                                missedHeartbeats.set(0)
+                                buffer.flip()
+                                val data = ByteArray(bytesRead)
+                                buffer.get(data)
+
+                                val sendResult = packetChannel.trySend(PacketData(data, System.currentTimeMillis()))
+                                if (!sendResult.isSuccess) {
+                                    Log.w(TAG, "Dropped incoming packet due to channel backpressure")
+                                }
+                            }
                         }
+
+                    } catch (e: Exception) {
+                        if (!isShuttingDown.get()) {
+                            Log.e(TAG, "Error receiving data", e)
+                            handleConnectionError("Receive error: ${e.message}")
+                        }
+                        break
                     }
-                    
-                } catch (e: Exception) {
-                    if (!isShuttingDown.get()) {
-                        Log.e(TAG, "Error receiving data", e)
-                        handleConnectionError("Receive error: ${e.message}")
-                    }
-                    break
+                }
+            } finally {
+                try {
+                    selector.close()
+                } catch (_: Exception) {
                 }
             }
         }
@@ -248,6 +295,22 @@ class RobustUDPConnection(
         if (channel == null || !channel.isConnected) {
             if (!isShuttingDown.get()) {
                 handleConnectionError("Heartbeat check failed: socket not connected")
+            }
+            return
+        }
+        val now = System.currentTimeMillis()
+        val elapsedSinceConnect = now - connectedAtMs
+        if (!firstInboundReceived.get() && elapsedSinceConnect < INITIAL_INBOUND_GRACE_MS) {
+            Log.v(TAG, "Heartbeat: waiting for initial inbound (grace ${INITIAL_INBOUND_GRACE_MS}ms)")
+            return
+        }
+
+        val misses = missedHeartbeats.incrementAndGet()
+        if (!firstInboundReceived.get()) {
+            if (misses >= MAX_MISSED_HEARTBEATS) {
+                handleConnectionError("No inbound UDP after connect grace; missed heartbeats=$misses")
+            } else {
+                Log.w(TAG, "No inbound UDP yet (missed heartbeats=$misses/$MAX_MISSED_HEARTBEATS)")
             }
             return
         }


### PR DESCRIPTION
### Motivation
- Centralize message dispatch through the `MessageRouter` to avoid duplicate/ambiguous handler invocation and simplify diagnostics.
- Make disconnect behavior idempotent and detect critical reliable-message timeouts (notably `USE_CIRCUIT_CODE`) to transition the connection into a faulted state and trigger reconnect logic.
- Harden the UDP I/O path by switching to non-blocking I/O with a `Selector`, adding send retries and heartbeat/missed-inbound detection to recover from flaky networks.
- Improve handler registration diagnostics by logging registrations to the `EnhancedPacketLogger` and keeping a shadow map for stats.

### Description
- Refactored `dispatchMessageDirect` to always route messages via `messageRouter.routeMessageSync` and treat `messageHandlers` as a diagnostic shadow map; unchanged `PacketAck` handling remains internal and unlogged-only messages are reported verbosely.
- Updated `registerHandler` and `registerMessageHandler` to first `unregisterHandler` on the `messageRouter`, register a routed handler with `messageRouter`, store a shadow entry in `messageHandlers`, and call `EnhancedPacketLogger.logHandlerRegistered`.
- Made `disconnect()` idempotent by using `_isConnected.compareAndSet(true, false)` to avoid double-disconnect work, and preserved clearing of ACKs, queues, inflight packets, and selector/channel cleanup.
- On inflight reliable packet timeouts, added special handling for `MessageIdRegistry.USE_CIRCUIT_CODE` to log an error, set `_connectionState` to `ConnectionState.FAULTED`, invoke `reconnectionCallback`, and call `disconnect()`.
- Swapped `getPacketHistory()` to return `recentPacketHistory.toList()` instead of `packetDiagnosticsRecorder.snapshot()`.
- In `RobustUDPConnection`, changed the socket to non-blocking, introduced a `Selector` with a receive timeout (`RECEIVE_SELECT_TIMEOUT_MS`), reset `missedHeartbeats` and mark `firstInboundReceived` on inbound packets, added send retry logic in `sendData`, and added an initial inbound grace window and missed-heartbeat counting in `sendHeartbeat` to detect and recover from no-inbound situations.

### Testing
- Ran the project unit test suite (`./gradlew test`) after the changes and all unit tests passed.
- Built the application (`./gradlew assemble`) to verify compilation of modified modules and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc279126708323add72b7e57655d4f)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the UDP connection handling to improve message routing, connection reliability, and fault recovery. The changes centralize message dispatch through a single `MessageRouter` to eliminate duplicate handler invocations, make disconnect operations idempotent to prevent double-cleanup issues, and add critical timeout detection for `USE_CIRCUIT_CODE` messages that triggers reconnection logic. Additionally, the UDP I/O path is hardened by switching to non-blocking I/O with a `Selector`, implementing send retry logic, and adding heartbeat/missed-inbound detection to recover from flaky network conditions. Handler registration now includes enhanced logging and maintains a shadow diagnostic map for improved observability.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/messages/UDPConnectionFixed.kt` |
| 2 | `src/main/java/com/linkpoint/protocol/messages/RobustUDPConnection.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UDP message routing to prevent duplicate processing.
  - Connections now recover more reliably when circuit-code capacity is exhausted.
  - Disconnect handling is more consistent and resilient.
  - Packet history now reflects locally retained packet activity.
  - Improved handling of partial data sends and receive operations.
  - Added heartbeat monitoring to detect stalled connections and trigger recovery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->