### PR TITLE
Buffer camera state set before LumiyaRenderer.initialize()

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt
@@ -49,6 +49,21 @@ class LumiyaRenderer : RenderEngineProvider {
 
     private lateinit var ctx: LumiyaRenderContext
 
+    // Camera / projection updates that arrive on the GL thread before
+    // initialize() has constructed the render context. The scene command
+    // consumer replays state via queueEvent { ... } the moment the engine
+    // is bound, which the GL thread will drain before onSurfaceChanged
+    // fires. Without this buffer those calls would hit the lateinit ctx
+    // and crash. Values are flushed into ctx at the end of initialize().
+    private var pendingCameraPosX: Float? = null
+    private var pendingCameraPosY: Float? = null
+    private var pendingCameraPosZ: Float? = null
+    private var pendingCameraTargetX: Float? = null
+    private var pendingCameraTargetY: Float? = null
+    private var pendingCameraTargetZ: Float? = null
+    private var pendingFovDegrees: Float? = null
+    private var pendingDrawDistance: Float? = null
+
     @Volatile private var glThreadId: Long = Long.MIN_VALUE
     @Volatile private var glThreadName: String = "<unset>"
 
@@ -218,6 +233,7 @@ class LumiyaRenderer : RenderEngineProvider {
             skyDrawable = DrawableSky(ctx)
             particleManager = DrawableParticleManager(ctx)
 
+            flushPendingCameraState()
             ctx.updateCamera()
             rebuildHudMatrices(width, height)
             hudStore.setViewportSize(width, height)
@@ -394,19 +410,50 @@ class LumiyaRenderer : RenderEngineProvider {
     // =====================================================================
 
     override fun setCameraPosition(x: Float, y: Float, z: Float) {
+        if (!::ctx.isInitialized) {
+            pendingCameraPosX = x; pendingCameraPosY = y; pendingCameraPosZ = z
+            return
+        }
         ctx.cameraPositionX = x; ctx.cameraPositionY = y; ctx.cameraPositionZ = z
     }
 
     override fun setCameraTarget(x: Float, y: Float, z: Float) {
+        if (!::ctx.isInitialized) {
+            pendingCameraTargetX = x; pendingCameraTargetY = y; pendingCameraTargetZ = z
+            return
+        }
         ctx.cameraTargetX = x; ctx.cameraTargetY = y; ctx.cameraTargetZ = z
     }
 
     override fun setFieldOfView(fovDegrees: Float) {
+        if (!::ctx.isInitialized) {
+            pendingFovDegrees = fovDegrees
+            return
+        }
         ctx.fovDegrees = fovDegrees
     }
 
     override fun setDrawDistance(distance: Float) {
+        if (!::ctx.isInitialized) {
+            pendingDrawDistance = distance
+            return
+        }
         ctx.drawDistance = distance
+    }
+
+    private fun flushPendingCameraState() {
+        pendingCameraPosX?.let { ctx.cameraPositionX = it }
+        pendingCameraPosY?.let { ctx.cameraPositionY = it }
+        pendingCameraPosZ?.let { ctx.cameraPositionZ = it }
+        pendingCameraTargetX?.let { ctx.cameraTargetX = it }
+        pendingCameraTargetY?.let { ctx.cameraTargetY = it }
+        pendingCameraTargetZ?.let { ctx.cameraTargetZ = it }
+        pendingFovDegrees?.let { ctx.fovDegrees = it }
+        pendingDrawDistance?.let { ctx.drawDistance = it }
+        pendingCameraPosX = null; pendingCameraPosY = null; pendingCameraPosZ = null
+        pendingCameraTargetX = null; pendingCameraTargetY = null; pendingCameraTargetZ = null
+        pendingFovDegrees = null
+        pendingDrawDistance = null
     }
 
     // =====================================================================


### PR DESCRIPTION
The scene-command consumer replays SetCamera through queueEvent the
moment the engine is bound, but the GL thread can drain those events
before onSurfaceChanged fires initialize(), so setCameraPosition was
hitting the lateinit ctx and crashing GLThread. Stash camera, target,
fov, and draw-distance into nullable shadow fields when ctx isn't
ready and flush them into the context inside initialize() before the
first updateCamera().

https://claude.ai/code/session_01VoukgaVe2hFSaFK1BVsYoX

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a race condition where camera state updates arriving on the GL thread before the renderer is initialized would crash due to accessing an uninitialized context. The fix introduces nullable buffer fields that temporarily store camera position, target, field of view, and draw distance when `ctx` is not yet initialized. These buffered values are then flushed into the actual render context during `initialize()` before the first camera update.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/render/lumiya/core/LumiyaRenderer.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->