### PR TITLE
Fix rendering issues and UDP errors

### DIFF
--- a/Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt
@@ -182,12 +182,21 @@ class SessionManager(private val context: Context) {
     fun updateRegionInfo(regionHandle: Long, x: Int, y: Int) {
         val current = _currentRegion.value
         if (current != null) {
-            _currentRegion.value = current.copy(handle = regionHandle, x = x, y = y)
-            Log.i(TAG, "Region info updated: handle=$regionHandle, position=($x, $y)")
+            // Preserve any real name already written by updateFromRegionHandshake
+            val name = if (current.name == "Unknown") {
+                val known = _regionSessionState.value.simName
+                if (known.isNotEmpty()) known else current.name
+            } else {
+                current.name
+            }
+            _currentRegion.value = current.copy(name = name, handle = regionHandle, x = x, y = y)
+            Log.i(TAG, "Region info updated: handle=$regionHandle, position=($x, $y), name=$name")
         } else {
-            // Create minimal region info if we don't have any yet
+            // Use the sim name from RegionHandshake if it already arrived; otherwise a
+            // placeholder that will be overwritten once RegionHandshake is processed.
+            val name = _regionSessionState.value.simName.ifEmpty { "Unknown" }
             _currentRegion.value = RegionInfo(
-                name = "Unknown",
+                name = name,
                 handle = regionHandle,
                 x = x,
                 y = y,
@@ -195,7 +204,7 @@ class SessionManager(private val context: Context) {
                 simPort = 0,
                 seedCapability = null
             )
-            Log.i(TAG, "Region info created with handle=$regionHandle, position=($x, $y)")
+            Log.i(TAG, "Region info created with handle=$regionHandle, position=($x, $y), name=$name")
         }
     }
     

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/RttEstimator.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/circuit/RttEstimator.kt
@@ -122,12 +122,13 @@ class RttEstimator {
         const val MIN_RTO_MS = 300L
 
         /**
-         * Upper bound. Sized to absorb the multi-second fades the M-UDP
-         * paper documents on cellular without giving up entirely. The
-         * unanswered-ping watchdog ([LinkpointConstants.UNANSWERED_PINGS_DISCONNECT])
-         * still backstops at 25–60s.
+         * Upper bound. Sized to absorb multi-second fades on cellular and
+         * satellite links (7+ second RTT spikes observed in the wild) without
+         * triggering premature retransmissions that flood the socket buffers.
+         * The unanswered-ping watchdog ([LinkpointConstants.UNANSWERED_PINGS_DISCONNECT])
+         * still backstops the circuit at 25–60s.
          */
-        const val MAX_RTO_MS = 6_000L
+        const val MAX_RTO_MS = 20_000L
 
         /** Default cold-start RTO before the first sample. Matches Lumiya's 5s. */
         const val DEFAULT_RTO_MS = LinkpointConstants.MESSAGE_TIMEOUT_MS

--- a/Linkpoint/src/main/java/com/linkpoint/protocol/scenery/SceneDataHandler.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/protocol/scenery/SceneDataHandler.kt
@@ -2,6 +2,8 @@ package com.linkpoint.protocol.scenery
 
 import android.util.Log
 import com.linkpoint.network.NetworkLogger
+import com.linkpoint.protocol.messages.MessageParser
+import com.linkpoint.protocol.messages.ObjectUpdateData
 import com.linkpoint.protocol.messages.PacketCodec
 import com.linkpoint.render.RenderQueue
 import com.linkpoint.render.RenderableUpdate
@@ -114,63 +116,51 @@ class SceneDataHandler(
      * @param data Raw message payload
      * @return true if handled successfully
      */
-    fun handleObjectUpdate(data: ByteArray): Boolean {
+    fun handleObjectUpdate(rawPacket: ByteArray): Boolean {
         try {
             NetworkLogger.log(NetworkLogger.Level.DEBUG, NetworkLogger.Category.UDP,
-                "Processing ObjectUpdate (${data.size} bytes)")
-            
-            val buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN)
-            
-            // Parse ObjectUpdate message format
-            val regionHandle = buffer.long
-            val timeDilation = buffer.short
-            
-            // Parse each object in the update
-            var objectCount = 0
-            while (buffer.remaining() > 0) {
-                // Parse object header
-                val pCode = buffer.get().toInt() and 0xFF
-                
-                // Only process avatars (pCode=47) and prims (pCode=9)
-                if (pCode == 47 || pCode == 9) {
-                    val obj = parseObjectUpdate(buffer, pCode)
-                    if (obj != null) {
-                        // Check if there are pending properties to apply
-                        val pending = pendingProperties.remove(obj.id)
-                        if (pending != null) {
-                            obj.name = pending.name
-                            obj.description = pending.description
-                        }
-                        
-                        objects[obj.id] = obj
-                        objectCount++
-                        
-                        // Update scene graph
-                        if (renderQueue != null) {
-                            renderQueue.enqueue(RenderableUpdate.SceneObjectUpdate(obj.copy()))
-                        } else {
-                            sceneGraph?.updateObject(obj)
-                        }
-                        
-                        NetworkLogger.log(NetworkLogger.Level.VERBOSE, NetworkLogger.Category.UDP,
-                            "Updated object: ${obj.name} (${obj.id})")
-                    }
-                } else if (pCode == 0) {
-                    // End of objects
-                    break
-                } else {
-                    // Skip unknown object types
-                    NetworkLogger.log(NetworkLogger.Level.VERBOSE, NetworkLogger.Category.UDP,
-                        "Skipping object with pCode=$pCode")
-                    break
-                }
+                "Processing ObjectUpdate (${rawPacket.size} bytes)")
+
+            // rawPacket includes the full LLUDP header; extract the body before parsing.
+            val payload = MessageParser.extractPayload(rawPacket)
+            if (payload == null) {
+                NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
+                    "ObjectUpdate: failed to extract payload")
+                return false
             }
-            
+
+            val updates: List<ObjectUpdateData> = MessageParser.parseObjectUpdate(payload)
+            var objectCount = 0
+            for (update in updates) {
+                val obj = SceneObject(
+                    id = update.fullId,
+                    position = Vector3(update.position.x, update.position.y, update.position.z),
+                    rotation = Quaternion(
+                        update.rotation.w, update.rotation.x,
+                        update.rotation.y, update.rotation.z
+                    ),
+                    pCode = update.pcode
+                )
+                // Merge any pending properties received ahead of this update.
+                val pending = pendingProperties.remove(obj.id)
+                if (pending != null) {
+                    obj.name = pending.name
+                    obj.description = pending.description
+                }
+                objects[obj.id] = obj
+                objectCount++
+                if (renderQueue != null) {
+                    renderQueue.enqueue(RenderableUpdate.SceneObjectUpdate(obj.copy()))
+                } else {
+                    sceneGraph?.updateObject(obj)
+                }
+                NetworkLogger.log(NetworkLogger.Level.VERBOSE, NetworkLogger.Category.UDP,
+                    "Updated object: ${obj.name} (${obj.id})")
+            }
+
             objectUpdateCount++
-            
             NetworkLogger.log(NetworkLogger.Level.INFO, NetworkLogger.Category.UDP,
                 "✓ Updated $objectCount objects (total: $objectUpdateCount updates)")
-            
             return true
         } catch (e: Exception) {
             NetworkLogger.log(NetworkLogger.Level.ERROR, NetworkLogger.Category.UDP,
@@ -246,39 +236,6 @@ class SceneDataHandler(
     }
     
     // ==================== Helper Methods ====================
-    
-    private fun parseObjectUpdate(buffer: ByteBuffer, pCode: Int): SceneObject? {
-        return try {
-            // Parse object ID
-            val objectId = PacketCodec.fromBuffer(buffer).readUuid()
-            
-            // Parse state
-            val state = buffer.get().toInt() and 0xFF
-            
-            // Parse position (Vector3)
-            val x = buffer.float
-            val y = buffer.float
-            val z = buffer.float
-            
-            // Parse rotation (Quaternion)
-            val rw = buffer.float
-            val rx = buffer.float
-            val ry = buffer.float
-            val rz = buffer.float
-            
-            // Create object
-            SceneObject(
-                id = objectId,
-                position = Vector3(x, y, z),
-                rotation = Quaternion(rw, rx, ry, rz),
-                pCode = pCode
-            )
-        } catch (e: Exception) {
-            NetworkLogger.log(NetworkLogger.Level.WARN, NetworkLogger.Category.UDP,
-                "Failed to parse object: ${e.message}")
-            null
-        }
-    }
     
     /**
      * Get terrain data for rendering

--- a/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
+++ b/Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt
@@ -1348,7 +1348,14 @@ class WorldViewActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         // destroyed by `UiHelper.onDetachedFromSurface`, which threw a native
         // crash and tripped the auto-restart loop the user observed when
         // opening any panel.
-        renderBackend?.onPause()
+        // Pause the active backend. Filament path goes through renderBackend (which is
+        // a FilamentBackend). Lumiya path has no renderBackend — the GLSurfaceView must
+        // be paused directly so EGL releases the surface and the GL thread stops.
+        if (rendererHandoffManager.currentBackend() == RendererHandoffManager.RendererBackend.LUMIYA) {
+            lumiyaSurfaceView?.onPause()
+        } else {
+            renderBackend?.onPause()
+        }
         super.onPause()
         NetworkLogger.log(
             NetworkLogger.Level.INFO,


### PR DESCRIPTION
- SessionManager: recover sim name from regionSessionState when
  updateRegionInfo(handle, x, y) creates or updates a region with
  name "Unknown", preventing the region header from showing "Unknown"
  after AgentMovementComplete arrives before RegionHandshake

- RttEstimator: raise MAX_RTO_MS from 6 s to 20 s so reliable
  retransmission does not fire prematurely on cellular/satellite
  links with 7+ second RTT spikes, avoiding socket-buffer floods

- WorldViewActivity: call lumiyaSurfaceView?.onPause() in onPause()
  when the Lumiya backend is active; renderBackend is null for Lumiya
  so the GLSurfaceView was never paused, leaking EGL resources

- SceneDataHandler: replace manual ObjectUpdate byte-parsing with
  MessageParser.extractPayload() + MessageParser.parseObjectUpdate()
  so the 6-byte LLUDP fixed header is stripped before reads, fixing
  misaligned field reads that produced zero objects

https://claude.ai/code/session_01KznjoDcQn7j1CfXkiB2Qfa

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes four distinct bugs affecting rendering and network reliability. It prevents regions from incorrectly displaying as "Unknown" by recovering the sim name from session state when updates arrive out of order. The UDP retransmission timeout is increased from 6 to 20 seconds to handle high-latency cellular and satellite connections without flooding socket buffers. The Lumiya rendering backend now properly pauses its GLSurfaceView to prevent EGL resource leaks. Finally, object updates are correctly parsed by stripping the LLUDP header before reading fields, fixing misaligned reads that previously yielded zero objects.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Linkpoint/src/main/java/com/linkpoint/protocol/circuit/RttEstimator.kt` |
| 2 | `Linkpoint/src/main/java/com/linkpoint/ui/world/WorldViewActivity.kt` |
| 3 | `Linkpoint/src/main/java/com/linkpoint/core/SessionManager.kt` |
| 4 | `Linkpoint/src/main/java/com/linkpoint/protocol/scenery/SceneDataHandler.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering pause behavior when app goes to background; now correctly pauses the active graphics backend.
  * Improved accuracy of displayed region and location names in location data updates.

* **Performance & Stability**
  * Enhanced network resilience to tolerate longer latency fades without triggering premature retransmissions.
  * Refined scene object update processing for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kaleaon/Linkpoint/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->